### PR TITLE
[codex] Fix WhatsApp notification template validation

### DIFF
--- a/alembic/versions/b3f1c9a2d7e4_notification_settings_and_log.py
+++ b/alembic/versions/b3f1c9a2d7e4_notification_settings_and_log.py
@@ -26,6 +26,38 @@ SCHEMA = "app"
 
 
 def upgrade() -> None:
+    # Some legacy deployments created whatsapp_templates without a primary key even
+    # though the SQLAlchemy model treats id as the PK. The notification setting FK
+    # needs a unique referenced column, so repair that invariant before creating it.
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1
+            FROM pg_constraint
+            WHERE conrelid = '{SCHEMA}.whatsapp_templates'::regclass
+              AND contype = 'p'
+          ) THEN
+            IF EXISTS (SELECT 1 FROM {SCHEMA}.whatsapp_templates WHERE id IS NULL) THEN
+              RAISE EXCEPTION 'Cannot add PK: %.whatsapp_templates.id has NULL values', '{SCHEMA}';
+            END IF;
+            IF EXISTS (
+              SELECT 1
+              FROM {SCHEMA}.whatsapp_templates
+              GROUP BY id
+              HAVING COUNT(*) > 1
+            ) THEN
+              RAISE EXCEPTION 'Cannot add PK: %.whatsapp_templates.id has duplicate values', '{SCHEMA}';
+            END IF;
+            ALTER TABLE {SCHEMA}.whatsapp_templates ALTER COLUMN id SET NOT NULL;
+            ALTER TABLE {SCHEMA}.whatsapp_templates
+              ADD CONSTRAINT whatsapp_templates_pkey PRIMARY KEY (id);
+          END IF;
+        END $$;
+        """
+    )
+
     op.create_table(
         "notification_settings",
         sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),

--- a/alembic/versions/c8d4e2f1a6b7_notification_header_media_url.py
+++ b/alembic/versions/c8d4e2f1a6b7_notification_header_media_url.py
@@ -1,0 +1,37 @@
+"""Add header media URL to notification settings.
+
+Revision ID: c8d4e2f1a6b7
+Revises: b3f1c9a2d7e4
+Create Date: 2026-06-10 10:30:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "c8d4e2f1a6b7"
+down_revision: Union[str, None] = "b3f1c9a2d7e4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        ALTER TABLE {SCHEMA}.notification_settings
+        ADD COLUMN IF NOT EXISTS header_media_url VARCHAR(1000)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"""
+        ALTER TABLE {SCHEMA}.notification_settings
+        DROP COLUMN IF EXISTS header_media_url
+        """
+    )

--- a/app/crud/notificationsCrud.py
+++ b/app/crud/notificationsCrud.py
@@ -31,6 +31,7 @@ class NotificationSettingData:
     enabled: bool
     template_id: Optional[int]
     param_mapping: Optional[list]
+    header_media_url: Optional[str]
     offsets_days: Optional[list]
     created_at: Optional[datetime]
     updated_at: Optional[datetime]
@@ -43,6 +44,7 @@ class NotificationSettingData:
             enabled=bool(m.enabled),
             template_id=m.template_id,
             param_mapping=m.param_mapping,
+            header_media_url=m.header_media_url,
             offsets_days=m.offsets_days,
             created_at=m.created_at,
             updated_at=m.updated_at,
@@ -79,6 +81,7 @@ async def upsert_setting(
     enabled: bool = False,
     template_id: Optional[int] = None,
     param_mapping: Optional[list] = None,
+    header_media_url: Optional[str] = None,
     offsets_days: Optional[list] = None,
     commit: bool = True,
 ) -> NotificationSetting:
