### PR TITLE
feat: notificaciones automáticas de WhatsApp (bienvenida/renovación/vencimiento)

### DIFF
--- a/alembic/versions/b3f1c9a2d7e4_notification_settings_and_log.py
+++ b/alembic/versions/b3f1c9a2d7e4_notification_settings_and_log.py
@@ -1,0 +1,95 @@
+"""Notification settings + idempotency log for automated WhatsApp notifications.
+
+Creates two FitPilot-native tables in the ``app`` schema:
+
+* ``notification_settings`` — per-event config (template + variable mapping + offsets).
+* ``notification_log`` — idempotency/audit ledger with a unique ``dedup_key``.
+
+Revision ID: b3f1c9a2d7e4
+Revises: 2c1a4e6f8b90
+Create Date: 2026-06-05 21:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "b3f1c9a2d7e4"
+down_revision: Union[str, None] = "2c1a4e6f8b90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_settings",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("event_type", sa.String(length=40), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("template_id", sa.BigInteger(), nullable=True),
+        sa.Column("param_mapping", sa.JSON(), nullable=True),
+        sa.Column("offsets_days", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(
+            ["template_id"],
+            [f"{SCHEMA}.whatsapp_templates.id"],
+            ondelete="SET NULL",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_notification_settings_event",
+        "notification_settings",
+        ["event_type"],
+        unique=True,
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "notification_log",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("event_type", sa.String(length=40), nullable=False),
+        sa.Column("person_id", sa.BigInteger(), nullable=True),
+        sa.Column("subscription_id", sa.BigInteger(), nullable=True),
+        sa.Column("template_id", sa.BigInteger(), nullable=True),
+        sa.Column("dedup_key", sa.String(length=120), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("wa_message_id", sa.String(length=120), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(
+            ["person_id"],
+            [f"{SCHEMA}.people.id"],
+            ondelete="CASCADE",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_notification_log_dedup",
+        "notification_log",
+        ["dedup_key"],
+        unique=True,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_notification_log_event_person",
+        "notification_log",
+        ["event_type", "person_id"],
+        unique=False,
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_notification_log_event_person", table_name="notification_log", schema=SCHEMA)
+    op.drop_index("uq_notification_log_dedup", table_name="notification_log", schema=SCHEMA)
+    op.drop_table("notification_log", schema=SCHEMA)
+    op.drop_index("uq_notification_settings_event", table_name="notification_settings", schema=SCHEMA)
+    op.drop_table("notification_settings", schema=SCHEMA)

--- a/app/crud/notificationsCrud.py
+++ b/app/crud/notificationsCrud.py
@@ -1,0 +1,175 @@
+"""CRUD for the automated notification system.
+
+Two concerns live here:
+
+* ``notification_settings`` reads/writes — the per-event configuration edited from the
+  desktop frontend (which template, variable mapping, offsets, enabled flag).
+* ``notification_log`` claim/mark — the idempotency ledger. ``claim_log`` performs an
+  ``INSERT ... ON CONFLICT (dedup_key) DO NOTHING`` so a claim is atomic: the first caller
+  wins (row returned) and any concurrent/duplicate caller gets ``None`` and skips sending.
+  This is what makes the daily sweep safe to run on multiple workers.
+"""
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import NotificationLog, NotificationSetting
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class NotificationSettingData:
+    id: Optional[int]
+    event_type: str
+    enabled: bool
+    template_id: Optional[int]
+    param_mapping: Optional[list]
+    offsets_days: Optional[list]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+
+    @classmethod
+    def from_model(cls, m: NotificationSetting) -> "NotificationSettingData":
+        return cls(
+            id=m.id,
+            event_type=m.event_type,
+            enabled=bool(m.enabled),
+            template_id=m.template_id,
+            param_mapping=m.param_mapping,
+            offsets_days=m.offsets_days,
+            created_at=m.created_at,
+            updated_at=m.updated_at,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Settings reads/writes
+# ---------------------------------------------------------------------------
+async def list_settings(db: AsyncSession) -> List[NotificationSettingData]:
+    stmt = select(NotificationSetting).order_by(NotificationSetting.event_type)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [NotificationSettingData.from_model(r) for r in rows]
+
+
+async def get_setting_model(
+    db: AsyncSession, event_type: str
+) -> Optional[NotificationSetting]:
+    stmt = select(NotificationSetting).where(NotificationSetting.event_type == event_type)
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def get_setting(
+    db: AsyncSession, event_type: str
+) -> Optional[NotificationSettingData]:
+    model = await get_setting_model(db, event_type)
+    return NotificationSettingData.from_model(model) if model else None
+
+
+async def upsert_setting(
+    db: AsyncSession,
+    *,
+    event_type: str,
+    enabled: bool = False,
+    template_id: Optional[int] = None,
+    param_mapping: Optional[list] = None,
+    offsets_days: Optional[list] = None,
+    commit: bool = True,
+) -> NotificationSetting:
+    """Create or update the config row for ``event_type`` with the full desired state.
+
+    The caller (the save mutation) always provides the complete configuration, so every
+    field is assigned authoritatively (e.g. ``template_id=None`` clears the template).
+    """
+    setting = await get_setting_model(db, event_type)
+    now = datetime.utcnow()
+    if setting is None:
+        setting = NotificationSetting(
+            event_type=event_type,
+            enabled=bool(enabled),
+            template_id=template_id,
+            param_mapping=param_mapping or [],
+            offsets_days=offsets_days or [],
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(setting)
+    else:
+        setting.enabled = bool(enabled)
+        setting.template_id = template_id
+        setting.param_mapping = param_mapping or []
+        setting.offsets_days = offsets_days or []
+        setting.updated_at = now
+    await db.flush()
+    if commit:
+        await db.commit()
+    return setting
+
+
+# ---------------------------------------------------------------------------
+# Idempotency ledger
+# ---------------------------------------------------------------------------
+async def claim_log(
+    db: AsyncSession,
+    *,
+    dedup_key: str,
+    event_type: str,
+    person_id: Optional[int],
+    subscription_id: Optional[int] = None,
+    template_id: Optional[int] = None,
+) -> Optional[NotificationLog]:
+    """Atomically claim ``dedup_key`` by inserting a ``pending`` log row.
+
+    Returns the claimed row, or ``None`` if the key already exists (already sent / in
+    flight). Caller commits. Uses ``ON CONFLICT DO NOTHING`` so the claim never raises.
+    """
+    now = datetime.utcnow()
+    stmt = (
+        pg_insert(NotificationLog)
+        .values(
+            event_type=event_type,
+            person_id=person_id,
+            subscription_id=subscription_id,
+            template_id=template_id,
+            dedup_key=dedup_key,
+            status="pending",
+            created_at=now,
+            updated_at=now,
+        )
+        .on_conflict_do_nothing(index_elements=["dedup_key"])
+        .returning(NotificationLog.id)
+    )
+    result = await db.execute(stmt)
+    inserted_id = result.scalar_one_or_none()
+    await db.flush()
+    if inserted_id is None:
+        return None
+    return await db.get(NotificationLog, inserted_id)
+
+
+async def mark_log(
+    db: AsyncSession,
+    log: NotificationLog,
+    *,
+    status: str,
+    wa_message_id: Optional[str] = None,
+    error: Optional[str] = None,
+    commit: bool = True,
+) -> NotificationLog:
+    """Update a claimed log row with the final outcome. Caller may commit."""
+    log.status = status
+    if wa_message_id is not None:
+        log.wa_message_id = wa_message_id
+    if error is not None:
+        log.error = error[:4000]
+    log.updated_at = datetime.utcnow()
+    await db.flush()
+    if commit:
+        await db.commit()
+    return log

--- a/app/graphql/memberships/mutations.py
+++ b/app/graphql/memberships/mutations.py
@@ -1,10 +1,18 @@
 
+import asyncio
 from datetime import datetime, timezone
 import json
+import logging
 
 import strawberry
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
+
+from app.models.notificationModel import (
+    EVENT_NEW_REGISTRATION,
+    EVENT_RENEWAL_CONFIRMATION,
+)
+from app.services.notification_service import dispatch_event_in_background
 
 from app.crud.membershipsCrud import (
     create_membership_plan,
@@ -216,6 +224,20 @@ class MembershipMutation:
             # Commit the transaction after all operations
             await db.commit()
 
+            # Fire-and-forget welcome notification (own session, never blocks/rolls back the alta).
+            try:
+                asyncio.create_task(
+                    dispatch_event_in_background(
+                        EVENT_NEW_REGISTRATION,
+                        person_id=person.id,
+                        subscription_id=subscription.id,
+                    )
+                )
+            except Exception:  # noqa: BLE001
+                logging.getLogger(__name__).warning(
+                    "Could not schedule welcome notification", exc_info=True
+                )
+
             # Build message and top-level fields like renewal
             try:
                 import json
@@ -292,6 +314,18 @@ class MembershipMutation:
 
             # Ensure the transaction is committed before returning
             await db.commit()
+
+            # Fire-and-forget renewal confirmation (own session, never blocks/rolls back the renovación).
+            try:
+                asyncio.create_task(
+                    dispatch_event_in_background(
+                        EVENT_RENEWAL_CONFIRMATION,
+                        person_id=subscription.person_id,
+                        subscription_id=subscription.id,
+                    )
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning("Could not schedule renewal confirmation", exc_info=True)
 
             # Calculate remaining days for response
             now = datetime.now(timezone.utc)

--- a/app/graphql/notifications/mutations.py
+++ b/app/graphql/notifications/mutations.py
@@ -1,0 +1,131 @@
+"""GraphQL mutations for the automated notification configuration.
+
+``save_notification_setting`` validates the chosen template + variable mapping before
+persisting (the number of mapped variables must match the template's body placeholders, and
+each variable must be one the event can actually resolve). ``run_notification_sweep`` runs the
+renewal/expired sweeps on demand — handy for testing and as a manual "send now" action.
+"""
+import logging
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud import notificationsCrud as crud
+from app.crud import whatsappTemplatesCrud as templates_crud
+from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.notifications.types import (
+    NotificationSettingResult,
+    NotificationSettingType,
+    SaveNotificationSettingInput,
+    SweepResult,
+)
+from app.graphql.whatsapp.template_types import WhatsAppTemplate
+from app.services.notification_service import EVENT_TYPES, run_all_sweeps
+from app.services.whatsapp_template_components import parse_components, placeholder_count
+
+logger = logging.getLogger(__name__)
+
+
+@strawberry.type
+class NotificationSettingsMutation:
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def save_notification_setting(
+        self, info: Info, input: SaveNotificationSettingInput
+    ) -> NotificationSettingResult:
+        db: AsyncSession = info.context.db
+
+        meta = EVENT_TYPES.get(input.event_type)
+        if meta is None:
+            return NotificationSettingResult(
+                success=False, error="Tipo de evento desconocido."
+            )
+
+        mapping = [str(v) for v in (input.param_mapping or [])]
+        offsets = [int(v) for v in (input.offsets_days or [])]
+
+        tpl = None
+        if input.template_id:
+            tpl = await templates_crud.get_template_model(db, input.template_id)
+            if tpl is None:
+                return NotificationSettingResult(
+                    success=False, error="Plantilla no encontrada."
+                )
+
+        # Can't enable an event without an approved template.
+        if input.enabled:
+            if tpl is None:
+                return NotificationSettingResult(
+                    success=False,
+                    error="Selecciona una plantilla antes de activar el evento.",
+                )
+            if (tpl.template_status or "").upper() != "APPROVED":
+                return NotificationSettingResult(
+                    success=False,
+                    error="La plantilla seleccionada no está aprobada por Meta.",
+                )
+
+        # Variable mapping must match the template body placeholders exactly.
+        if tpl is not None:
+            body_text, _, _ = parse_components(tpl.components)
+            expected = placeholder_count(body_text)
+            if len(mapping) != expected:
+                return NotificationSettingResult(
+                    success=False,
+                    error=(
+                        f"La plantilla requiere {expected} variable(s) en el cuerpo; "
+                        f"se recibieron {len(mapping)}."
+                    ),
+                )
+
+        allowed = set(meta.get("variables", []))
+        invalid = [key for key in mapping if key not in allowed]
+        if invalid:
+            return NotificationSettingResult(
+                success=False,
+                error=f"Variable(s) no válida(s) para este evento: {', '.join(invalid)}.",
+            )
+
+        if offsets and not meta.get("supports_offsets", False):
+            offsets = []
+        if any(o <= 0 for o in offsets):
+            return NotificationSettingResult(
+                success=False, error="Los días de aviso deben ser mayores a 0."
+            )
+
+        try:
+            await crud.upsert_setting(
+                db,
+                event_type=input.event_type,
+                enabled=input.enabled,
+                template_id=input.template_id,
+                param_mapping=mapping,
+                offsets_days=sorted(set(offsets)) if offsets else [],
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            logger.exception("Error saving notification setting")
+            return NotificationSettingResult(success=False, error=str(e))
+
+        data = await crud.get_setting(db, input.event_type)
+        template = WhatsAppTemplate.from_data(
+            await templates_crud.get_template(db, data.template_id)
+        ) if data and data.template_id else None
+        return NotificationSettingResult(
+            success=True,
+            setting=NotificationSettingType.from_data(input.event_type, meta, data, template),
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def run_notification_sweep(self, info: Info) -> SweepResult:
+        """Run the renewal + expired sweeps now (idempotent; safe to call repeatedly)."""
+        try:
+            stats = await run_all_sweeps()
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Manual notification sweep failed")
+            return SweepResult(success=False, error=str(e))
+
+        sent = sum(group.get("sent", 0) for group in stats.values())
+        skipped = sum(group.get("skipped", 0) for group in stats.values())
+        failed = sum(group.get("failed", 0) for group in stats.values())
+        return SweepResult(success=True, sent=sent, skipped=skipped, failed=failed)

--- a/app/graphql/notifications/queries.py
+++ b/app/graphql/notifications/queries.py
@@ -1,0 +1,61 @@
+"""GraphQL queries for the automated notification configuration."""
+from typing import List
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud import notificationsCrud as crud
+from app.crud import whatsappTemplatesCrud as templates_crud
+from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.notifications.types import (
+    NotificationEventCatalog,
+    NotificationSettingType,
+    NotificationVariable,
+)
+from app.graphql.whatsapp.template_types import WhatsAppTemplate
+from app.services.notification_service import EVENT_TYPES, VARIABLES
+
+
+@strawberry.type
+class NotificationSettingsQuery:
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def notification_settings(self, info: Info) -> List[NotificationSettingType]:
+        """Return the config for every event type (with safe defaults if not yet saved)."""
+        db: AsyncSession = info.context.db
+        existing = {s.event_type: s for s in await crud.list_settings(db)}
+
+        results: List[NotificationSettingType] = []
+        for event_type, meta in EVENT_TYPES.items():
+            data = existing.get(event_type)
+            template = None
+            if data is not None and data.template_id:
+                t = await templates_crud.get_template(db, data.template_id)
+                template = WhatsAppTemplate.from_data(t) if t else None
+            results.append(
+                NotificationSettingType.from_data(event_type, meta, data, template)
+            )
+        return results
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def notification_catalog(self, info: Info) -> List[NotificationEventCatalog]:
+        """Expose each event and the variables it can resolve, for the placeholder pickers."""
+        catalog: List[NotificationEventCatalog] = []
+        for event_type, meta in EVENT_TYPES.items():
+            variables = [
+                NotificationVariable(
+                    key=key,
+                    label=VARIABLES.get(key, {}).get("label", key),
+                    sample=VARIABLES.get(key, {}).get("sample", ""),
+                )
+                for key in meta.get("variables", [])
+            ]
+            catalog.append(
+                NotificationEventCatalog(
+                    event_type=event_type,
+                    label=str(meta.get("label", event_type)),
+                    supports_offsets=bool(meta.get("supports_offsets", False)),
+                    variables=variables,
+                )
+            )
+        return catalog

--- a/app/graphql/notifications/types.py
+++ b/app/graphql/notifications/types.py
@@ -1,0 +1,91 @@
+"""GraphQL types for the automated notification configuration.
+
+These power the desktop "Notificaciones" tab: one ``NotificationSettingType`` per business
+event (template + variable mapping + offsets + enabled), plus a ``NotificationEventCatalog``
+that tells the UI which variables each event can resolve so the placeholder pickers stay in
+sync with the backend.
+"""
+from typing import Any, Dict, List, Optional
+
+import strawberry
+
+from app.crud.notificationsCrud import NotificationSettingData
+from app.graphql.whatsapp.template_types import WhatsAppTemplate
+
+
+@strawberry.type
+class NotificationVariable:
+    key: str
+    label: str
+    sample: str
+
+
+@strawberry.type
+class NotificationEventCatalog:
+    event_type: str
+    label: str
+    supports_offsets: bool
+    variables: List[NotificationVariable]
+
+
+@strawberry.type
+class NotificationSettingType:
+    event_type: str
+    label: str
+    supports_offsets: bool
+    enabled: bool
+    template_id: Optional[int]
+    param_mapping: Optional[List[str]]
+    offsets_days: Optional[List[int]]
+    template: Optional[WhatsAppTemplate]
+
+    @classmethod
+    def from_data(
+        cls,
+        event_type: str,
+        meta: Dict[str, Any],
+        data: Optional[NotificationSettingData],
+        template: Optional[WhatsAppTemplate],
+    ) -> "NotificationSettingType":
+        param_mapping = None
+        offsets_days = None
+        if data is not None:
+            if data.param_mapping is not None:
+                param_mapping = [str(v) for v in data.param_mapping]
+            if data.offsets_days is not None:
+                offsets_days = [int(v) for v in data.offsets_days]
+        return cls(
+            event_type=event_type,
+            label=str(meta.get("label", event_type)),
+            supports_offsets=bool(meta.get("supports_offsets", False)),
+            enabled=bool(data.enabled) if data is not None else False,
+            template_id=data.template_id if data is not None else None,
+            param_mapping=param_mapping,
+            offsets_days=offsets_days,
+            template=template,
+        )
+
+
+@strawberry.input
+class SaveNotificationSettingInput:
+    event_type: str
+    enabled: bool = False
+    template_id: Optional[int] = None
+    param_mapping: Optional[List[str]] = None
+    offsets_days: Optional[List[int]] = None
+
+
+@strawberry.type
+class NotificationSettingResult:
+    success: bool = False
+    setting: Optional[NotificationSettingType] = None
+    error: Optional[str] = None
+
+
+@strawberry.type
+class SweepResult:
+    success: bool = False
+    sent: int = 0
+    skipped: int = 0
+    failed: int = 0
+    error: Optional[str] = None

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -28,6 +28,8 @@ from app.graphql.whatsapp.mutations import WhatsAppChatMutation
 from app.graphql.whatsapp.subscriptions import WhatsAppChatSubscription
 from app.graphql.whatsapp.template_queries import WhatsAppTemplateQuery
 from app.graphql.whatsapp.template_mutations import WhatsAppTemplateMutation
+from app.graphql.notifications.queries import NotificationSettingsQuery
+from app.graphql.notifications.mutations import NotificationSettingsMutation
 
 logger = logging.getLogger(__name__)
 
@@ -50,13 +52,13 @@ except ImportError as e:
         pass
 
 @strawberry.type
-class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery):
+class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery):
     @strawberry.field
     def hello(self) -> str:
         return "Hello from GraphQL!"
 
 @strawberry.type
-class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation):
+class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation):
     pass
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from app.graphql.schema import schema
 from app.graphql.context import build_context
 from app.webhooks.whatsapp_webhook import router as whatsapp_webhook_router
 from app.services.whatsapp_listener import listener as whatsapp_listener
+from app.services.notification_scheduler import scheduler as notification_scheduler
 
 # Initialize logging system
 from app.core.logging_config import setup_logging, get_logger
@@ -28,9 +29,12 @@ async def lifespan(app: FastAPI):
     # Start the Postgres LISTEN/NOTIFY bridge for WhatsApp realtime events.
     await whatsapp_listener.start()
     logger.info("WhatsApp NOTIFY listener started")
+    # Start the daily notification sweep (renewal reminders + expired win-back).
+    notification_scheduler.start()
     try:
         yield
     finally:
+        notification_scheduler.stop()
         await whatsapp_listener.stop()
         logger.info("WhatsApp NOTIFY listener stopped")
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.leadsModel import (
 from app.models.whatsappModel import (
     Contact, Conversation, Message, MessageStatus, Media, WebhookLog, WhatsAppTemplate
 )
+from app.models.notificationModel import NotificationSetting, NotificationLog
 
 __all__ = [
     "People", "Role", "PersonRole", "Account",
@@ -24,5 +25,6 @@ __all__ = [
     "Session",
     "LeadSource", "Lead", "LeadEvent", "FormSubmission", "MarketingCampaign",
     "LeadAttribution", "CommunicationOptIn", "WhatsAppThread",
-    "Contact", "Conversation", "Message", "MessageStatus", "Media", "WebhookLog", "WhatsAppTemplate"
+    "Contact", "Conversation", "Message", "MessageStatus", "Media", "WebhookLog", "WhatsAppTemplate",
+    "NotificationSetting", "NotificationLog"
 ]

--- a/app/models/notificationModel.py
+++ b/app/models/notificationModel.py
@@ -1,0 +1,98 @@
+"""Notification configuration and audit models for FitPilot.
+
+Two tables power the automated WhatsApp notification system:
+
+* ``notification_settings`` — one row per business event (new registration, renewal
+  reminder, renewal confirmation, expired membership). Each row stores which approved
+  Meta template to use, how its ``{{1}}..{{n}}`` placeholders map to member variables,
+  whether the event is enabled, and (for reminders) the day offsets before expiry.
+
+* ``notification_log`` — an idempotency + audit ledger. Each send attempt claims a unique
+  ``dedup_key`` *before* contacting Meta, so the same notification is never sent twice even
+  if the daily sweep runs on multiple workers or is retried.
+
+Unlike the externally-created WhatsApp chat tables (plain TIMESTAMP), these are FitPilot
+native tables and use TIMESTAMPTZ like the rest of the domain. Primary keys are assigned
+by the database sequence (never set ``id`` manually).
+"""
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger, Boolean, ForeignKey, String, Text, TIMESTAMP, Index, JSON
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.postgresql import Base
+
+
+# Canonical event types. Keep in sync with EVENT_TYPES in
+# app/services/notification_service.py (single source of truth for behaviour).
+EVENT_NEW_REGISTRATION = "new_registration"
+EVENT_RENEWAL_REMINDER = "renewal_reminder"
+EVENT_RENEWAL_CONFIRMATION = "renewal_confirmation"
+EVENT_MEMBERSHIP_EXPIRED = "membership_expired"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class NotificationSetting(Base):
+    """Per-event notification configuration (editable from the desktop frontend)."""
+
+    __tablename__ = "notification_settings"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    event_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # FK to app.whatsapp_templates.id; nullable until an admin assigns a template.
+    template_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("whatsapp_templates.id", ondelete="SET NULL")
+    )
+    # Ordered list of variable keys for the template body placeholders, e.g.
+    # ["member_first_name", "plan_name", "end_date"] maps {{1}}->name, {{2}}->plan, {{3}}->date.
+    param_mapping: Mapped[Optional[list]] = mapped_column(JSON)
+    # Reminder day offsets before end_at, e.g. [7, 1]. Only used by renewal_reminder.
+    offsets_days: Mapped[Optional[list]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+
+    __table_args__ = (
+        Index("uq_notification_settings_event", "event_type", unique=True),
+    )
+
+
+class NotificationLog(Base):
+    """Idempotency + audit ledger for every notification dispatch attempt."""
+
+    __tablename__ = "notification_log"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    event_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    person_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("people.id", ondelete="CASCADE")
+    )
+    subscription_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    template_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    # Unique claim key: e.g. "renewal_reminder:{subscription_id}:{offset}" — claimed before
+    # send so duplicates (multiple workers / retries) are impossible.
+    dedup_key: Mapped[str] = mapped_column(String(120), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    wa_message_id: Mapped[Optional[str]] = mapped_column(String(120))
+    error: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+
+    __table_args__ = (
+        Index("uq_notification_log_dedup", "dedup_key", unique=True),
+        Index("idx_notification_log_event_person", "event_type", "person_id"),
+    )

--- a/app/services/notification_scheduler.py
+++ b/app/services/notification_scheduler.py
@@ -1,0 +1,85 @@
+"""Daily scheduler for renewal-reminder and expired-membership notifications.
+
+A single in-process ``AsyncIOScheduler`` (APScheduler) runs ``run_all_sweeps`` once a day at
+``NOTIFICATION_SWEEP_HOUR`` (local time, America/Mexico_City). Duplicate sends are impossible
+even if several app workers each start a scheduler, because every dispatch claims a unique
+``dedup_key`` in ``notification_log`` before sending.
+
+The scheduler is started/stopped from the FastAPI lifespan (see ``app/main.py``). If APScheduler
+is not installed the app still boots — scheduling is simply disabled and the manual
+``runNotificationSweep`` mutation can be used instead.
+"""
+import logging
+import os
+
+from app.services.notification_service import run_all_sweeps
+
+logger = logging.getLogger(__name__)
+
+try:
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from apscheduler.triggers.cron import CronTrigger
+
+    _APSCHEDULER_AVAILABLE = True
+except Exception:  # noqa: BLE001
+    AsyncIOScheduler = None  # type: ignore
+    CronTrigger = None  # type: ignore
+    _APSCHEDULER_AVAILABLE = False
+
+_TIMEZONE = "America/Mexico_City"
+
+
+def _sweep_hour() -> int:
+    try:
+        hour = int(os.getenv("NOTIFICATION_SWEEP_HOUR", "9"))
+    except ValueError:
+        hour = 9
+    return min(max(hour, 0), 23)
+
+
+async def _run_sweeps_job() -> None:
+    try:
+        stats = await run_all_sweeps()
+        logger.info("Notification sweep completed: %s", stats)
+    except Exception:  # noqa: BLE001
+        logger.exception("Notification sweep job failed")
+
+
+class NotificationScheduler:
+    def __init__(self) -> None:
+        self._scheduler = None
+
+    def start(self) -> None:
+        if not _APSCHEDULER_AVAILABLE:
+            logger.warning(
+                "APScheduler not installed; notification reminders will not run automatically. "
+                "Install 'apscheduler' or trigger runNotificationSweep manually."
+            )
+            return
+        if self._scheduler is not None:
+            return
+        hour = _sweep_hour()
+        self._scheduler = AsyncIOScheduler(timezone=_TIMEZONE)
+        self._scheduler.add_job(
+            _run_sweeps_job,
+            trigger=CronTrigger(hour=hour, minute=0, timezone=_TIMEZONE),
+            id="notification_daily_sweep",
+            replace_existing=True,
+            max_instances=1,
+            coalesce=True,
+            misfire_grace_time=3600,
+        )
+        self._scheduler.start()
+        logger.info("Notification scheduler started (daily at %02d:00 %s)", hour, _TIMEZONE)
+
+    def stop(self) -> None:
+        if self._scheduler is not None:
+            try:
+                self._scheduler.shutdown(wait=False)
+            except Exception:  # noqa: BLE001
+                pass
+            self._scheduler = None
+            logger.info("Notification scheduler stopped")
+
+
+scheduler = NotificationScheduler()

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -1,0 +1,498 @@
+"""Automated WhatsApp notification dispatcher.
+
+This is the heart of the renewal/registration notification system. Given a business event
+and a member, it resolves the admin-configured template + variable mapping, builds the body
+parameters from member data, and sends an approved Meta template — reusing the same proven
+send-and-persist path as the manual ``send_template_test`` mutation.
+
+Robustness guarantees:
+* **Idempotent** — every attempt claims a unique ``dedup_key`` in ``notification_log``
+  before sending, so a notification is never sent twice (safe across workers and retries).
+* **Isolated** — triggers run in their own DB session, after the business transaction has
+  committed, so a WhatsApp failure can never roll back an enrollment/renewal.
+* **Respectful** — only APPROVED templates are sent, and members who revoked WhatsApp
+  consent (``communications_opt_in``) are skipped.
+
+The variable catalog (``VARIABLES`` / ``EVENT_TYPES``) is the single source of truth shared
+with the frontend (exposed via the ``notificationCatalog`` GraphQL query) so the placeholder
+pickers always match what the backend can actually resolve.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.crud import notificationsCrud as crud
+from app.crud import whatsappCrud as chat_crud
+from app.crud import whatsappTemplatesCrud as templates_crud
+from app.db.postgresql import async_session_factory
+from app.models import CommunicationOptIn, MembershipSubscription, People
+from app.models.notificationModel import (
+    EVENT_MEMBERSHIP_EXPIRED,
+    EVENT_NEW_REGISTRATION,
+    EVENT_RENEWAL_CONFIRMATION,
+    EVENT_RENEWAL_REMINDER,
+)
+from app.services import whatsapp_cloud_service as cloud
+from app.services.whatsapp_template_components import render_template_text
+
+logger = logging.getLogger(__name__)
+
+try:
+    from zoneinfo import ZoneInfo
+
+    _LOCAL_TZ = ZoneInfo("America/Mexico_City")
+except Exception:  # noqa: BLE001 - fallback if tzdata unavailable
+    _LOCAL_TZ = timezone.utc
+
+GYM_NAME = os.getenv("NOTIFICATION_GYM_NAME", os.getenv("GYM_NAME", "FitPilot"))
+
+
+# ---------------------------------------------------------------------------
+# Variable catalog (single source of truth, shared with the frontend)
+# ---------------------------------------------------------------------------
+VARIABLES: Dict[str, Dict[str, str]] = {
+    "member_name": {"label": "Nombre completo del socio", "sample": "Juan Pérez"},
+    "member_first_name": {"label": "Primer nombre del socio", "sample": "Juan"},
+    "plan_name": {"label": "Nombre del plan", "sample": "Mensualidad"},
+    "end_date": {"label": "Fecha de vencimiento", "sample": "15/07/2026"},
+    "start_date": {"label": "Fecha de inicio", "sample": "15/06/2026"},
+    "amount": {"label": "Monto del plan", "sample": "$500.00"},
+    "days_left": {"label": "Días restantes", "sample": "7"},
+    "gym_name": {"label": "Nombre del gimnasio", "sample": GYM_NAME},
+}
+
+EVENT_TYPES: Dict[str, Dict[str, Any]] = {
+    EVENT_NEW_REGISTRATION: {
+        "label": "Bienvenida nuevo registro",
+        "variables": [
+            "member_name", "member_first_name", "plan_name",
+            "start_date", "end_date", "amount", "gym_name",
+        ],
+        "supports_offsets": False,
+    },
+    EVENT_RENEWAL_REMINDER: {
+        "label": "Recordatorio de renovación",
+        "variables": [
+            "member_name", "member_first_name", "plan_name",
+            "end_date", "days_left", "amount", "gym_name",
+        ],
+        "supports_offsets": True,
+    },
+    EVENT_RENEWAL_CONFIRMATION: {
+        "label": "Confirmación de renovación",
+        "variables": [
+            "member_name", "member_first_name", "plan_name",
+            "start_date", "end_date", "amount", "gym_name",
+        ],
+        "supports_offsets": False,
+    },
+    EVENT_MEMBERSHIP_EXPIRED: {
+        "label": "Membresía vencida / reactivación",
+        "variables": [
+            "member_name", "member_first_name", "plan_name", "end_date", "gym_name",
+        ],
+        "supports_offsets": False,
+    },
+}
+
+DEFAULT_REMINDER_OFFSETS = [7, 1]
+# Don't blast win-back messages to memberships that lapsed long ago (e.g. on first deploy).
+EXPIRED_WINDOW_DAYS = 2
+
+
+# ---------------------------------------------------------------------------
+# Variable resolution
+# ---------------------------------------------------------------------------
+def _fmt_date(value: Optional[datetime]) -> str:
+    if not value:
+        return ""
+    dt = value
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_LOCAL_TZ).strftime("%d/%m/%Y")
+
+
+def _fmt_amount(value: Optional[Any]) -> str:
+    if value is None:
+        return ""
+    try:
+        return f"${Decimal(str(value)):,.2f}"
+    except Exception:  # noqa: BLE001
+        return str(value)
+
+
+def build_variable_context(
+    person: People,
+    subscription: Optional[MembershipSubscription] = None,
+    plan: Optional[Any] = None,
+    *,
+    now: Optional[datetime] = None,
+) -> Dict[str, str]:
+    """Resolve every catalog variable to its concrete string value for ``person``."""
+    now = now or datetime.now(timezone.utc)
+    full_name = (person.full_name or "").strip() or "socio"
+    first_name = full_name.split()[0] if full_name else "socio"
+
+    plan = plan or (subscription.plan if subscription is not None else None)
+    plan_name = getattr(plan, "name", "") or ""
+    amount = getattr(plan, "price", None)
+
+    end_at = getattr(subscription, "end_at", None)
+    start_at = getattr(subscription, "start_at", None)
+    days_left = ""
+    if end_at is not None:
+        end_aware = end_at if end_at.tzinfo else end_at.replace(tzinfo=timezone.utc)
+        delta_days = (end_aware - now).days
+        days_left = str(max(delta_days, 0))
+
+    return {
+        "member_name": full_name,
+        "member_first_name": first_name,
+        "plan_name": plan_name,
+        "end_date": _fmt_date(end_at),
+        "start_date": _fmt_date(start_at),
+        "amount": _fmt_amount(amount),
+        "days_left": days_left,
+        "gym_name": GYM_NAME,
+    }
+
+
+def _resolve_body_params(
+    param_mapping: Optional[List[str]], context: Dict[str, str]
+) -> Optional[List[str]]:
+    if not param_mapping:
+        return None
+    return [str(context.get(key, "")) for key in param_mapping]
+
+
+# ---------------------------------------------------------------------------
+# Opt-out
+# ---------------------------------------------------------------------------
+async def _is_opted_out(db: AsyncSession, person_id: int) -> bool:
+    """True only when the member's most recent WhatsApp consent record is revoked.
+
+    Absence of any record means allowed (the member shared their number at signup and
+    these are transactional UTILITY templates).
+    """
+    stmt = (
+        select(CommunicationOptIn)
+        .where(
+            CommunicationOptIn.person_id == person_id,
+            CommunicationOptIn.channel == "whatsapp",
+        )
+        .order_by(CommunicationOptIn.created_at.desc())
+        .limit(1)
+    )
+    row = (await db.execute(stmt)).scalars().first()
+    if row is None:
+        return False
+    if row.revoked_at is not None and (
+        row.granted_at is None or row.revoked_at >= row.granted_at
+    ):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch (single event for a single member)
+# ---------------------------------------------------------------------------
+async def dispatch(
+    db: AsyncSession,
+    *,
+    event_type: str,
+    person: People,
+    dedup_key: str,
+    subscription: Optional[MembershipSubscription] = None,
+    plan: Optional[Any] = None,
+) -> str:
+    """Send one notification for ``event_type`` to ``person``. Returns an outcome string.
+
+    Outcomes: ``sent`` | ``failed`` | ``duplicate`` | ``disabled`` | ``no_template`` |
+    ``no_phone`` | ``opted_out``. Never raises — failures are recorded in ``notification_log``.
+    """
+    setting = await crud.get_setting_model(db, event_type)
+    if setting is None or not setting.enabled or not setting.template_id:
+        return "disabled"
+
+    tpl = await templates_crud.get_template_model(db, setting.template_id)
+    if tpl is None or (tpl.template_status or "").upper() != "APPROVED":
+        logger.info("notification %s: template missing/not approved", event_type)
+        return "no_template"
+
+    phone = (person.phone_number or person.wa_id or "").strip()
+    wa_id = re.sub(r"\D", "", phone)
+    if not wa_id:
+        return "no_phone"
+
+    # Claim first so concurrent duplicates (multiple workers / retries) bail out here.
+    log = await crud.claim_log(
+        db,
+        dedup_key=dedup_key,
+        event_type=event_type,
+        person_id=person.id,
+        subscription_id=getattr(subscription, "id", None),
+        template_id=tpl.id,
+    )
+    if log is None:
+        return "duplicate"
+
+    if await _is_opted_out(db, person.id):
+        await crud.mark_log(db, log, status="skipped", error="opted_out", commit=True)
+        return "opted_out"
+
+    context = build_variable_context(person, subscription, plan)
+    body_params = _resolve_body_params(setting.param_mapping, context)
+
+    try:
+        # authoritative=False: reuse the existing 52/521-aware contact, never overwrite its wa_id.
+        contact = await chat_crud.upsert_contact(
+            db, wa_id=wa_id, phone_number=phone, authoritative=False
+        )
+        conversation = await chat_crud.get_or_open_conversation(db, contact.id)
+        result = await cloud.send_template(
+            to=contact.wa_id,
+            template_name=tpl.template_name,
+            language_code=tpl.template_language,
+            body_params=body_params,
+            components=tpl.components,
+        )
+    except cloud.WhatsAppError as e:
+        await crud.mark_log(db, log, status="failed", error=e.message, commit=True)
+        logger.warning("notification %s send failed: %s", event_type, e.message)
+        return "failed"
+    except Exception as e:  # noqa: BLE001
+        await db.rollback()
+        logger.exception("notification %s unexpected error", event_type)
+        # Best effort: record the failure in a fresh transaction.
+        try:
+            async with async_session_factory() as db2:
+                fresh = await crud.claim_log(
+                    db2,
+                    dedup_key=dedup_key,
+                    event_type=event_type,
+                    person_id=person.id,
+                    subscription_id=getattr(subscription, "id", None),
+                    template_id=tpl.id,
+                )
+                if fresh is not None:
+                    await crud.mark_log(db2, fresh, status="failed", error=str(e), commit=True)
+        except Exception:  # noqa: BLE001
+            pass
+        return "failed"
+
+    await chat_crud.insert_outbound_message(
+        db,
+        conversation_id=conversation.id,
+        contact_id=contact.id,
+        text=render_template_text(tpl.components, body_params) or tpl.template_name,
+        wa_message_id=result.get("wa_message_id"),
+        message_type="template",
+        template_id=tpl.id,
+    )
+    await crud.mark_log(
+        db, log, status="sent", wa_message_id=result.get("wa_message_id"), commit=True
+    )
+    return "sent"
+
+
+# ---------------------------------------------------------------------------
+# Background trigger helpers (own session, called after the business commit)
+# ---------------------------------------------------------------------------
+async def _load_person(db: AsyncSession, person_id: int) -> Optional[People]:
+    return (
+        await db.execute(select(People).where(People.id == person_id))
+    ).scalars().first()
+
+
+async def _load_subscription(
+    db: AsyncSession, subscription_id: int
+) -> Optional[MembershipSubscription]:
+    stmt = (
+        select(MembershipSubscription)
+        .options(selectinload(MembershipSubscription.plan))
+        .where(MembershipSubscription.id == subscription_id)
+    )
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def dispatch_event_in_background(
+    event_type: str,
+    *,
+    person_id: int,
+    subscription_id: Optional[int] = None,
+) -> None:
+    """Open a fresh session, reload entities by id and dispatch. Swallows all errors.
+
+    Meant to be scheduled with ``asyncio.create_task`` from a GraphQL mutation *after* the
+    business transaction has committed, so notification work never affects that transaction.
+    """
+    try:
+        async with async_session_factory() as db:
+            person = await _load_person(db, person_id)
+            if person is None:
+                return
+            subscription = (
+                await _load_subscription(db, subscription_id)
+                if subscription_id is not None
+                else None
+            )
+            if event_type == EVENT_NEW_REGISTRATION:
+                dedup_key = f"{event_type}:{person_id}"
+            elif subscription_id is not None:
+                dedup_key = f"{event_type}:{subscription_id}"
+            else:
+                dedup_key = f"{event_type}:{person_id}"
+            outcome = await dispatch(
+                db,
+                event_type=event_type,
+                person=person,
+                subscription=subscription,
+                dedup_key=dedup_key,
+            )
+            logger.info("notification %s -> %s (person=%s)", event_type, outcome, person_id)
+    except Exception:  # noqa: BLE001
+        logger.exception("background dispatch failed for %s person=%s", event_type, person_id)
+
+
+# ---------------------------------------------------------------------------
+# Sweeps (scheduled daily + manual trigger)
+# ---------------------------------------------------------------------------
+async def _active_subscriptions_expiring_within(
+    db: AsyncSession, days_ahead: int
+) -> List[MembershipSubscription]:
+    now = datetime.now(timezone.utc)
+    future = now + timedelta(days=days_ahead)
+    stmt = (
+        select(MembershipSubscription)
+        .options(
+            selectinload(MembershipSubscription.person),
+            selectinload(MembershipSubscription.plan),
+        )
+        .where(
+            and_(
+                MembershipSubscription.status == "active",
+                MembershipSubscription.end_at.between(now, future),
+            )
+        )
+        .order_by(MembershipSubscription.end_at.asc())
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def _recently_lapsed_subscriptions(
+    db: AsyncSession, window_days: int
+) -> List[MembershipSubscription]:
+    now = datetime.now(timezone.utc)
+    floor = now - timedelta(days=window_days)
+    stmt = (
+        select(MembershipSubscription)
+        .options(
+            selectinload(MembershipSubscription.person),
+            selectinload(MembershipSubscription.plan),
+        )
+        .where(
+            and_(
+                MembershipSubscription.status == "active",
+                MembershipSubscription.end_at < now,
+                MembershipSubscription.end_at >= floor,
+            )
+        )
+        .order_by(MembershipSubscription.end_at.desc())
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+def _days_until(end_at: datetime, now: datetime) -> float:
+    end_aware = end_at if end_at.tzinfo else end_at.replace(tzinfo=timezone.utc)
+    return (end_aware - now).total_seconds() / 86400.0
+
+
+def _matches_offset(days_until: float, offset: int) -> bool:
+    """A subscription crosses offset ``N`` exactly once: when N-1 < days_until <= N.
+
+    With a daily sweep this fires each reminder once on the right day and avoids sending
+    several offsets at once for memberships shorter than the largest offset.
+    """
+    return (offset - 1) < days_until <= offset
+
+
+async def run_renewal_sweep(db: AsyncSession) -> Dict[str, int]:
+    """Send renewal reminders for each configured offset. Idempotent per (sub, offset)."""
+    stats = {"sent": 0, "skipped": 0, "failed": 0}
+    setting = await crud.get_setting_model(db, EVENT_RENEWAL_REMINDER)
+    if setting is None or not setting.enabled or not setting.template_id:
+        return stats
+
+    offsets = sorted({int(o) for o in (setting.offsets_days or DEFAULT_REMINDER_OFFSETS) if int(o) > 0})
+    if not offsets:
+        return stats
+
+    now = datetime.now(timezone.utc)
+    subs = await _active_subscriptions_expiring_within(db, max(offsets))
+    for sub in subs:
+        if sub.person is None:
+            continue
+        days_until = _days_until(sub.end_at, now)
+        for offset in offsets:
+            if not _matches_offset(days_until, offset):
+                continue
+            outcome = await dispatch(
+                db,
+                event_type=EVENT_RENEWAL_REMINDER,
+                person=sub.person,
+                subscription=sub,
+                plan=sub.plan,
+                dedup_key=f"{EVENT_RENEWAL_REMINDER}:{sub.id}:{offset}",
+            )
+            _tally(stats, outcome)
+    return stats
+
+
+async def run_expired_sweep(db: AsyncSession) -> Dict[str, int]:
+    """Send win-back messages for memberships that lapsed within the safety window."""
+    stats = {"sent": 0, "skipped": 0, "failed": 0}
+    setting = await crud.get_setting_model(db, EVENT_MEMBERSHIP_EXPIRED)
+    if setting is None or not setting.enabled or not setting.template_id:
+        return stats
+
+    subs = await _recently_lapsed_subscriptions(db, EXPIRED_WINDOW_DAYS)
+    for sub in subs:
+        if sub.person is None:
+            continue
+        outcome = await dispatch(
+            db,
+            event_type=EVENT_MEMBERSHIP_EXPIRED,
+            person=sub.person,
+            subscription=sub,
+            plan=sub.plan,
+            dedup_key=f"{EVENT_MEMBERSHIP_EXPIRED}:{sub.id}",
+        )
+        _tally(stats, outcome)
+    return stats
+
+
+def _tally(stats: Dict[str, int], outcome: str) -> None:
+    if outcome == "sent":
+        stats["sent"] += 1
+    elif outcome == "failed":
+        stats["failed"] += 1
+    elif outcome in ("duplicate", "disabled", "no_template", "no_phone", "opted_out"):
+        stats["skipped"] += 1
+
+
+async def run_all_sweeps() -> Dict[str, Dict[str, int]]:
+    """Run both scheduled sweeps in a fresh session. Used by the scheduler and the
+    manual ``runNotificationSweep`` mutation."""
+    async with async_session_factory() as db:
+        renewal = await run_renewal_sweep(db)
+        expired = await run_expired_sweep(db)
+    return {"renewal_reminder": renewal, "membership_expired": expired}

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ python-dotenv>=1.0.0
 tzdata>=2024.1
 
 # Background job scheduling
+APScheduler>=3.10.0
 
 # Date utilities (for memberships)
 python-dateutil>=2.9.0


### PR DESCRIPTION
## Resumen
Sistema robusto de notificaciones automáticas de WhatsApp usando plantillas aprobadas de Meta, configurables desde el frontend (pestaña "Notificaciones").

### Eventos soportados
- **new_registration** — bienvenida al alta de socio
- **renewal_reminder** — recordatorio con offsets configurables (p. ej. 7 y 1 días antes)
- **renewal_confirmation** — confirmación tras renovar
- **membership_expired** — reactivación tras vencer (ventana de seguridad)

### Robustez
- Idempotencia: `notification_log` con `dedup_key` único (claim antes de enviar) → sin duplicados aunque haya varios workers o reintentos.
- Aislamiento: triggers fire-and-forget tras commit en enrollment/renovación, con sesión propia; una falla de WhatsApp nunca revierte la transacción de negocio.
- Barrido diario con APScheduler (lifespan) + mutación manual `runNotificationSweep`.
- Respeta `communications_opt_in`; solo envía plantillas APPROVED.

### Cambios principales
- Modelos `NotificationSetting` + `NotificationLog` (migración `b3f1c9a2d7e4`).
- `notification_service` (catálogo de variables, dispatch, sweeps) y `notification_scheduler`.
- GraphQL: `notificationSettings`, `notificationCatalog`, `saveNotificationSetting`, `runNotificationSweep`.
- Triggers en `graphql/memberships/mutations.py`; scheduler en `main.py` lifespan.
- Dependencia nueva: `APScheduler`.

### Despliegue
- Requiere `alembic upgrade head` (crea `app.notification_settings` y `app.notification_log`).
- Crear/aprobar plantillas en Meta y `syncWhatsappTemplates` antes de activar cada evento.
- Env opcional: `NOTIFICATION_SWEEP_HOUR` (default 9, America/Mexico_City), `NOTIFICATION_GYM_NAME`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
