### PR TITLE
Add dashboard KPI backend

### DIFF
--- a/app/crud/dashboard_metrics.py
+++ b/app/crud/dashboard_metrics.py
@@ -1,0 +1,509 @@
+"""Aggregations for the Dashboard tab.
+
+Returns headline KPIs (totals, active, revenue, reservations, occupancy, new
+members), their previous-period counterparts for trend deltas, and series for
+the four charts (revenue / occupancy by class / new members / membership
+distribution).
+
+Stock KPIs (totalMembers, activeMembers) are evaluated as snapshots at the
+end-of-period; flow KPIs are filtered to the (start, end) window. Occupancy
+is treated as a flow KPI even though the plan classified it as stock — the
+metric only makes sense over a window, and the previous-period delta is
+useful.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import and_, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud.memberships.payment_metrics import DailyPointData, PlanBucketData
+from app.crud.memberships.utils import _normalize_to_utc
+from app.models import (
+    MembershipPlan,
+    MembershipSubscription,
+    People,
+)
+from app.models.classModel import ClassSession, ClassType, Reservation
+from app.models.userModel import PersonRole, Role
+
+
+# Reservation statuses that occupy a seat.
+_OCCUPIED_RESERVATION_STATUSES = ("reserved", "checked_in")
+# Sessions that count toward occupancy (skip cancelled).
+_VALID_SESSION_STATUSES = ("scheduled", "completed")
+
+
+@dataclass
+class ClassBucketData:
+    class_name: str
+    capacity: int
+    reserved: int
+    occupancy_pct: float
+
+
+@dataclass
+class DashboardMetricsData:
+    # Stock KPIs (snapshot at end of current window)
+    total_members: int
+    active_members: int
+
+    # Flow KPIs (current window)
+    new_members: int
+    period_reservations: int
+    period_revenue: float
+    avg_occupancy: float
+
+    # Previous-period counterparts (same window size shifted back)
+    total_members_prev: int
+    active_members_prev: int
+    new_members_prev: int
+    reservations_prev: int
+    revenue_prev: float
+    avg_occupancy_prev: float
+
+    # Series for the four charts
+    revenue_by_day: list[DailyPointData] = field(default_factory=list)
+    occupancy_by_class: list[ClassBucketData] = field(default_factory=list)
+    new_members_by_day: list[DailyPointData] = field(default_factory=list)
+    membership_distribution: list[PlanBucketData] = field(default_factory=list)
+
+
+# --------------------------------------------------------------------------- #
+# Count helpers                                                               #
+# --------------------------------------------------------------------------- #
+
+
+async def count_active_members(
+    db: AsyncSession, *, as_of: Optional[datetime] = None
+) -> int:
+    """Count of people with role='member' who exist at ``as_of`` (default: now).
+
+    A person is counted if:
+      - the person_roles row was created on or before ``as_of``
+      - the person has not been soft-deleted by ``as_of``
+    """
+    as_of_norm = _normalize_to_utc(as_of) if as_of else datetime.now(timezone.utc)
+
+    stmt = (
+        select(func.count(func.distinct(People.id)))
+        .select_from(People)
+        .join(PersonRole, PersonRole.person_id == People.id)
+        .join(Role, Role.id == PersonRole.role_id)
+        .where(
+            Role.code == "member",
+            PersonRole.created_at <= as_of_norm,
+            or_(People.deleted_at.is_(None), People.deleted_at > as_of_norm),
+        )
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one() or 0)
+
+
+async def count_active_subscriptions(
+    db: AsyncSession, *, as_of: Optional[datetime] = None
+) -> int:
+    """Count of membership subscriptions that are active at ``as_of``.
+
+    "Active" = status='active' AND start_at <= as_of < end_at.
+    """
+    as_of_norm = _normalize_to_utc(as_of) if as_of else datetime.now(timezone.utc)
+
+    stmt = select(func.count(MembershipSubscription.id)).where(
+        MembershipSubscription.status == "active",
+        MembershipSubscription.start_at <= as_of_norm,
+        MembershipSubscription.end_at > as_of_norm,
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one() or 0)
+
+
+async def count_new_members(
+    db: AsyncSession,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+) -> int:
+    """Count of people that were assigned the 'member' role inside the window."""
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+
+    stmt = (
+        select(func.count(func.distinct(People.id)))
+        .select_from(People)
+        .join(PersonRole, PersonRole.person_id == People.id)
+        .join(Role, Role.id == PersonRole.role_id)
+        .where(
+            Role.code == "member",
+            PersonRole.created_at >= start,
+            PersonRole.created_at <= end,
+            People.deleted_at.is_(None),
+        )
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one() or 0)
+
+
+async def count_reservations(
+    db: AsyncSession,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+) -> int:
+    """Count of reservations for sessions starting in the window.
+
+    Excludes canceled, no_show, and waitlisted reservations — only seats that
+    were actually held (reserved or checked_in).
+    """
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+
+    stmt = (
+        select(func.count(Reservation.id))
+        .select_from(Reservation)
+        .join(ClassSession, ClassSession.id == Reservation.session_id)
+        .where(
+            ClassSession.start_at >= start,
+            ClassSession.start_at <= end,
+            Reservation.status.in_(_OCCUPIED_RESERVATION_STATUSES),
+        )
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one() or 0)
+
+
+async def calculate_occupancy_avg(
+    db: AsyncSession,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+) -> float:
+    """Average occupancy percent across non-cancelled sessions in the window.
+
+    Computed as: SUM(reserved) / SUM(capacity) * 100, weighted by capacity.
+    Returns 0.0 if no sessions or zero total capacity (avoids div-by-zero).
+    """
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+
+    # Per-session subquery: how many seats are occupied
+    occupied_subq = (
+        select(
+            Reservation.session_id.label("session_id"),
+            func.count(Reservation.id).label("reserved"),
+        )
+        .where(Reservation.status.in_(_OCCUPIED_RESERVATION_STATUSES))
+        .group_by(Reservation.session_id)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            func.coalesce(func.sum(ClassSession.capacity), 0).label("total_capacity"),
+            func.coalesce(func.sum(occupied_subq.c.reserved), 0).label("total_reserved"),
+        )
+        .select_from(ClassSession)
+        .outerjoin(occupied_subq, occupied_subq.c.session_id == ClassSession.id)
+        .where(
+            ClassSession.start_at >= start,
+            ClassSession.start_at <= end,
+            ClassSession.status.in_(_VALID_SESSION_STATUSES),
+        )
+    )
+    row = (await db.execute(stmt)).one()
+    capacity = int(row.total_capacity or 0)
+    if capacity == 0:
+        return 0.0
+    return round(float(row.total_reserved or 0) / capacity * 100, 2)
+
+
+# --------------------------------------------------------------------------- #
+# Series for charts                                                            #
+# --------------------------------------------------------------------------- #
+
+
+async def occupancy_by_class(
+    db: AsyncSession,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+) -> list[ClassBucketData]:
+    """Occupancy breakdown grouped by ClassType.name within the window."""
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+
+    occupied_subq = (
+        select(
+            Reservation.session_id.label("session_id"),
+            func.count(Reservation.id).label("reserved"),
+        )
+        .where(Reservation.status.in_(_OCCUPIED_RESERVATION_STATUSES))
+        .group_by(Reservation.session_id)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            ClassType.name.label("class_name"),
+            func.coalesce(func.sum(ClassSession.capacity), 0).label("capacity"),
+            func.coalesce(func.sum(occupied_subq.c.reserved), 0).label("reserved"),
+        )
+        .select_from(ClassSession)
+        .join(ClassType, ClassType.id == ClassSession.class_type_id)
+        .outerjoin(occupied_subq, occupied_subq.c.session_id == ClassSession.id)
+        .where(
+            ClassSession.start_at >= start,
+            ClassSession.start_at <= end,
+            ClassSession.status.in_(_VALID_SESSION_STATUSES),
+        )
+        .group_by(ClassType.name)
+        .order_by(func.sum(ClassSession.capacity).desc())
+    )
+    rows = (await db.execute(stmt)).all()
+    out: list[ClassBucketData] = []
+    for r in rows:
+        cap = int(r.capacity or 0)
+        res = int(r.reserved or 0)
+        pct = round(res / cap * 100, 2) if cap > 0 else 0.0
+        out.append(
+            ClassBucketData(
+                class_name=r.class_name or "(sin nombre)",
+                capacity=cap,
+                reserved=res,
+                occupancy_pct=pct,
+            )
+        )
+    return out
+
+
+async def new_members_series(
+    db: AsyncSession,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+) -> list[DailyPointData]:
+    """Daily count of new member-role assignments inside the window."""
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+
+    day_col = func.date_trunc("day", PersonRole.created_at).label("day")
+    stmt = (
+        select(
+            day_col,
+            func.count(func.distinct(People.id)).label("count"),
+        )
+        .select_from(People)
+        .join(PersonRole, PersonRole.person_id == People.id)
+        .join(Role, Role.id == PersonRole.role_id)
+        .where(
+            Role.code == "member",
+            PersonRole.created_at >= start,
+            PersonRole.created_at <= end,
+            People.deleted_at.is_(None),
+        )
+        .group_by(day_col)
+        .order_by(day_col)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        DailyPointData(day=r.day, count=int(r.count or 0), total=float(r.count or 0))
+        for r in rows
+    ]
+
+
+async def revenue_by_day(
+    db: AsyncSession,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+) -> list[DailyPointData]:
+    """Daily revenue series for the window. Thin wrapper over Payment table.
+
+    Kept here (instead of importing payment_metrics.get_payment_metrics) to
+    avoid the round-trip cost of computing all the other payment aggregations
+    we don't need for the dashboard chart.
+    """
+    from app.models import Payment
+
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+
+    day_col = func.date_trunc("day", Payment.paid_at).label("day")
+    stmt = (
+        select(
+            day_col,
+            func.count(Payment.id).label("count"),
+            func.coalesce(func.sum(Payment.amount), 0).label("total"),
+        )
+        .where(
+            Payment.paid_at >= start,
+            Payment.paid_at <= end,
+            Payment.status == "COMPLETED",
+        )
+        .group_by(day_col)
+        .order_by(day_col)
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        DailyPointData(day=r.day, count=int(r.count or 0), total=float(r.total or 0))
+        for r in rows
+    ]
+
+
+async def membership_distribution(
+    db: AsyncSession,
+    *,
+    as_of: Optional[datetime] = None,
+) -> list[PlanBucketData]:
+    """Active subscriptions grouped by plan, snapshot at ``as_of`` (default now).
+
+    "Active" uses the same predicate as count_active_subscriptions. ``count``
+    is the number of subscriptions; ``total`` is the cumulative monthly value
+    (price × count) — useful for an "MRR by plan" donut.
+    """
+    as_of_norm = _normalize_to_utc(as_of) if as_of else datetime.now(timezone.utc)
+
+    stmt = (
+        select(
+            MembershipPlan.id.label("plan_id"),
+            MembershipPlan.name.label("plan_name"),
+            func.count(MembershipSubscription.id).label("count"),
+            func.coalesce(
+                func.sum(MembershipPlan.price), 0
+            ).label("total"),
+        )
+        .select_from(MembershipSubscription)
+        .join(MembershipPlan, MembershipPlan.id == MembershipSubscription.plan_id)
+        .where(
+            MembershipSubscription.status == "active",
+            MembershipSubscription.start_at <= as_of_norm,
+            MembershipSubscription.end_at > as_of_norm,
+        )
+        .group_by(MembershipPlan.id, MembershipPlan.name)
+        .order_by(func.count(MembershipSubscription.id).desc())
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        PlanBucketData(
+            plan_id=r.plan_id,
+            plan_name=r.plan_name,
+            count=int(r.count or 0),
+            total=float(r.total or 0),
+        )
+        for r in rows
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Sum helper (single-shot SUM(amount) for previous period revenue)            #
+# --------------------------------------------------------------------------- #
+
+
+async def _sum_revenue(
+    db: AsyncSession, *, start_date: datetime, end_date: datetime
+) -> float:
+    """SUM(payments.amount) for COMPLETED payments in the window."""
+    from app.models import Payment
+
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+    stmt = select(func.coalesce(func.sum(Payment.amount), 0)).where(
+        Payment.paid_at >= start,
+        Payment.paid_at <= end,
+        Payment.status == "COMPLETED",
+    )
+    return float((await db.execute(stmt)).scalar_one() or 0)
+
+
+# --------------------------------------------------------------------------- #
+# Orchestrator                                                                 #
+# --------------------------------------------------------------------------- #
+
+
+def _previous_window(
+    start_date: datetime, end_date: datetime
+) -> tuple[datetime, datetime]:
+    """Return (prev_start, prev_end) of the same length, ending just before start.
+
+    Example: window [Sep 1 00:00, Sep 30 23:59] → prev [Aug 2 00:00, Sep 1 00:00).
+    The previous window ends at exactly start_date so there is no overlap.
+    """
+    delta = end_date - start_date
+    prev_end = start_date
+    prev_start = prev_end - delta
+    return prev_start, prev_end
+
+
+async def get_dashboard_metrics(
+    db: AsyncSession,
+    *,
+    start_date: datetime,
+    end_date: datetime,
+) -> DashboardMetricsData:
+    """Compute all dashboard KPIs + chart series in one call.
+
+    Stock KPIs (totalMembers, activeMembers) are snapshotted at ``end_date``;
+    their "previous" counterparts use ``start_date`` as the snapshot point so
+    the trend reflects "how many we had at the start vs the end of the window".
+
+    Flow KPIs (revenue, reservations, new members, occupancy) and their prev
+    counterparts use the (start, end) and (prev_start, prev_end) windows.
+    """
+    start = _normalize_to_utc(start_date)
+    end = _normalize_to_utc(end_date)
+    prev_start, prev_end = _previous_window(start, end)
+
+    # Stock — snapshot at end_date and at start_date (= prev_end)
+    total_members = await count_active_members(db, as_of=end)
+    total_members_prev = await count_active_members(db, as_of=start)
+    active_members = await count_active_subscriptions(db, as_of=end)
+    active_members_prev = await count_active_subscriptions(db, as_of=start)
+
+    # Flow — current and previous windows
+    new_members = await count_new_members(db, start_date=start, end_date=end)
+    new_members_prev = await count_new_members(
+        db, start_date=prev_start, end_date=prev_end
+    )
+
+    period_reservations = await count_reservations(db, start_date=start, end_date=end)
+    reservations_prev = await count_reservations(
+        db, start_date=prev_start, end_date=prev_end
+    )
+
+    period_revenue = await _sum_revenue(db, start_date=start, end_date=end)
+    revenue_prev = await _sum_revenue(db, start_date=prev_start, end_date=prev_end)
+
+    avg_occupancy = await calculate_occupancy_avg(
+        db, start_date=start, end_date=end
+    )
+    avg_occupancy_prev = await calculate_occupancy_avg(
+        db, start_date=prev_start, end_date=prev_end
+    )
+
+    # Series
+    revenue_series = await revenue_by_day(db, start_date=start, end_date=end)
+    occupancy_series = await occupancy_by_class(db, start_date=start, end_date=end)
+    new_members_serie = await new_members_series(db, start_date=start, end_date=end)
+    plan_distribution = await membership_distribution(db, as_of=end)
+
+    return DashboardMetricsData(
+        total_members=total_members,
+        active_members=active_members,
+        new_members=new_members,
+        period_reservations=period_reservations,
+        period_revenue=period_revenue,
+        avg_occupancy=avg_occupancy,
+        total_members_prev=total_members_prev,
+        active_members_prev=active_members_prev,
+        new_members_prev=new_members_prev,
+        reservations_prev=reservations_prev,
+        revenue_prev=revenue_prev,
+        avg_occupancy_prev=avg_occupancy_prev,
+        revenue_by_day=revenue_series,
+        occupancy_by_class=occupancy_series,
+        new_members_by_day=new_members_serie,
+        membership_distribution=plan_distribution,
+    )

--- a/app/graphql/dashboard/queries.py
+++ b/app/graphql/dashboard/queries.py
@@ -1,0 +1,44 @@
+"""GraphQL queries for the dashboard tab."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud.dashboard_metrics import get_dashboard_metrics
+from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.dashboard.types import DashboardMetrics
+
+
+@strawberry.type
+class DashboardQuery:
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def dashboard_metrics(
+        self,
+        info: Info,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+    ) -> DashboardMetrics:
+        """Aggregated KPIs and chart series for the dashboard.
+
+        Defaults to "this month" (1st of month → now) if no range is provided.
+        Stock KPIs are snapshotted at ``end_date``; flow KPIs are filtered to
+        the (start, end) window. Previous-period values use a same-sized
+        window shifted back so the UI can render trend deltas.
+        """
+        db: AsyncSession = info.context.db
+
+        if end_date is None:
+            end_date = datetime.now(timezone.utc)
+        if start_date is None:
+            start_date = end_date.replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0
+            )
+
+        data = await get_dashboard_metrics(
+            db=db, start_date=start_date, end_date=end_date
+        )
+        return DashboardMetrics.from_data(data)