@@ -95,6 +98,7 @@ async def upsert_setting(
             enabled=bool(enabled),
             template_id=template_id,
             param_mapping=param_mapping or [],
+            header_media_url=header_media_url,
             offsets_days=offsets_days or [],
             created_at=now,
             updated_at=now,
@@ -104,6 +108,7 @@ async def upsert_setting(
         setting.enabled = bool(enabled)
         setting.template_id = template_id
         setting.param_mapping = param_mapping or []
+        setting.header_media_url = header_media_url
         setting.offsets_days = offsets_days or []
         setting.updated_at = now
     await db.flush()

--- a/app/crud/whatsappTemplatesCrud.py
+++ b/app/crud/whatsappTemplatesCrud.py
@@ -7,7 +7,7 @@ the database; callers commit (``commit=True`` by default for convenience).
 """
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Set, Tuple
 
 import logging
 
@@ -59,6 +59,12 @@ async def list_templates(
         stmt = stmt.where(WhatsAppTemplate.template_name.ilike(f"%{search}%"))
     rows = (await db.execute(stmt)).scalars().all()
     return [WhatsAppTemplateData.from_model(r) for r in rows]
+
+
+async def list_template_models(db: AsyncSession) -> List[WhatsAppTemplate]:
+    """Return local template models for internal reconciliation jobs."""
+    rows = (await db.execute(select(WhatsAppTemplate))).scalars().all()
+    return list(rows)
 
 
 async def get_template(db: AsyncSession, template_id: int) -> Optional[WhatsAppTemplateData]:
@@ -191,10 +197,32 @@ async def upsert_from_meta(
         tpl.template_status = status
         tpl.category = category
         tpl.components = components
-        if meta_template_id:
-            tpl.meta_template_id = meta_template_id
+        tpl.meta_template_id = meta_template_id
         tpl.updated_at = now
     await db.flush()
     if commit:
         await db.commit()
     return tpl
+
+
+async def mark_not_found_except(
+    db: AsyncSession,
+    remote_keys: Set[Tuple[str, str]],
+    *,
+    commit: bool = True,
+) -> int:
+    """Mark local templates absent from Meta as stale without deleting audit references."""
+    count = 0
+    for tpl in await list_template_models(db):
+        key = (tpl.template_name, tpl.template_language)
+        if key in remote_keys:
+            continue
+        if tpl.template_status != "NOT_FOUND" or tpl.meta_template_id is not None:
+            tpl.template_status = "NOT_FOUND"
+            tpl.meta_template_id = None
+            tpl.updated_at = datetime.utcnow()
+            count += 1
+    await db.flush()
+    if commit:
+        await db.commit()
+    return count

--- a/app/graphql/notifications/mutations.py
+++ b/app/graphql/notifications/mutations.py
@@ -6,6 +6,8 @@ each variable must be one the event can actually resolve). ``run_notification_sw
 renewal/expired sweeps on demand — handy for testing and as a manual "send now" action.
 """
 import logging
+from typing import Optional
+from urllib.parse import urlparse
 
 import strawberry
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -15,16 +17,31 @@ from app.crud import notificationsCrud as crud
 from app.crud import whatsappTemplatesCrud as templates_crud
 from app.graphql.auth.permissions import IsAuthenticated
 from app.graphql.notifications.types import (
+    NotificationRetryResult,
     NotificationSettingResult,
     NotificationSettingType,
     SaveNotificationSettingInput,
     SweepResult,
 )
 from app.graphql.whatsapp.template_types import WhatsAppTemplate
-from app.services.notification_service import EVENT_TYPES, run_all_sweeps
-from app.services.whatsapp_template_components import parse_components, placeholder_count
+from app.services.notification_service import EVENT_TYPES, retry_failed_log, run_all_sweeps
+from app.services.whatsapp_template_components import (
+    parse_components,
+    placeholder_count,
+    required_header_media_format,
+)
 
 logger = logging.getLogger(__name__)
+
+
+def _clean_header_media_url(value: Optional[str]) -> Optional[str]:
+    url = (value or "").strip()
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("La URL de media debe ser una URL pública HTTPS.")
+    return url
 
 
 @strawberry.type
@@ -43,6 +60,10 @@ class NotificationSettingsMutation:
 
         mapping = [str(v) for v in (input.param_mapping or [])]
         offsets = [int(v) for v in (input.offsets_days or [])]
+        try:
+            header_media_url = _clean_header_media_url(input.header_media_url)
+        except ValueError as exc:
+            return NotificationSettingResult(success=False, error=str(exc))
 
         tpl = None
         if input.template_id:
@@ -52,17 +73,29 @@ class NotificationSettingsMutation:
                     success=False, error="Plantilla no encontrada."
                 )
 
-        # Can't enable an event without an approved template.
+        # Can't enable an event without a synchronized, approved template.
         if input.enabled:
             if tpl is None:
                 return NotificationSettingResult(
                     success=False,
                     error="Selecciona una plantilla antes de activar el evento.",
                 )
+            if not tpl.meta_template_id:
+                return NotificationSettingResult(
+                    success=False,
+                    error="La plantilla no está sincronizada con Meta. Sincroniza plantillas primero.",
+                )
             if (tpl.template_status or "").upper() != "APPROVED":
                 return NotificationSettingResult(
                     success=False,
                     error="La plantilla seleccionada no está aprobada por Meta.",
+                )
+
+            media_format = required_header_media_format(tpl.components)
+            if media_format and not header_media_url:
+                return NotificationSettingResult(
+                    success=False,
+                    error=f"La plantilla requiere media de encabezado ({media_format}); agrega una URL HTTPS.",
                 )
 
         # Variable mapping must match the template body placeholders exactly.
@@ -100,6 +133,11 @@ class NotificationSettingsMutation:
                 enabled=input.enabled,
                 template_id=input.template_id,
                 param_mapping=mapping,
+                header_media_url=(
+                    header_media_url
+                    if tpl is not None and required_header_media_format(tpl.components)
+                    else None
+                ),
                 offsets_days=sorted(set(offsets)) if offsets else [],
             )
         except Exception as e:  # noqa: BLE001
