### PR TITLE
Optimize WhatsApp conversation list query for pagination

### DIFF
--- a/app/crud/whatsappCrud.py
+++ b/app/crud/whatsappCrud.py
@@ -348,6 +348,22 @@ def _contact_data(
 # ---------------------------------------------------------------------------
 # Reads
 # ---------------------------------------------------------------------------
+def _last_activity_subquery():
+    """Grouped max(timestamp) per conversation.
+
+    Replaces a per-row correlated subquery with a single ``GROUP BY`` scan so the
+    list can be ordered and paginated (``OFFSET``/``LIMIT``) efficiently.
+    """
+    return (
+        select(
+            Message.conversation_id.label("cid"),
+            func.max(Message.timestamp).label("last_activity"),
+        )
+        .group_by(Message.conversation_id)
+        .subquery()
+    )
+
+
 async def get_conversations(
     db: AsyncSession,
     limit: Optional[int] = 50,
@@ -355,15 +371,11 @@ async def get_conversations(
     search: Optional[str] = None,
 ) -> List[ConversationData]:
     """Return conversations ordered by most recent message activity."""
-    last_activity_sq = (
-        select(func.max(Message.timestamp))
-        .where(Message.conversation_id == Conversation.id)
-        .correlate(Conversation)
-        .scalar_subquery()
-    )
+    activity_sq = _last_activity_subquery()
 
     stmt = (
-        select(Conversation, last_activity_sq.label("last_activity"))
+        select(Conversation, activity_sq.c.last_activity)
+        .outerjoin(activity_sq, activity_sq.c.cid == Conversation.id)
         .options(selectinload(Conversation.contact))
     )
 
@@ -390,7 +402,7 @@ async def get_conversations(
             )
         )
 
-    stmt = stmt.order_by(last_activity_sq.desc().nullslast()).offset(offset)
+    stmt = stmt.order_by(activity_sq.c.last_activity.desc().nullslast()).offset(offset)
     if limit is not None:
         stmt = stmt.limit(limit)
 
@@ -420,29 +432,61 @@ async def get_conversations(
     return result
 
 
+async def get_conversation_data(
+    db: AsyncSession, conversation_id: int
+) -> Optional[ConversationData]:
+    """Return a single conversation enriched like ``get_conversations``.
+
+    Used by the desktop client to insert a newly-active conversation incrementally
+    (e.g. a realtime message arrives for a conversation outside the loaded pages)
+    without reloading the whole list.
+    """
+    activity_sq = _last_activity_subquery()
+    stmt = (
+        select(Conversation, activity_sq.c.last_activity)
+        .outerjoin(activity_sq, activity_sq.c.cid == Conversation.id)
+        .options(selectinload(Conversation.contact))
+        .where(Conversation.id == conversation_id)
+    )
+    row = (await db.execute(stmt)).first()
+    if row is None:
+        return None
+
+    conv, last_activity = row
+    last_messages = await _latest_message_per_conversation(db, [conv.id])
+    member_by_contact_id = await _resolve_member_contacts(db, [conv.contact])
+    member = member_by_contact_id.get(conv.contact_id)
+    return ConversationData(
+        id=conv.id,
+        status=conv.status,
+        contact=_contact_data(conv.contact, member),
+        last_message=last_messages.get(conv.id),
+        last_activity=last_activity,
+        unread_count=0,  # reserved for a later phase
+    )
+
+
 async def _latest_message_per_conversation(
     db: AsyncSession, conv_ids: List[int]
 ) -> Dict[int, ChatMessageData]:
-    """Fetch the most recent message for each given conversation id."""
+    """Fetch the most recent message for each given conversation id.
+
+    Uses ``DISTINCT ON (conversation_id)`` ordered by ``timestamp DESC, id DESC`` so
+    exactly one row is returned per conversation even when two messages share the same
+    timestamp (deterministic tie-break by id).
+    """
     if not conv_ids:
         return {}
 
-    maxts_sq = (
-        select(
-            Message.conversation_id.label("cid"),
-            func.max(Message.timestamp).label("maxts"),
-        )
+    stmt = (
+        select(Message)
         .where(Message.conversation_id.in_(conv_ids))
-        .group_by(Message.conversation_id)
-        .subquery()
-    )
-
-    stmt = select(Message).join(
-        maxts_sq,
-        and_(
-            Message.conversation_id == maxts_sq.c.cid,
-            Message.timestamp == maxts_sq.c.maxts,
-        ),
+        .distinct(Message.conversation_id)
+        .order_by(
+            Message.conversation_id,
+            Message.timestamp.desc(),
+            Message.id.desc(),
+        )
     )
     messages = (await db.execute(stmt)).scalars().all()
 

--- a/app/graphql/whatsapp/queries.py
+++ b/app/graphql/whatsapp/queries.py
@@ -5,7 +5,11 @@ import strawberry
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
-from app.crud.whatsappCrud import get_conversations, get_conversation_messages
+from app.crud.whatsappCrud import (
+    get_conversations,
+    get_conversation_data,
+    get_conversation_messages,
+)
 from app.graphql.whatsapp.types import ChatConversation, ChatMessage
 from app.graphql.auth.permissions import IsAuthenticated
 
@@ -24,6 +28,17 @@ class WhatsAppChatQuery:
         db: AsyncSession = info.context.db
         data = await get_conversations(db=db, limit=limit, offset=offset, search=search)
         return [ChatConversation.from_data(d) for d in data]
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def conversation(
+        self,
+        info: Info,
+        id: int,
+    ) -> Optional[ChatConversation]:
+        """Fetch a single conversation enriched like the list (for incremental inserts)."""
+        db: AsyncSession = info.context.db
+        data = await get_conversation_data(db=db, conversation_id=id)
+        return ChatConversation.from_data(data) if data else None
 
     @strawberry.field(permission_classes=[IsAuthenticated])
     async def conversation_messages(

--- a/tests/test_whatsapp_member_matching.py
+++ b/tests/test_whatsapp_member_matching.py
@@ -7,6 +7,7 @@ from app.crud.whatsappCrud import (
     _MemberCandidate,
     _member_contact_match_rank,
     _phone_match_keys,
+    get_conversation_data,
     get_conversations,
 )
 from app.models import (
@@ -172,3 +173,58 @@ async def test_get_conversations_searches_by_member_name(db):
 
     assert conversation.id in by_id
     assert by_id[conversation.id].contact.member_name == "Nombre Buscable WhatsApp 3008"
+
+
+async def test_get_conversation_data_returns_enriched_single(db):
+    role = await _ensure_member_role(db)
+    plan = await _make_plan(db, "WhatsApp Single Plan 3008")
+    await _make_member(
+        db,
+        role=role,
+        plan=plan,
+        full_name="Socia Single WhatsApp 3008",
+        phone_number="3006550004",
+    )
+    conversation = await _make_conversation(
+        db,
+        wa_id="5213006550004",
+        text="mensaje individual",
+    )
+
+    data = await get_conversation_data(db, conversation.id)
+    assert data is not None
+    assert data.id == conversation.id
+    assert data.contact.member_name == "Socia Single WhatsApp 3008"
+    assert data.last_message is not None
+    assert data.last_message.text_content == "mensaje individual"
+
+    assert await get_conversation_data(db, 999_999_999) is None
+
+
+async def test_latest_message_dedupes_on_equal_timestamp(db):
+    conversation = await _make_conversation(
+        db,
+        wa_id="5213006550005",
+        text="primer mensaje",
+    )
+    # Second message with the SAME timestamp as the first; deterministic tie-break
+    # must pick the higher id (newest) as the last message — and only one row.
+    same_ts = datetime(3008, 1, 10, 12, 0, 0)
+    second = Message(
+        conversation_id=conversation.id,
+        contact_id=conversation.contact_id,
+        direction="inbound",
+        message_type="text",
+        text_content="segundo mensaje",
+        timestamp=same_ts,
+    )
+    db.add(second)
+    await db.flush()
+
+    conversations = await get_conversations(db, limit=None)
+    matching = [c for c in conversations if c.id == conversation.id]
+
+    assert len(matching) == 1  # no duplicate conversation rows
+    assert matching[0].last_message is not None
+    assert matching[0].last_message.id == second.id
+    assert matching[0].last_message.text_content == "segundo mensaje"


### PR DESCRIPTION
## Context
The chat tab did not load all conversations: the conversation list was capped at 50 with no pagination, and the backend query was not efficiently paginable. This PR optimizes the backend read path so the desktop client can paginate (infinite scroll) and update incrementally.

## Changes
- **Paginable ordering:** replace the per-row correlated `max(timestamp)` subquery with a single grouped subquery join (`GROUP BY conversation_id`), so `ORDER BY last_activity` + `OFFSET/LIMIT` scale efficiently.
- **Dedupe latest message:** `_latest_message_per_conversation` now uses `DISTINCT ON (conversation_id)` ordered by `timestamp DESC, id DESC` → exactly one deterministic row per conversation (fixes possible duplicate rows on equal timestamps).
- **Single fetch:** new `get_conversation_data(db, conversation_id)` + `conversation(id: Int!)` GraphQL query, used by the client to insert a newly-active conversation without reloading the whole list.
- **Tests:** added coverage for the single fetch and the equal-timestamp dedupe.

No schema migration required (the denormalized `last_activity` column is intentionally left as a future option).

## Verification
- `cd backend; pytest tests/` (requires a Postgres test DB).
- GraphQL: `conversations(limit, offset)` paginates with stable ordering and no duplicate `lastMessage`; `conversation(id)` returns the enriched conversation or null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)