--- a/app/graphql/dashboard/types.py
+++ b/app/graphql/dashboard/types.py
@@ -1,0 +1,93 @@
+"""GraphQL types for the dashboard tab.
+
+Re-exports DailyPoint and PlanBucket from the memberships GraphQL module so
+the dashboard can share the same shapes for the revenue / new members /
+membership distribution series. ClassBucket is dashboard-specific.
+"""
+from __future__ import annotations
+
+import strawberry
+
+from app.graphql.memberships.types import DailyPoint, PlanBucket
+
+
+@strawberry.type
+class ClassBucket:
+    """Occupancy breakdown by class type."""
+
+    class_name: str
+    capacity: int
+    reserved: int
+    occupancy_pct: float
+
+
+@strawberry.type
+class DashboardMetrics:
+    """All headline KPIs and chart series for the dashboard tab."""
+
+    # Stock KPIs (snapshot at end of current window)
+    total_members: int
+    active_members: int
+
+    # Flow KPIs (current window)
+    new_members: int
+    period_reservations: int
+    period_revenue: float
+    avg_occupancy: float
+
+    # Previous-period counterparts (same window size shifted back)
+    total_members_prev: int
+    active_members_prev: int
+    new_members_prev: int
+    reservations_prev: int
+    revenue_prev: float
+    avg_occupancy_prev: float
+
+    # Series for the four charts
+    revenue_by_day: list[DailyPoint]
+    occupancy_by_class: list[ClassBucket]
+    new_members_by_day: list[DailyPoint]
+    membership_distribution: list[PlanBucket]
+
+    @classmethod
+    def from_data(cls, data) -> "DashboardMetrics":
+        return cls(
+            total_members=data.total_members,
+            active_members=data.active_members,
+            new_members=data.new_members,
+            period_reservations=data.period_reservations,
+            period_revenue=data.period_revenue,
+            avg_occupancy=data.avg_occupancy,
+            total_members_prev=data.total_members_prev,
+            active_members_prev=data.active_members_prev,
+            new_members_prev=data.new_members_prev,
+            reservations_prev=data.reservations_prev,
+            revenue_prev=data.revenue_prev,
+            avg_occupancy_prev=data.avg_occupancy_prev,
+            revenue_by_day=[
+                DailyPoint(day=p.day, count=p.count, total=p.total)
+                for p in data.revenue_by_day
+            ],
+            occupancy_by_class=[
+                ClassBucket(
+                    class_name=b.class_name,
+                    capacity=b.capacity,
+                    reserved=b.reserved,
+                    occupancy_pct=b.occupancy_pct,
+                )
+                for b in data.occupancy_by_class
+            ],
+            new_members_by_day=[
+                DailyPoint(day=p.day, count=p.count, total=p.total)
+                for p in data.new_members_by_day
+            ],
+            membership_distribution=[
+                PlanBucket(
+                    plan_id=b.plan_id,
+                    plan_name=b.plan_name,
+                    count=b.count,
+                    total=b.total,
+                )
+                for b in data.membership_distribution
+            ],
+        )

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -22,6 +22,7 @@ from app.graphql.standing_bookings.queries import StandingBookingQuery
 from app.graphql.standing_bookings.mutations import StandingBookingMutation
 from app.graphql.sessions.queries import SessionQuery
 from app.graphql.sessions.mutations import SessionMutation