@@ -129,3 +167,32 @@ class NotificationSettingsMutation:
         skipped = sum(group.get("skipped", 0) for group in stats.values())
         failed = sum(group.get("failed", 0) for group in stats.values())
         return SweepResult(success=True, sent=sent, skipped=skipped, failed=failed)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def retry_notification_log(self, info: Info, log_id: int) -> NotificationRetryResult:
+        """Retry one failed notification log using the current saved configuration."""
+        db: AsyncSession = info.context.db
+        try:
+            status = await retry_failed_log(db, log_id)
+        except Exception as e:  # noqa: BLE001
+            logger.exception("Manual notification retry failed")
+            return NotificationRetryResult(success=False, status="failed", error=str(e))
+
+        errors = {
+            "not_found": "No se encontró el intento original.",
+            "not_failed": "Solo se pueden reintentar notificaciones fallidas.",
+            "no_person": "No se encontró el socio asociado al intento.",
+            "disabled": "El evento está desactivado o sin plantilla configurada.",
+            "no_template": "La plantilla actual no está disponible o no está aprobada.",
+            "no_phone": "El socio no tiene teléfono válido.",
+            "opted_out": "El socio revocó consentimiento de WhatsApp.",
+            "duplicate": "El reintento ya fue registrado.",
+            "failed": "El reintento falló; revisa el log para ver el error de Meta.",
+        }
+        if status == "sent":
+            return NotificationRetryResult(success=True, status=status)
+        return NotificationRetryResult(
+            success=False,
+            status=status,
+            error=errors.get(status, f"No se envió la notificación ({status})."),
+        )

--- a/app/graphql/notifications/types.py
+++ b/app/graphql/notifications/types.py
@@ -36,6 +36,7 @@ class NotificationSettingType:
     enabled: bool
     template_id: Optional[int]
     param_mapping: Optional[List[str]]
+    header_media_url: Optional[str]
     offsets_days: Optional[List[int]]
     template: Optional[WhatsAppTemplate]
 
@@ -61,6 +62,7 @@ class NotificationSettingType:
             enabled=bool(data.enabled) if data is not None else False,
             template_id=data.template_id if data is not None else None,
             param_mapping=param_mapping,
+            header_media_url=data.header_media_url if data is not None else None,
             offsets_days=offsets_days,
             template=template,
         )
@@ -72,6 +74,7 @@ class SaveNotificationSettingInput:
     enabled: bool = False
     template_id: Optional[int] = None
     param_mapping: Optional[List[str]] = None
+    header_media_url: Optional[str] = None
     offsets_days: Optional[List[int]] = None
 
 
@@ -88,4 +91,11 @@ class SweepResult:
     sent: int = 0
     skipped: int = 0
     failed: int = 0
+    error: Optional[str] = None
+
+
+@strawberry.type
+class NotificationRetryResult:
+    success: bool = False
+    status: Optional[str] = None
     error: Optional[str] = None

--- a/app/graphql/whatsapp/template_mutations.py
+++ b/app/graphql/whatsapp/template_mutations.py
@@ -44,12 +44,18 @@ class WhatsAppTemplateMutation:
         db: AsyncSession = info.context.db
         namespace = await mgmt.fetch_namespace() or ""
         remote = await mgmt.list_templates()
+        remote_keys = set()
         for t in remote:
             meta_id = t.get("id")
