### PR TITLE
Unify WhatsApp contacts so templates don't spawn a separate chat

### DIFF
--- a/app/crud/whatsappCrud.py
+++ b/app/crud/whatsappCrud.py
@@ -535,6 +535,49 @@ async def get_contact_by_wa_id(db: AsyncSession, wa_id: str) -> Optional[Contact
     return (await db.execute(stmt)).scalars().first()
 
 
+def _contact_number_match_condition(keys: set[str], last10: set[str]):
+    """SQL condition matching a Contact by normalized phone keys (52/521 aware).
+
+    Mirrors ``_member_contact_sql_match_condition`` but targets Contact, comparing the
+    digit-only wa_id/phone_number against the candidate key set and the last-10 digits.
+    """
+    contact_wa = _digits_expr(Contact.wa_id)
+    contact_phone = _digits_expr(Contact.phone_number)
+    conds = []
+    if keys:
+        conds.append(contact_wa.in_(keys))
+        conds.append(contact_phone.in_(keys))
+    if last10:
+        conds.append(
+            and_(func.length(contact_wa) >= 10, func.right(contact_wa, 10).in_(last10))
+        )
+        conds.append(
+            and_(func.length(contact_phone) >= 10, func.right(contact_phone, 10).in_(last10))
+        )
+    if not conds:
+        return None
+    return or_(*conds)
+
+
+async def find_contact_by_number(db: AsyncSession, raw_number: Optional[str]) -> Optional[Contact]:
+    """Find an existing contact whose number matches ``raw_number`` (52/521 aware).
+
+    Returns the lowest-id match (deterministic) or None. Used so a send that types the
+    number in a different format (e.g. 52... vs 521...) reuses the existing contact
+    instead of creating a duplicate.
+    """
+    digits = _digits_only(raw_number)
+    if not digits:
+        return None
+    keys = _phone_match_keys(raw_number)
+    last10 = {digits[-10:]} if len(digits) >= 10 else set()
+    cond = _contact_number_match_condition(keys, last10)
+    if cond is None:
+        return None
+    stmt = select(Contact).where(cond).order_by(Contact.id.asc())
+    return (await db.execute(stmt)).scalars().first()
+
+
 async def get_conversation(db: AsyncSession, conversation_id: int) -> Optional[Conversation]:
     """Load a conversation with its contact eager-loaded (used by send mutation)."""
     stmt = (
@@ -550,9 +593,26 @@ async def upsert_contact(
     wa_id: str,
     phone_number: Optional[str] = None,
     profile_name: Optional[str] = None,
+    *,
+    authoritative: bool = True,
 ) -> Contact:
-    """Create or update a contact by wa_id. Caller commits."""
+    """Create or update a contact, matching by normalized number (52/521 aware).
+
+    Lookup order: exact ``wa_id`` (fast path), then a normalized phone match against
+    ``wa_id``/``phone_number``. This keeps a single contact per human number across the
+    inbound webhook and outbound sends, even when the number is stored/typed in
+    different Mexican formats.
+
+    ``authoritative`` should be True for the inbound webhook (Meta's ``from`` is the
+    canonical wa_id) and False for sends (the typed number must not overwrite the good
+    wa_id of an existing contact). Caller commits.
+    """
     contact = await get_contact_by_wa_id(db, wa_id)
+    if contact is None:
+        contact = await find_contact_by_number(db, wa_id)
+    if contact is None and phone_number:
+        contact = await find_contact_by_number(db, phone_number)
+
     now = datetime.utcnow()
     if contact is None:
         contact = Contact(
@@ -571,9 +631,15 @@ async def upsert_contact(
     if profile_name and contact.profile_name != profile_name:
         contact.profile_name = profile_name
         changed = True
-    if phone_number and contact.phone_number != phone_number:
-        contact.phone_number = phone_number
-        changed = True
+    # Only the authoritative inbound source may canonicalize the stored identity;
+    # sends never downgrade an existing contact's wa_id/phone_number.
+    if authoritative:
+        if wa_id and contact.wa_id != wa_id:
+            contact.wa_id = wa_id
+            changed = True
+        if phone_number and contact.phone_number != phone_number:
+            contact.phone_number = phone_number
+            changed = True
     if changed:
         contact.updated_at = now
         await db.flush()

--- a/app/graphql/whatsapp/mutations.py
+++ b/app/graphql/whatsapp/mutations.py
@@ -39,9 +39,11 @@ class WhatsAppChatMutation:
                 return SendMessageResult(success=False, error="Conversación no encontrada.")
             contact = conversation.contact
         elif input.wa_id:
-            contact = await crud.get_contact_by_wa_id(db, input.wa_id)
-            if contact is None:
-                contact = await crud.upsert_contact(db, wa_id=input.wa_id, phone_number=input.wa_id)
+            # Resolve by normalized number (52/521 aware) so a send never spawns a
+            # duplicate contact/conversation for a number that already exists.
+            contact = await crud.upsert_contact(
+                db, wa_id=input.wa_id, phone_number=input.wa_id, authoritative=False
+            )
             conversation = await crud.get_or_open_conversation(db, contact.id)
         else:
             return SendMessageResult(success=False, error="Falta conversationId o waId.")

--- a/app/graphql/whatsapp/template_mutations.py
+++ b/app/graphql/whatsapp/template_mutations.py
@@ -177,7 +177,11 @@ class WhatsAppTemplateMutation:
         if not wa_id:
             return SendMessageResult(success=False, error="Número de teléfono inválido.")
 
-        contact = await chat_crud.upsert_contact(db, wa_id=wa_id, phone_number=phone)
+        # authoritative=False: reuse an existing contact (52/521 aware) instead of
+        # creating a duplicate, and never overwrite its canonical wa_id with the typed one.
+        contact = await chat_crud.upsert_contact(
+            db, wa_id=wa_id, phone_number=phone, authoritative=False
+        )
         conversation = await chat_crud.get_or_open_conversation(db, contact.id)
 
         try:

--- a/scripts/merge_duplicate_whatsapp_contacts.py
+++ b/scripts/merge_duplicate_whatsapp_contacts.py
@@ -1,0 +1,254 @@
+"""One-time, idempotent merge of duplicate WhatsApp contacts.
+
+Mexican WhatsApp numbers are stored in two equivalent forms (``52...`` vs ``521...``).
+Before the normalized contact resolver landed, sends could create a second contact +
+conversation for a number that already existed, so the same person showed up as two
+chats. This script consolidates those duplicates:
+
+  - groups contacts by their last-10 normalized digits;
+  - for each group with >1 contact, picks a deterministic canonical contact;
+  - repoints every message of the group onto the canonical contact and a single
+    target conversation;
+  - deletes the now-empty extra conversations and the non-canonical contacts.
+
+``message_statuses`` and ``media`` reference ``message_id`` (not contact/conversation),
+so repointing messages never orphans them.
+
+Idempotent: with no duplicates it is a no-op. Run ``--dry-run`` first (reports the plan
+without writing); the real run commits in a single transaction.
+
+Usage (from the ``backend`` directory):
+    python -m scripts.merge_duplicate_whatsapp_contacts --dry-run
+    python -m scripts.merge_duplicate_whatsapp_contacts
+"""
+import argparse
+import asyncio
+import re
+from collections import defaultdict
+from typing import Dict, List, Optional
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.postgresql import async_session_factory
+from app.models import Contact, Conversation, Message
+
+
+def _digits(value: Optional[str]) -> str:
+    return re.sub(r"\D", "", value or "")
+
+
+def _group_key(contact: Contact) -> Optional[str]:
+    """Last-10 digits of the contact's number (shared by the 52/521 forms)."""
+    digits = _digits(contact.wa_id) or _digits(contact.phone_number)
+    if not digits:
+        return None
+    return digits[-10:] if len(digits) >= 10 else digits
+
+
+def _is_authoritative_form(contact: Contact) -> bool:
+    """The Mexican inbound ``521...`` (13-digit) form is the canonical wa_id."""
+    digits = _digits(contact.wa_id)
+    return digits.startswith("521") and len(digits) >= 13
+
+
+def _pick_canonical(group: List[Contact], msg_counts: Dict[int, int]) -> Contact:
+    """Most messages -> authoritative 521 form -> longest wa_id -> lowest id."""
+    return sorted(
+        group,
+        key=lambda c: (
+            -msg_counts.get(c.id, 0),
+            0 if _is_authoritative_form(c) else 1,
+            -len(_digits(c.wa_id)),
+            c.id,
+        ),
+    )[0]
+
+
+async def _message_counts(db: AsyncSession) -> Dict[int, int]:
+    rows = (
+        await db.execute(
+            select(Message.contact_id, func.count()).group_by(Message.contact_id)
+        )
+    ).all()
+    return {contact_id: count for contact_id, count in rows}
+
+
+async def _conversations_for(db: AsyncSession, contact_ids: List[int]):
+    """Return (conv_id, contact_id, last_message_ts) for the given contacts."""
+    rows = (
+        await db.execute(
+            select(
+                Conversation.id,
+                Conversation.contact_id,
+                func.max(Message.timestamp),
+            )
+            .select_from(Conversation)
+            .outerjoin(Message, Message.conversation_id == Conversation.id)
+            .where(Conversation.contact_id.in_(contact_ids))
+            .group_by(Conversation.id, Conversation.contact_id)
+        )
+    ).all()
+    return rows
+
+
+async def _merge_group(
+    db: AsyncSession,
+    group: List[Contact],
+    msg_counts: Dict[int, int],
+    dry_run: bool,
+) -> dict:
+    contact_ids = [c.id for c in group]
+    canonical = _pick_canonical(group, msg_counts)
+    dup_ids = [cid for cid in contact_ids if cid != canonical.id]
+
+    conv_rows = await _conversations_for(db, contact_ids)
+    conv_ids = [r[0] for r in conv_rows]
+
+    # Target conversation: the one with the most recent message, else lowest id.
+    if conv_rows:
+        target_conv_id = sorted(
+            conv_rows,
+            key=lambda r: (r[2] is not None, r[2], -r[0]),
+            reverse=True,
+        )[0][0]
+    else:
+        target_conv_id = None
+
+    # Count messages that will be repointed (by contact or by conversation).
+    repoint_filter = Message.contact_id.in_(contact_ids)
+    if conv_ids:
+        repoint_filter = repoint_filter | Message.conversation_id.in_(conv_ids)
+    msg_total = (
+        await db.execute(select(func.count()).select_from(Message).where(repoint_filter))
+    ).scalar_one()
+
+    summary = {
+        "key": _group_key(canonical),
+        "canonical_id": canonical.id,
+        "canonical_wa_id": canonical.wa_id,
+        "removed_contact_ids": dup_ids,
+        "removed_conversation_ids": [cid for cid in conv_ids if cid != target_conv_id],
+        "repointed_messages": msg_total,
+    }
+
+    if dry_run:
+        return summary
+
+    # 1) Ensure a single target conversation owned by the canonical contact.
+    if target_conv_id is None:
+        target_conv = Conversation(contact_id=canonical.id, status="active")
+        db.add(target_conv)
+        await db.flush()
+        target_conv_id = target_conv.id
+    else:
+        await db.execute(
+            update(Conversation)
+            .where(Conversation.id == target_conv_id)
+            .values(contact_id=canonical.id)
+        )
+
+    # 2) Repoint every message of the group onto the canonical contact + target conv.
+    await db.execute(
+        update(Message)
+        .where(repoint_filter)
+        .values(contact_id=canonical.id, conversation_id=target_conv_id)
+    )
+
+    # 3) Carry over name/profile_name if the canonical lacks them.
+    if not canonical.name:
+        for c in group:
+            if c.name:
+                canonical.name = c.name
+                break
+    if not canonical.profile_name:
+        for c in group:
+            if c.profile_name:
+                canonical.profile_name = c.profile_name
+                break
+    await db.flush()
+
+    # 4) Delete the now-empty extra conversations, then the non-canonical contacts.
+    stale_conv_ids = [cid for cid in conv_ids if cid != target_conv_id]
+    if stale_conv_ids:
+        await db.execute(delete(Conversation).where(Conversation.id.in_(stale_conv_ids)))
+    if dup_ids:
+        await db.execute(delete(Contact).where(Contact.id.in_(dup_ids)))
+
+    return summary
+
+
+async def merge_duplicates(db: AsyncSession, dry_run: bool) -> List[dict]:
+    """Core merge over a given session. Commits (or rolls back, if dry-run) at the end.
+
+    Returns one summary dict per duplicate group. Separated from ``run`` so it can be
+    driven by tests with their own (rolled-back) session.
+    """
+    contacts = (await db.execute(select(Contact))).scalars().all()
+    groups: Dict[str, List[Contact]] = defaultdict(list)
+    for contact in contacts:
+        key = _group_key(contact)
+        if key:
+            groups[key].append(contact)
+    dup_groups = {k: v for k, v in groups.items() if len(v) > 1}
+
+    if not dup_groups:
+        return []
+
+    msg_counts = await _message_counts(db)
+    summaries: List[dict] = []
+    for _key, group in sorted(dup_groups.items()):
+        summaries.append(await _merge_group(db, group, msg_counts, dry_run))
+
+    if dry_run:
+        await db.rollback()
+    else:
+        await db.commit()
+    return summaries
+
+
+async def run(dry_run: bool) -> None:
+    async with async_session_factory() as db:
+        total_contacts = (
+            await db.execute(select(func.count()).select_from(Contact))
+        ).scalar_one()
+        summaries = await merge_duplicates(db, dry_run)
+
+        if not summaries:
+            print(f"No duplicate contacts found among {total_contacts} contacts. Nothing to do.")
+            return
+
+        print(
+            f"{'[DRY-RUN] ' if dry_run else ''}Found {len(summaries)} duplicate group(s) "
+            f"among {total_contacts} contacts."
+        )
+        total_removed = 0
+        for s in summaries:
+            total_removed += len(s["removed_contact_ids"])
+            print(
+                f"  • key …{s['key']}: keep contact #{s['canonical_id']} "
+                f"({s['canonical_wa_id']}); "
+                f"remove contacts {s['removed_contact_ids']}; "
+                f"drop conversations {s['removed_conversation_ids']}; "
+                f"repoint {s['repointed_messages']} message(s)."
+            )
+
+        if dry_run:
+            print(f"[DRY-RUN] Would remove {total_removed} duplicate contact(s). No changes written.")
+        else:
+            print(f"Done. Removed {total_removed} duplicate contact(s).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report the merge plan without writing any changes.",
+    )
+    args = parser.parse_args()
+    asyncio.run(run(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_whatsapp_contact_dedup.py
+++ b/tests/test_whatsapp_contact_dedup.py
@@ -1,0 +1,135 @@
+"""Tests for normalized WhatsApp contact resolution and duplicate merging.
+
+Covers the 52/521 Mexican-format equivalence so that sending a template (or text)
+reuses an existing contact/conversation instead of creating a duplicate chat.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.crud.whatsappCrud import find_contact_by_number, upsert_contact
+from app.models import Contact, Conversation, Message
+from scripts.merge_duplicate_whatsapp_contacts import merge_duplicates
+from sqlalchemy import func, select
+
+# Same person, two equivalent Mexican formats.
+WA_521 = "5218719708890"   # inbound/authoritative form (with the "1")
+WA_52 = "528719708890"     # typed-on-send form (without the "1")
+
+
+async def test_find_contact_by_number_matches_mexican_formats(db):
+    created = await upsert_contact(db, wa_id=WA_521, phone_number=WA_521)
+    await db.flush()
+
+    # Different format, spaces and "+" — still the same person.
+    assert (await find_contact_by_number(db, "+52 871 970 8890")).id == created.id
+    assert (await find_contact_by_number(db, WA_52)).id == created.id
+    assert await find_contact_by_number(db, "9999999999") is None
+
+
+async def test_send_reuses_existing_contact_without_downgrading_wa_id(db):
+    inbound = await upsert_contact(db, wa_id=WA_521, phone_number=WA_521)
+    await db.flush()
+
+    # A send types the number without the "1"; authoritative=False.
+    reused = await upsert_contact(db, wa_id=WA_52, phone_number=WA_52, authoritative=False)
+
+    assert reused.id == inbound.id           # no duplicate contact
+    assert reused.wa_id == WA_521            # canonical wa_id preserved
+
+
+async def test_inbound_upsert_canonicalizes_wa_id(db):
+    # Contact first created by a send (52 form, non-authoritative).
+    sent = await upsert_contact(db, wa_id=WA_52, phone_number=WA_52, authoritative=False)
+    await db.flush()
+
+    # Later an inbound message arrives with Meta's authoritative 521 form.
+    inbound = await upsert_contact(db, wa_id=WA_521, phone_number=WA_521)
+
+    assert inbound.id == sent.id             # same contact, no duplicate
+    assert inbound.wa_id == WA_521           # upgraded to the authoritative form
+
+
+async def _make_contact_with_message(db, wa_id: str, text: str, ts: datetime) -> Contact:
+    contact = Contact(wa_id=wa_id, phone_number=wa_id)
+    db.add(contact)
+    await db.flush()
+    conversation = Conversation(contact_id=contact.id, status="active")
+    db.add(conversation)
+    await db.flush()
+    db.add(
+        Message(
+            conversation_id=conversation.id,
+            contact_id=contact.id,
+            direction="inbound",
+            message_type="text",
+            text_content=text,
+            timestamp=ts,
+        )
+    )
+    await db.flush()
+    return contact
+
+
+def _last10(value: str) -> str:
+    return "".join(ch for ch in value if ch.isdigit())[-10:]
+
+
+async def test_merge_collapses_duplicate_contacts(db):
+    a = await _make_contact_with_message(db, WA_521, "si", datetime(3009, 1, 2, 12, 0, 0))
+    b = await _make_contact_with_message(db, WA_52, "Plantilla enviada", datetime(3009, 1, 1, 12, 0, 0))
+    await db.commit()
+
+    summaries = await merge_duplicates(db, dry_run=False)
+
+    # Exactly one group merged; the 521 (authoritative) contact is canonical.
+    group = [s for s in summaries if s["key"] == _last10(WA_521)]
+    assert len(group) == 1
+    assert group[0]["canonical_id"] == a.id
+    assert b.id in group[0]["removed_contact_ids"]
+
+    # One contact, one conversation, both messages preserved under the canonical.
+    remaining = (
+        await db.execute(
+            select(Contact).where(
+                func.right(func.regexp_replace(Contact.wa_id, r"\D", "", "g"), 10)
+                == _last10(WA_521)
+            )
+        )
+    ).scalars().all()
+    assert [c.id for c in remaining] == [a.id]
+
+    conv_count = (
+        await db.execute(
+            select(func.count()).select_from(Conversation).where(Conversation.contact_id == a.id)
+        )
+    ).scalar_one()
+    assert conv_count == 1
+
+    msg_count = (
+        await db.execute(
+            select(func.count()).select_from(Message).where(Message.contact_id == a.id)
+        )
+    ).scalar_one()
+    assert msg_count == 2
+
+
+async def test_merge_dry_run_keeps_duplicates(db):
+    await _make_contact_with_message(db, WA_521, "si", datetime(3009, 2, 2, 12, 0, 0))
+    await _make_contact_with_message(db, WA_52, "Plantilla enviada", datetime(3009, 2, 1, 12, 0, 0))
+    await db.commit()
+
+    summaries = await merge_duplicates(db, dry_run=True)
+    assert len(summaries) == 1  # reported but not applied
+
+    count = (
+        await db.execute(
+            select(func.count())
+            .select_from(Contact)
+            .where(
+                func.right(func.regexp_replace(Contact.wa_id, r"\D", "", "g"), 10)
+                == _last10(WA_521)
+            )
+        )
+    ).scalar_one()
+    assert count == 2  # both duplicates still present


### PR DESCRIPTION
## Context
Sending a template showed up as a **separate chat** from the contact's normal conversation. Mexican numbers are stored in two equivalent forms (`52…` vs `521…`); contact resolution did an exact `wa_id` string match, so a send (which builds the `wa_id` from the typed number) created a duplicate contact + conversation for a number that already existed (inbound stores Meta's authoritative `521…`).

## Changes
- **Normalized resolver:** new `find_contact_by_number` (52/521 aware) reusing the existing phone-match helpers (`_phone_match_keys`, `_digits_only`, `_digits_expr`). `upsert_contact` now resolves by exact `wa_id` → normalized number.
- **`authoritative` flag:** the inbound webhook canonicalizes the stored `wa_id` (Meta's form); sends (`authoritative=False`) reuse the contact without downgrading it.
- **Send paths fixed:** `send_template_test` and the `waId` branch of `send_text_message` go through the resolver, so they land on the existing conversation — no new chat.
- **Merge existing duplicates:** idempotent `scripts/merge_duplicate_whatsapp_contacts.py` (with `--dry-run`) consolidates already-duplicated contacts/conversations: pick a deterministic canonical, repoint messages to one contact + one conversation, delete the leftovers (`message_statuses`/`media` hang off `message_id`, so nothing is orphaned).
- **Tests:** resolver matching, send-reuse without downgrade, inbound canonicalization, merge collapse, and dry-run no-op.

No schema migration. A DB-level unique guarantee on the normalized number is left as a future option (requires the data to be clean first).

## Verification
- `cd backend; pytest tests/test_whatsapp_contact_dedup.py` (requires a Postgres test DB).
- Manual: send a template to a number that already has a normal conversation (in either `52`/`521` format) → it lands in the same chat.
- Merge: `python -m scripts.merge_duplicate_whatsapp_contacts --dry-run` then the real run; existing duplicates collapse to a single thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)