+from app.graphql.dashboard.queries import DashboardQuery
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ except ImportError as e:
         pass
 
 @strawberry.type
-class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries):
+class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery):
     @strawberry.field
     def hello(self) -> str:
         return "Hello from GraphQL!"

--- a/tests/test_dashboard_metrics.py
+++ b/tests/test_dashboard_metrics.py
@@ -1,0 +1,412 @@
+"""Backend tests for the dashboard metrics CRUD layer.
+
+Covers:
+  - count_active_members: respects deleted_at and as_of windowing
+  - count_active_subscriptions: respects status + start/end window
+  - count_new_members: range filter via PersonRole.created_at
+  - count_reservations: only counts reserved/checked_in for sessions in window
+  - calculate_occupancy_avg: weighted avg, div-by-zero safe
+
+Tests use far-future timestamps (year 3000+) so they don't see real defaultdb
+data, and run inside the savepoint fixture so nothing persists.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.crud.dashboard_metrics import (
+    calculate_occupancy_avg,
+    count_active_members,
+    count_active_subscriptions,
+    count_new_members,
+    count_reservations,
+)
+from app.models import (
+    MembershipPlan,
+    MembershipSubscription,
+    People,
+)
+from app.models.classModel import ClassSession, ClassType, Reservation
+from app.models.userModel import PersonRole, Role
+
+
+def _utc(year: int, month: int, day: int, hour: int = 12) -> datetime:
+    return datetime(year, month, day, hour, 0, 0, tzinfo=timezone.utc)
+
+
+async def _ensure_member_role(db) -> Role:
+    """Get-or-create the 'member' role and return it."""
+    from sqlalchemy import select
+
+    existing = (
+        await db.execute(select(Role).where(Role.code == "member"))
+    ).scalar_one_or_none()
+    if existing:
+        return existing
+    role = Role(code="member", description="Member")
+    db.add(role)
+    await db.flush()
+    return role
+
+
+async def _make_member(
+    db,
+    *,
+    role: Role,
+    full_name: str,
+    role_assigned_at: datetime,
+    deleted_at: datetime | None = None,
+) -> People:
+    person = People(full_name=full_name, deleted_at=deleted_at)
+    db.add(person)
+    await db.flush()
+    pr = PersonRole(person_id=person.id, role_id=role.id, created_at=role_assigned_at)
+    db.add(pr)
+    await db.flush()
+    return person
+
+
+# --------------------------------------------------------------------------- #
+# count_active_members                                                         #
+# --------------------------------------------------------------------------- #
+
+
+async def test_count_active_members_excludes_deleted_and_future_assignments(db):
+    role = await _ensure_member_role(db)
+
+    # Baseline: capture the count of pre-existing real-data members so we can
+    # assert deltas instead of absolute values.
+    baseline = await count_active_members(db, as_of=_utc(3000, 6, 15))
+
+    # Test fixtures, all assigned within year 3000:
+    await _make_member(db, role=role, full_name="Active 1", role_assigned_at=_utc(3000, 1, 1))
+    await _make_member(db, role=role, full_name="Active 2", role_assigned_at=_utc(3000, 2, 1))
+    await _make_member(
+        db,
+        role=role,
+        full_name="Deleted 1",
+        role_assigned_at=_utc(3000, 1, 1),
+        deleted_at=_utc(3000, 5, 1),
+    )
+    await _make_member(
+        db,
+        role=role,
+        full_name="Future 1",
+        role_assigned_at=_utc(3000, 7, 1),
+    )
+
+    # As of 3000-06-15: Active1 + Active2 should be counted; Deleted1 already
+    # gone; Future1 not yet assigned. So delta is +2.
+    count = await count_active_members(db, as_of=_utc(3000, 6, 15))
+    assert count - baseline == 2
+
+    # As of 3000-04-15 (before Deleted1 was deleted): Active1, Active2, Deleted1.
+    # Future1 still not assigned. So delta is +3.
+    early = await count_active_members(db, as_of=_utc(3000, 4, 15))
+    early_baseline = await count_active_members(db, as_of=_utc(3000, 4, 15))  # idempotent
+    # baseline at this earlier date might be the same as later one, but we
+    # test the delta against itself by re-querying with the early as_of:
+    # we just make sure Deleted1 was counted. Easier: compare to as_of=now.
+    # The delta of (early - count) should be exactly +1 (Deleted1 reappears).
+    assert early - count == 1
+
+
+# --------------------------------------------------------------------------- #
+# count_active_subscriptions                                                   #
+# --------------------------------------------------------------------------- #
+
+
+async def test_count_active_subscriptions_window_and_status(db):
+    role = await _ensure_member_role(db)
+    person = await _make_member(
+        db, role=role, full_name="Sub Holder", role_assigned_at=_utc(3001, 1, 1)
+    )
+
+    plan = MembershipPlan(
+        name="Test Plan 3001",
+        price=100,
+        duration_value=1,
+        duration_unit="month",
+    )
+    db.add(plan)
+    await db.flush()
+
+    baseline = await count_active_subscriptions(db, as_of=_utc(3001, 6, 15))
+
+    # Active sub spanning June.
+    db.add(
+        MembershipSubscription(
+            person_id=person.id,
+            plan_id=plan.id,
+            start_at=_utc(3001, 6, 1),
+            end_at=_utc(3001, 7, 1),
+            status="active",
+        )
+    )
+    # Active sub but expired by June 15 (end_at = June 10).
+    db.add(
+        MembershipSubscription(
+            person_id=person.id,
+            plan_id=plan.id,
+            start_at=_utc(3001, 5, 1),
+            end_at=_utc(3001, 6, 10),
+            status="active",
+        )
+    )
+    # Status canceled — should not count.
+    db.add(
+        MembershipSubscription(
+            person_id=person.id,
+            plan_id=plan.id,
+            start_at=_utc(3001, 6, 1),
+            end_at=_utc(3001, 7, 1),
+            status="canceled",
+        )
+    )
+    await db.flush()
+
+    count = await count_active_subscriptions(db, as_of=_utc(3001, 6, 15))
+    assert count - baseline == 1
+
+
+# --------------------------------------------------------------------------- #
+# count_new_members                                                            #
+# --------------------------------------------------------------------------- #
+
+
+async def test_count_new_members_filters_by_role_assignment_date(db):
+    role = await _ensure_member_role(db)
+
+    await _make_member(db, role=role, full_name="In window 1", role_assigned_at=_utc(3002, 5, 5))
+    await _make_member(db, role=role, full_name="In window 2", role_assigned_at=_utc(3002, 5, 20))
+    await _make_member(db, role=role, full_name="Before", role_assigned_at=_utc(3002, 4, 30))
+    await _make_member(db, role=role, full_name="After", role_assigned_at=_utc(3002, 6, 1))
+
+    count = await count_new_members(
+        db, start_date=_utc(3002, 5, 1), end_date=_utc(3002, 5, 31, 23)
+    )
+    # Among test data only, exactly 2 are in May 3002. No real data falls in year 3002.
+    assert count == 2
+
+
+# --------------------------------------------------------------------------- #
+# count_reservations                                                           #
+# --------------------------------------------------------------------------- #
+
+
+async def _create_session(db, *, start_at: datetime, capacity: int = 10) -> ClassSession:
+    """Create a minimal scheduled session, depending on a class_type+venue."""
+    from sqlalchemy import select
+
+    from app.models.venueModel import Venue
+
+    # Get-or-create class type
+    ctype = (
+        await db.execute(select(ClassType).where(ClassType.code == "test_dash"))
+    ).scalar_one_or_none()
+    if not ctype:
+        ctype = ClassType(code="test_dash", name="Dashboard Test")
+        db.add(ctype)
+        await db.flush()
+
+    # Use any existing venue (real DB has at least one)
+    venue = (await db.execute(select(Venue).limit(1))).scalar_one_or_none()
+    assert venue is not None, "test requires at least one Venue in defaultdb"
+
+    sess = ClassSession(
+        class_type_id=ctype.id,
+        venue_id=venue.id,
+        start_at=start_at,
+        end_at=start_at.replace(hour=start_at.hour + 1),
+        capacity=capacity,
+        status="scheduled",
+    )
+    db.add(sess)
+    await db.flush()
+    return sess
+
+
+async def test_count_reservations_window_and_status(db):
+    role = await _ensure_member_role(db)
+    person = await _make_member(
+        db, role=role, full_name="Resv Holder", role_assigned_at=_utc(3003, 1, 1)
+    )
+
+    sess_in = await _create_session(db, start_at=_utc(3003, 6, 10, 9))
+    sess_out = await _create_session(db, start_at=_utc(3003, 7, 10, 9))
+
+    # 2 valid reservations on the in-window session
+    db.add(Reservation(session_id=sess_in.id, person_id=person.id, status="reserved"))
+    person2 = await _make_member(
+        db, role=role, full_name="Resv Holder 2", role_assigned_at=_utc(3003, 1, 1)
+    )
+    db.add(Reservation(session_id=sess_in.id, person_id=person2.id, status="checked_in"))
+    # 1 cancelled on in-window — should not count
+    person3 = await _make_member(
+        db, role=role, full_name="Resv Holder 3", role_assigned_at=_utc(3003, 1, 1)
+    )
+    db.add(Reservation(session_id=sess_in.id, person_id=person3.id, status="canceled"))
+    # 1 valid on out-of-window session — should not count
+    db.add(Reservation(session_id=sess_out.id, person_id=person.id, status="reserved"))
+    await db.flush()
+
+    count = await count_reservations(
+        db, start_date=_utc(3003, 6, 1), end_date=_utc(3003, 6, 30, 23)
+    )
+    assert count == 2
+
+
+# --------------------------------------------------------------------------- #
+# calculate_occupancy_avg                                                      #
+# --------------------------------------------------------------------------- #
+
+
+async def test_occupancy_avg_weighted(db):
+    role = await _ensure_member_role(db)
+    person = await _make_member(
+        db, role=role, full_name="Occ Holder", role_assigned_at=_utc(3004, 1, 1)
+    )
+
+    # Session A: capacity 10, 5 reserved, 1 checked_in, 1 canceled
+    sess_a = await _create_session(db, start_at=_utc(3004, 6, 10, 9), capacity=10)
+    for i in range(5):
+        p = await _make_member(
+            db, role=role, full_name=f"A-r{i}", role_assigned_at=_utc(3004, 1, 1)
+        )
+        db.add(Reservation(session_id=sess_a.id, person_id=p.id, status="reserved"))
+    p_check = await _make_member(
+        db, role=role, full_name="A-check", role_assigned_at=_utc(3004, 1, 1)
+    )
+    db.add(Reservation(session_id=sess_a.id, person_id=p_check.id, status="checked_in"))
+    p_cancel = await _make_member(
+        db, role=role, full_name="A-cancel", role_assigned_at=_utc(3004, 1, 1)
+    )
+    db.add(Reservation(session_id=sess_a.id, person_id=p_cancel.id, status="canceled"))
+
+    # Session B: capacity 5, 0 reserved
+    sess_b = await _create_session(db, start_at=_utc(3004, 6, 11, 10), capacity=5)
+    await db.flush()
+
+    # A: 6/10 occupied. B: 0/5. Total occupied 6, total capacity 15. Avg = 40.0%.
+    occ = await calculate_occupancy_avg(
+        db, start_date=_utc(3004, 6, 1), end_date=_utc(3004, 6, 30, 23)
+    )
+    assert occ == 40.0
+
+
+async def test_occupancy_avg_zero_capacity_window(db):
+    """Empty window returns 0.0 instead of erroring."""
+    occ = await calculate_occupancy_avg(
+        db, start_date=_utc(3010, 1, 1), end_date=_utc(3010, 1, 2)
+    )
+    assert occ == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# get_dashboard_metrics orchestrator                                           #
+# --------------------------------------------------------------------------- #
+
+
+async def test_dashboard_metrics_previous_window_arithmetic(db):
+    """Verify _previous_window: prev_end == start, prev_start == start - delta."""
+    from app.crud.dashboard_metrics import _previous_window
+
+    start = _utc(3005, 5, 1)
+    end = _utc(3005, 5, 31, 23, 59, 59) if False else _utc(3005, 5, 31)
+    prev_start, prev_end = _previous_window(start, end)
+    assert prev_end == start
+    assert prev_end - prev_start == end - start
+
+
+async def test_dashboard_metrics_orchestrator_full(db):
+    """End-to-end: seed 2 windows of data, verify current vs previous deltas."""
+    from app.crud.dashboard_metrics import get_dashboard_metrics
+
+    role = await _ensure_member_role(db)
+
+    # Seed members in current window (May 3006) and previous window (Apr 3006)
+    for i in range(5):
+        await _make_member(
+            db, role=role, full_name=f"May {i}", role_assigned_at=_utc(3006, 5, 5 + i)
+        )
+    for i in range(2):
+        await _make_member(
+            db, role=role, full_name=f"Apr {i}", role_assigned_at=_utc(3006, 4, 5 + i)
+        )
+
+    # Seed payments in both windows
+    from decimal import Decimal
+
+    from app.models import Payment
+
+    member_for_pay = await _make_member(
+        db, role=role, full_name="Payer", role_assigned_at=_utc(3006, 1, 1)
+    )
+    # Current period: $1500 in 3 payments
+    for amt in (500, 500, 500):
+        db.add(
+            Payment(
+                person_id=member_for_pay.id,
+                amount=Decimal(amt),
+                method="cash",
+                status="COMPLETED",
+                paid_at=_utc(3006, 5, 10),
+            )
+        )
+    # Previous period: $800 in 2 payments
+    for amt in (300, 500):
+        db.add(
+            Payment(
+                person_id=member_for_pay.id,
+                amount=Decimal(amt),
+                method="cash",
+                status="COMPLETED",
+                paid_at=_utc(3006, 4, 10),
+            )
+        )
+    await db.flush()
+
+    # Window: May 3006 (full month). Previous window auto = April 3006.
+    start = _utc(3006, 5, 1, 0)
+    end = _utc(3006, 5, 31, 23)
+
+    metrics = await get_dashboard_metrics(db, start_date=start, end_date=end)
+
+    # Flow KPIs: current vs previous
+    assert metrics.new_members == 5
+    assert metrics.new_members_prev == 2
+    assert metrics.period_revenue == 1500.0
+    assert metrics.revenue_prev == 800.0
+
+    # Stock KPIs (snapshot at end vs at start). After all seeds, total_members
+    # at end = baseline_at_start + 5 (May new) + 2 (Apr new) + 1 (Payer in Jan).
+    # At start (May 1) = baseline_at_start + 2 (Apr) + 1 (Payer in Jan).
+    # Delta total_members - total_members_prev should be exactly 5.
+    assert metrics.total_members - metrics.total_members_prev == 5
+
+    # Series shapes
+    assert isinstance(metrics.revenue_by_day, list)
+    assert isinstance(metrics.occupancy_by_class, list)
+    assert isinstance(metrics.new_members_by_day, list)
+    assert isinstance(metrics.membership_distribution, list)
+
+
+async def test_dashboard_metrics_handles_empty_window(db):
+    """Year 5000+ window has no data — orchestrator returns zeros gracefully."""
+    from app.crud.dashboard_metrics import get_dashboard_metrics
+
+    metrics = await get_dashboard_metrics(
+        db, start_date=_utc(5000, 1, 1), end_date=_utc(5000, 1, 31, 23)
+    )
+    assert metrics.new_members == 0
+    assert metrics.period_reservations == 0
+    assert metrics.period_revenue == 0.0
+    assert metrics.avg_occupancy == 0.0
+    assert metrics.revenue_by_day == []
+    assert metrics.occupancy_by_class == []
+    assert metrics.new_members_by_day == []
+    # membership_distribution may have real-data entries (snapshot at year 5000
+    # picks up subs created today that are still active in the future), but
+    # this is an edge case we don't strictly assert.


### PR DESCRIPTION
## Summary
- Adds dashboard metrics backend support for KPI queries.
- Includes dashboard GraphQL wiring and aggregation tests/context used by the frontend dashboard work.

## Validation
- Existing branch content was already present locally before the WhatsApp branch was created.