+            name = t.get("name")
+            language = t.get("language")
+            if not name or not language:
+                continue
+            remote_keys.add((name, language))
             await crud.upsert_from_meta(
                 db,
-                name=t.get("name"),
-                language=t.get("language"),
+                name=name,
+                language=language,
                 namespace=namespace,
                 status=t.get("status") or "",
                 category=t.get("category"),
@@ -57,6 +63,7 @@ class WhatsAppTemplateMutation:
                 meta_template_id=str(meta_id) if meta_id is not None else None,
                 commit=False,
             )
+        await crud.mark_not_found_except(db, remote_keys, commit=False)
         await db.commit()
         data = await crud.list_templates(db)
         return [WhatsAppTemplate.from_data(d) for d in data]

--- a/app/models/notificationModel.py
+++ b/app/models/notificationModel.py
@@ -5,7 +5,8 @@ Two tables power the automated WhatsApp notification system:
 * ``notification_settings`` — one row per business event (new registration, renewal
   reminder, renewal confirmation, expired membership). Each row stores which approved
   Meta template to use, how its ``{{1}}..{{n}}`` placeholders map to member variables,
-  whether the event is enabled, and (for reminders) the day offsets before expiry.
+  whether the event is enabled, an optional media URL for templates with media headers,
+  and (for reminders) the day offsets before expiry.
 
 * ``notification_log`` — an idempotency + audit ledger. Each send attempt claims a unique
   ``dedup_key`` *before* contacting Meta, so the same notification is never sent twice even
@@ -53,6 +54,8 @@ class NotificationSetting(Base):
     # Ordered list of variable keys for the template body placeholders, e.g.
     # ["member_first_name", "plan_name", "end_date"] maps {{1}}->name, {{2}}->plan, {{3}}->date.
     param_mapping: Mapped[Optional[list]] = mapped_column(JSON)
+    # Public HTTPS URL used when the selected template has IMAGE/VIDEO/DOCUMENT header media.
+    header_media_url: Mapped[Optional[str]] = mapped_column(String(1000))
     # Reminder day offsets before end_at, e.g. [7, 1]. Only used by renewal_reminder.
     offsets_days: Mapped[Optional[list]] = mapped_column(JSON)
     created_at: Mapped[datetime] = mapped_column(

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import uuid
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
@@ -40,6 +41,7 @@ from app.models.notificationModel import (
     EVENT_NEW_REGISTRATION,
     EVENT_RENEWAL_CONFIRMATION,
     EVENT_RENEWAL_REMINDER,
+    NotificationLog,
 )
 from app.services import whatsapp_cloud_service as cloud
 from app.services.whatsapp_template_components import render_template_text
@@ -264,6 +266,7 @@ async def dispatch(
             language_code=tpl.template_language,
             body_params=body_params,
             components=tpl.components,
+            header_media_url=setting.header_media_url,
         )
     except cloud.WhatsAppError as e:
         await crud.mark_log(db, log, status="failed", error=e.message, commit=True)
@@ -322,6 +325,39 @@ async def _load_subscription(
         .where(MembershipSubscription.id == subscription_id)
     )
     return (await db.execute(stmt)).scalars().first()
+
+
+async def retry_failed_log(db: AsyncSession, log_id: int) -> str:
+    """Retry one failed notification using today's saved configuration.
+
+    The original log row is left untouched. A new log row is created with a derived
+    dedup key so the retry remains auditable without weakening normal idempotency.
+    """
+    original = await db.get(NotificationLog, log_id)
+    if original is None:
+        return "not_found"
+    if original.status != "failed":
+        return "not_failed"
+    if original.person_id is None:
+        return "no_person"
+
+    person = await _load_person(db, original.person_id)
+    if person is None:
+        return "no_person"
+
+    subscription = (
+        await _load_subscription(db, original.subscription_id)
+        if original.subscription_id is not None
+        else None
+    )
+    retry_key = f"{original.dedup_key}:retry:{original.id}:{uuid.uuid4().hex[:8]}"
+    return await dispatch(
+        db,
+        event_type=original.event_type,
+        person=person,
+        subscription=subscription,
+        dedup_key=retry_key,
+    )
 
 
 async def dispatch_event_in_background(

--- a/app/services/whatsapp_template_components.py
+++ b/app/services/whatsapp_template_components.py
@@ -17,6 +17,19 @@ def placeholder_count(body_text: str) -> int:
     return max(indices) if indices else 0
 
 
+def required_header_media_format(components: Optional[List[Any]]) -> Optional[str]:
+    """Return IMAGE/VIDEO/DOCUMENT when the template requires header media."""
+    for component in components or []:
+        if not isinstance(component, dict):
+            continue
+        if str(component.get("type") or "").upper() != "HEADER":
+            continue
+        header_format = str(component.get("format") or "").upper()
+        if header_format in {"IMAGE", "VIDEO", "DOCUMENT"}:
+            return header_format
+    return None
+
+
 def build_components(
     body_text: str,
     body_examples: Optional[List[str]] = None,

--- a/tests/test_notification_settings_validation.py
+++ b/tests/test_notification_settings_validation.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.graphql.notifications.mutations import NotificationSettingsMutation
+from app.models.notificationModel import EVENT_RENEWAL_CONFIRMATION
+
+
+def _info():
+    return SimpleNamespace(context=SimpleNamespace(db=object()))
+
+
+def _input(**overrides):
+    values = {
+        "event_type": EVENT_RENEWAL_CONFIRMATION,
+        "enabled": True,
+        "template_id": 10,
+        "param_mapping": ["member_first_name"],
+        "header_media_url": None,
+        "offsets_days": [],
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.asyncio
+async def test_save_notification_setting_rejects_unsynced_template(monkeypatch):
+    async def fake_get_template_model(_db, _template_id):
+        return SimpleNamespace(
+            meta_template_id=None,
+            template_status="APPROVED",
+            components=[{"type": "BODY", "text": "Hola {{1}}"}],
+        )
+
+    monkeypatch.setattr(
+        "app.graphql.notifications.mutations.templates_crud.get_template_model",
+        fake_get_template_model,
+    )
+
+    result = await NotificationSettingsMutation().save_notification_setting(_info(), _input())
+
+    assert result.success is False
+    assert "sincronizada" in result.error
+
+
+@pytest.mark.asyncio
+async def test_save_notification_setting_requires_header_media_url(monkeypatch):
+    async def fake_get_template_model(_db, _template_id):
+        return SimpleNamespace(
+            meta_template_id="1608879749764787",
+            template_status="APPROVED",
+            components=[
+                {"type": "HEADER", "format": "IMAGE"},
+                {"type": "BODY", "text": "Hola {{1}}"},
+            ],
+        )
+
+    monkeypatch.setattr(
+        "app.graphql.notifications.mutations.templates_crud.get_template_model",
+        fake_get_template_model,
+    )
+
+    result = await NotificationSettingsMutation().save_notification_setting(_info(), _input())
+
+    assert result.success is False
+    assert "media de encabezado" in result.error

--- a/tests/test_whatsapp_template_payload.py
+++ b/tests/test_whatsapp_template_payload.py
@@ -4,7 +4,10 @@ from app.services.whatsapp_cloud_service import (
     WhatsAppError,
     _template_send_components,
 )
-from app.services.whatsapp_template_components import render_template_text
+from app.services.whatsapp_template_components import (
+    render_template_text,
+    required_header_media_format,
+)
 
 
 def test_template_payload_includes_media_header_and_body_params():
@@ -45,6 +48,12 @@ def test_template_payload_includes_media_header_and_body_params():
             ],
         },
     ]
+
+
+def test_required_header_media_format_detects_only_media_headers():
+    assert required_header_media_format([{"type": "HEADER", "format": "IMAGE"}]) == "IMAGE"
+    assert required_header_media_format([{"type": "HEADER", "format": "TEXT"}]) is None
+    assert required_header_media_format([{"type": "BODY", "text": "Hola"}]) is None
 
 
 def test_template_payload_uses_template_examples_as_send_defaults():


### PR DESCRIPTION
﻿## Summary
- Make WhatsApp template sync authoritative and mark local-only templates as NOT_FOUND.
- Add notification header media URL support and stricter validation for approved/synced templates.
- Add manual failed-notification retry mutation and coverage for new validation paths.

## Root Cause
Production could send with stale local template rows because the template mirror was not authoritative and notification settings trusted APPROVED rows without a Meta template id.

## Validation
- python -m py_compile alembic\versions\b3f1c9a2d7e4_notification_settings_and_log.py alembic\versions\c8d4e2f1a6b7_notification_header_media_url.py app\graphql\notifications\mutations.py app\graphql\notifications\types.py app\graphql\whatsapp\template_mutations.py app\services\notification_service.py app\services\whatsapp_template_components.py app\crud\notificationsCrud.py app\crud\whatsappTemplatesCrud.py app\models\notificationModel.py
- python -m pytest tests\test_whatsapp_template_payload.py tests\test_notification_settings_validation.py -q
