### PR TITLE
Resolve WhatsApp template send media fallback

### DIFF
--- a/app/graphql/notifications/mutations.py
+++ b/app/graphql/notifications/mutations.py
@@ -14,7 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
 from app.crud import notificationsCrud as crud
-from app.crud import whatsappMediaAssetsCrud as media_crud
 from app.crud import whatsappTemplatesCrud as templates_crud
 from app.graphql.auth.permissions import IsAuthenticated
 from app.graphql.notifications.types import (
@@ -32,6 +31,7 @@ from app.services.whatsapp_template_components import (
     placeholder_count,
     required_header_media_format,
 )
+from app.services.whatsapp_template_send_media import resolve_template_send_header_media
 
 logger = logging.getLogger(__name__)
 
@@ -96,23 +96,30 @@ class NotificationSettingsMutation:
 
             media_format = required_header_media_format(tpl.components)
             if media_format:
-                asset = None
-                if header_media_asset_id:
-                    asset = await media_crud.get_asset_model(db, header_media_asset_id)
-                    try:
-                        media_service.assert_asset_matches_header(asset, media_format)
-                    except media_service.MediaAssetError as exc:
-                        return NotificationSettingResult(success=False, error=str(exc))
-                    header_media_url = asset.public_url
-                if not header_media_url:
-                    return NotificationSettingResult(
-                        success=False,
-                        error=(
-                            f"La plantilla requiere media de encabezado ({media_format}); "
-                            "selecciona un asset o agrega una URL HTTPS."
-                        ),
+                try:
+                    resolved_media = await resolve_template_send_header_media(
+                        db,
+                        template=tpl,
+                        override_media_asset_id=header_media_asset_id,
+                        legacy_header_media_url=header_media_url,
                     )
+                except media_service.MediaAssetError as exc:
+                    return NotificationSettingResult(success=False, error=str(exc))
+
+                if resolved_media.source == "override_asset":
+                    header_media_url = None
+                elif resolved_media.source == "legacy_url":
+                    header_media_asset_id = None
+                    header_media_url = resolved_media.media_url
+                else:
+                    header_media_asset_id = None
+                    header_media_url = None
             elif header_media_asset_id:
+                return NotificationSettingResult(
+                    success=False,
+                    error="La plantilla seleccionada no requiere media de encabezado.",
+                )
+            elif header_media_url:
                 return NotificationSettingResult(
                     success=False,
                     error="La plantilla seleccionada no requiere media de encabezado.",

--- a/app/graphql/whatsapp/template_mutations.py
+++ b/app/graphql/whatsapp/template_mutations.py
@@ -38,6 +38,7 @@ from app.services.whatsapp_template_components import (
     render_template_text,
     required_header_media_format,
 )
+from app.services.whatsapp_template_send_media import resolve_template_send_header_media
 
 logger = logging.getLogger(__name__)
 
@@ -307,31 +308,32 @@ class WhatsAppTemplateMutation:
         if not wa_id:
             return SendMessageResult(success=False, error="Número de teléfono inválido.")
 
-        # authoritative=False: reuse an existing contact (52/521 aware) instead of
-        # creating a duplicate, and never overwrite its canonical wa_id with the typed one.
-        contact = await chat_crud.upsert_contact(
-            db, wa_id=wa_id, phone_number=phone, authoritative=False
-        )
-        conversation = await chat_crud.get_or_open_conversation(db, contact.id)
-
-        header_media_url = input.header_media_url
-        media_format = required_header_media_format(tpl.components)
-        if input.header_media_asset_id:
-            try:
-                asset = await _ensure_header_asset(db, input.header_media_asset_id, media_format)
-                header_media_url = asset.public_url
-            except (media_service.MediaAssetError, ValueError) as exc:
-                return SendMessageResult(success=False, error=str(exc))
+        try:
+            resolved_media = await resolve_template_send_header_media(
+                db,
+                template=tpl,
+                override_media_asset_id=input.header_media_asset_id,
+                legacy_header_media_url=input.header_media_url,
+                header_media_id=input.header_media_id,
+            )
+        except media_service.MediaAssetError as exc:
+            return SendMessageResult(success=False, error=str(exc))
 
         try:
+            # authoritative=False: reuse an existing contact (52/521 aware) instead of
+            # creating a duplicate, and never overwrite its canonical wa_id with the typed one.
+            contact = await chat_crud.upsert_contact(
+                db, wa_id=wa_id, phone_number=phone, authoritative=False
+            )
+            conversation = await chat_crud.get_or_open_conversation(db, contact.id)
             result = await cloud.send_template(
                 to=contact.wa_id,
                 template_name=tpl.template_name,
                 language_code=tpl.template_language,
                 body_params=input.body_params,
                 components=tpl.components,
-                header_media_url=header_media_url,
-                header_media_id=input.header_media_id,
+                header_media_url=resolved_media.media_url,
+                header_media_id=resolved_media.media_id,
             )
         except cloud.WhatsAppError as e:
             await db.rollback()

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -32,7 +32,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.crud import notificationsCrud as crud
-from app.crud import whatsappMediaAssetsCrud as media_crud
 from app.crud import whatsappCrud as chat_crud
 from app.crud import whatsappTemplatesCrud as templates_crud
 from app.db.postgresql import async_session_factory
@@ -47,6 +46,7 @@ from app.models.notificationModel import (
 from app.services import whatsapp_cloud_service as cloud
 from app.services import whatsapp_media_assets_service as media_service
 from app.services.whatsapp_template_components import render_template_text
+from app.services.whatsapp_template_send_media import resolve_template_send_header_media
 
 logger = logging.getLogger(__name__)
 
@@ -255,12 +255,12 @@ async def dispatch(
 
     context = build_variable_context(person, subscription, plan)
     body_params = _resolve_body_params(setting.param_mapping, context)
-    header_media_url = setting.header_media_url
     try:
-        asset = await media_crud.get_asset_model(db, setting.header_media_asset_id)
-        header_media_url = media_service.resolve_header_media_url(
-            asset=asset,
-            legacy_url=setting.header_media_url,
+        resolved_media = await resolve_template_send_header_media(
+            db,
+            template=tpl,
+            override_media_asset_id=setting.header_media_asset_id,
+            legacy_header_media_url=setting.header_media_url,
         )
     except media_service.MediaAssetError as exc:
         await crud.mark_log(db, log, status="failed", error=str(exc), commit=True)
@@ -278,7 +278,8 @@ async def dispatch(
             language_code=tpl.template_language,
             body_params=body_params,
             components=tpl.components,
-            header_media_url=header_media_url,
+            header_media_url=resolved_media.media_url,
+            header_media_id=resolved_media.media_id,
         )
     except cloud.WhatsAppError as e:
         await crud.mark_log(db, log, status="failed", error=e.message, commit=True)

--- a/app/services/whatsapp_media_assets_service.py
+++ b/app/services/whatsapp_media_assets_service.py
@@ -215,17 +215,5 @@ def _extension(filename: str, mime_type: str) -> str:
     return ".jpg" if guessed == ".jpe" else guessed
 
 
-def resolve_header_media_url(
-    *,
-    asset: Optional[WhatsAppMediaAsset],
-    legacy_url: Optional[str] = None,
-) -> Optional[str]:
-    if asset is not None:
-        if (asset.status or "").lower() != "active":
-            raise MediaAssetError("El asset seleccionado no esta activo.")
-        return asset.public_url
-    return (legacy_url or "").strip() or None
-
-
 def header_format_for_kind(kind: str) -> Optional[str]:
     return MEDIA_KIND_TO_HEADER_FORMAT.get((kind or "").lower())

--- a/app/services/whatsapp_template_send_media.py
+++ b/app/services/whatsapp_template_send_media.py
@@ -1,0 +1,109 @@
+"""Resolve runtime media for WhatsApp template sends.
+
+Template media samples are used only for Meta review. Sends must provide a runtime
+header media source when the approved template has an IMAGE/VIDEO/DOCUMENT header.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import urlparse
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import whatsappMediaAssetsCrud as media_crud
+from app.models import WhatsAppTemplate
+from app.services import whatsapp_media_assets_service as media_service
+from app.services.whatsapp_template_components import required_header_media_format
+
+
+@dataclass(frozen=True)
+class ResolvedHeaderMedia:
+    media_format: Optional[str]
+    media_url: Optional[str]
+    media_id: Optional[str]
+    source: str
+
+
+def _clean_https_url(value: Optional[str]) -> Optional[str]:
+    url = (value or "").strip()
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise media_service.MediaAssetError("La URL de media debe ser una URL publica HTTPS.")
+    return url
+
+
+async def resolve_template_send_header_media(
+    db: AsyncSession,
+    *,
+    template: WhatsAppTemplate,
+    override_media_asset_id: Optional[int] = None,
+    legacy_header_media_url: Optional[str] = None,
+    header_media_id: Optional[str] = None,
+) -> ResolvedHeaderMedia:
+    """Resolve the media source to pass to ``cloud.send_template``.
+
+    Priority:
+    1. Direct WhatsApp ``header_media_id``.
+    2. Per-send/per-event override asset.
+    3. Template default asset.
+    4. Legacy HTTPS URL.
+    """
+    media_format = required_header_media_format(template.components)
+    media_id = (header_media_id or "").strip() or None
+    legacy_url = _clean_https_url(legacy_header_media_url)
+
+    if not media_format:
+        if media_id or override_media_asset_id or legacy_url:
+            raise media_service.MediaAssetError(
+                "La plantilla seleccionada no requiere media de encabezado."
+            )
+        return ResolvedHeaderMedia(
+            media_format=None,
+            media_url=None,
+            media_id=None,
+            source="none",
+        )
+
+    if media_id:
+        return ResolvedHeaderMedia(
+            media_format=media_format,
+            media_url=None,
+            media_id=media_id,
+            source="id",
+        )
+
+    if override_media_asset_id:
+        asset = await media_crud.get_asset_model(db, override_media_asset_id)
+        media_service.assert_asset_matches_header(asset, media_format)
+        return ResolvedHeaderMedia(
+            media_format=media_format,
+            media_url=asset.public_url,
+            media_id=None,
+            source="override_asset",
+        )
+
+    if template.default_header_media_asset_id:
+        asset = await media_crud.get_asset_model(db, template.default_header_media_asset_id)
+        media_service.assert_asset_matches_header(asset, media_format)
+        return ResolvedHeaderMedia(
+            media_format=media_format,
+            media_url=asset.public_url,
+            media_id=None,
+            source="template_default_asset",
+        )
+
+    if legacy_url:
+        return ResolvedHeaderMedia(
+            media_format=media_format,
+            media_url=legacy_url,
+            media_id=None,
+            source="legacy_url",
+        )
+
+    raise media_service.MediaAssetError(
+        f"La plantilla requiere media de encabezado ({media_format}); "
+        "selecciona un asset, usa el default de la plantilla o agrega una URL HTTPS."
+    )

--- a/tests/test_notification_settings_validation.py
+++ b/tests/test_notification_settings_validation.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.crud.notificationsCrud import NotificationSettingData
 from app.graphql.notifications.mutations import NotificationSettingsMutation
 from app.models.notificationModel import EVENT_RENEWAL_CONFIRMATION
 
@@ -17,6 +18,7 @@ def _input(**overrides):
         "template_id": 10,
         "param_mapping": ["member_first_name"],
         "header_media_url": None,
+        "header_media_asset_id": None,
         "offsets_days": [],
     }
     values.update(overrides)
@@ -49,6 +51,7 @@ async def test_save_notification_setting_requires_header_media_url(monkeypatch):
         return SimpleNamespace(
             meta_template_id="1608879749764787",
             template_status="APPROVED",
+            default_header_media_asset_id=None,
             components=[
                 {"type": "HEADER", "format": "IMAGE"},
                 {"type": "BODY", "text": "Hola {{1}}"},
@@ -64,3 +67,95 @@ async def test_save_notification_setting_requires_header_media_url(monkeypatch):
 
     assert result.success is False
     assert "media de encabezado" in result.error
+
+
+@pytest.mark.asyncio
+async def test_save_notification_setting_accepts_template_default_header_media(monkeypatch):
+    captured = {}
+
+    async def fake_get_template_model(_db, _template_id):
+        return SimpleNamespace(
+            id=10,
+            template_name="renovacion",
+            template_namespace="",
+            template_language="es_MX",
+            template_status="APPROVED",
+            category="MARKETING",
+            meta_template_id="1608879749764787",
+            default_header_media_asset_id=44,
+            components=[
+                {"type": "HEADER", "format": "IMAGE"},
+                {"type": "BODY", "text": "Hola {{1}}"},
+            ],
+            created_at=None,
+            updated_at=None,
+        )
+
+    async def fake_get_asset_model(_db, asset_id):
+        assert asset_id == 44
+        return SimpleNamespace(
+            id=44,
+            media_kind="image",
+            status="active",
+            public_url="https://media.example.com/default.png",
+        )
+
+    async def fake_upsert_setting(_db, **kwargs):
+        captured.update(kwargs)
+
+    async def fake_get_setting(_db, event_type):
+        return NotificationSettingData(
+            id=1,
+            event_type=event_type,
+            enabled=True,
+            template_id=10,
+            param_mapping=["member_first_name"],
+            header_media_url=None,
+            header_media_asset_id=None,
+            offsets_days=[],
+            created_at=None,
+            updated_at=None,
+        )
+
+    async def fake_get_template(_db, _template_id):
+        model = await fake_get_template_model(_db, _template_id)
+        return SimpleNamespace(
+            id=model.id,
+            template_name=model.template_name,
+            template_namespace=model.template_namespace,
+            template_language=model.template_language,
+            template_status=model.template_status,
+            category=model.category,
+            meta_template_id=model.meta_template_id,
+            default_header_media_asset_id=model.default_header_media_asset_id,
+            components=model.components,
+            created_at=None,
+            updated_at=None,
+        )
+
+    monkeypatch.setattr(
+        "app.graphql.notifications.mutations.templates_crud.get_template_model",
+        fake_get_template_model,
+    )
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fake_get_asset_model,
+    )
+    monkeypatch.setattr(
+        "app.graphql.notifications.mutations.crud.upsert_setting",
+        fake_upsert_setting,
+    )
+    monkeypatch.setattr(
+        "app.graphql.notifications.mutations.crud.get_setting",
+        fake_get_setting,
+    )
+    monkeypatch.setattr(
+        "app.graphql.notifications.mutations.templates_crud.get_template",
+        fake_get_template,
+    )
+
+    result = await NotificationSettingsMutation().save_notification_setting(_info(), _input())
+
+    assert result.success is True
+    assert captured["header_media_asset_id"] is None
+    assert captured["header_media_url"] is None

--- a/tests/test_whatsapp_template_send_flows.py
+++ b/tests/test_whatsapp_template_send_flows.py
@@ -1,0 +1,221 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.graphql.whatsapp.template_mutations import WhatsAppTemplateMutation
+from app.services.notification_service import dispatch
+
+
+class _FakeDb:
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+def _template(*, default_asset_id=77):
+    return SimpleNamespace(
+        id=10,
+        template_name="renovacion",
+        template_language="es_MX",
+        template_status="APPROVED",
+        meta_template_id="meta-10",
+        default_header_media_asset_id=default_asset_id,
+        components=[
+            {"type": "HEADER", "format": "IMAGE"},
+            {"type": "BODY", "text": "Hola"},
+        ],
+    )
+
+
+def _asset(asset_id):
+    return SimpleNamespace(
+        id=asset_id,
+        media_kind="image",
+        status="active",
+        public_url=f"https://media.example.com/{asset_id}.png",
+    )
+
+
+def _message():
+    return SimpleNamespace(
+        id=1,
+        conversation_id=2,
+        contact_id=3,
+        direction="outbound",
+        message_type="template",
+        text_content="Hola",
+        timestamp=datetime.now(timezone.utc),
+        wa_message_id="wamid.test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_template_test_uses_default_media_when_no_override(monkeypatch):
+    captured = {}
+
+    async def fake_get_template_model(_db, template_id):
+        assert template_id == 10
+        return _template(default_asset_id=77)
+
+    async def fake_get_asset_model(_db, asset_id):
+        assert asset_id == 77
+        return _asset(asset_id)
+
+    async def fake_send_template(**kwargs):
+        captured.update(kwargs)
+        return {"wa_message_id": "wamid.test"}
+
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.template_mutations.crud.get_template_model",
+        fake_get_template_model,
+    )
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fake_get_asset_model,
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.template_mutations.cloud.send_template",
+        fake_send_template,
+    )
+
+    async def async_upsert_contact(*args, **kwargs):
+        return SimpleNamespace(id=3, wa_id="5215555555555")
+
+    async def async_get_or_open_conversation(*args, **kwargs):
+        return SimpleNamespace(id=2)
+
+    async def async_insert_outbound_message(*args, **kwargs):
+        return _message()
+
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.template_mutations.chat_crud.upsert_contact",
+        async_upsert_contact,
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.template_mutations.chat_crud.get_or_open_conversation",
+        async_get_or_open_conversation,
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.template_mutations.chat_crud.insert_outbound_message",
+        async_insert_outbound_message,
+    )
+
+    info = SimpleNamespace(context=SimpleNamespace(db=_FakeDb()))
+    input_data = SimpleNamespace(
+        phone="+52 1 555 555 5555",
+        template_id=10,
+        body_params=[],
+        header_media_url=None,
+        header_media_id=None,
+        header_media_asset_id=None,
+    )
+
+    result = await WhatsAppTemplateMutation().send_template_test(info, input_data)
+
+    assert result.success is True
+    assert captured["header_media_url"] == "https://media.example.com/77.png"
+    assert captured["header_media_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_notification_dispatch_uses_override_media(monkeypatch):
+    captured = {}
+
+    await _run_dispatch(monkeypatch, captured, setting_asset_id=88, default_asset_id=77)
+
+    assert captured["header_media_url"] == "https://media.example.com/88.png"
+
+
+@pytest.mark.asyncio
+async def test_notification_dispatch_uses_default_media_without_override(monkeypatch):
+    captured = {}
+
+    await _run_dispatch(monkeypatch, captured, setting_asset_id=None, default_asset_id=77)
+
+    assert captured["header_media_url"] == "https://media.example.com/77.png"
+
+
+async def _run_dispatch(monkeypatch, captured, *, setting_asset_id, default_asset_id):
+    setting = SimpleNamespace(
+        enabled=True,
+        template_id=10,
+        param_mapping=[],
+        header_media_asset_id=setting_asset_id,
+        header_media_url=None,
+    )
+    person = SimpleNamespace(
+        id=1,
+        full_name="Alejandro Martinez",
+        phone_number="+52 1 555 555 5555",
+        wa_id=None,
+    )
+
+    async def fake_get_setting_model(_db, event_type):
+        return setting
+
+    async def fake_get_template_model(_db, template_id):
+        return _template(default_asset_id=default_asset_id)
+
+    async def fake_get_asset_model(_db, asset_id):
+        return _asset(asset_id)
+
+    async def fake_claim_log(*args, **kwargs):
+        return SimpleNamespace(id=99)
+
+    async def fake_mark_log(*args, **kwargs):
+        return SimpleNamespace(id=99)
+
+    async def fake_upsert_contact(*args, **kwargs):
+        return SimpleNamespace(id=3, wa_id="5215555555555")
+
+    async def fake_get_or_open_conversation(*args, **kwargs):
+        return SimpleNamespace(id=2)
+
+    async def fake_send_template(**kwargs):
+        captured.update(kwargs)
+        return {"wa_message_id": "wamid.test"}
+
+    async def fake_insert_outbound_message(*args, **kwargs):
+        return _message()
+
+    monkeypatch.setattr(
+        "app.services.notification_service.crud.get_setting_model",
+        fake_get_setting_model,
+    )
+    monkeypatch.setattr(
+        "app.services.notification_service.templates_crud.get_template_model",
+        fake_get_template_model,
+    )
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fake_get_asset_model,
+    )
+    monkeypatch.setattr("app.services.notification_service.crud.claim_log", fake_claim_log)
+    monkeypatch.setattr("app.services.notification_service.crud.mark_log", fake_mark_log)
+    monkeypatch.setattr("app.services.notification_service.chat_crud.upsert_contact", fake_upsert_contact)
+    monkeypatch.setattr(
+        "app.services.notification_service.chat_crud.get_or_open_conversation",
+        fake_get_or_open_conversation,
+    )
+    monkeypatch.setattr("app.services.notification_service.cloud.send_template", fake_send_template)
+    monkeypatch.setattr(
+        "app.services.notification_service.chat_crud.insert_outbound_message",
+        fake_insert_outbound_message,
+    )
+
+    async def fake_is_opted_out(*args, **kwargs):
+        return False
+
+    monkeypatch.setattr("app.services.notification_service._is_opted_out", fake_is_opted_out)
+
+    outcome = await dispatch(
+        _FakeDb(),
+        event_type="renewal_confirmation",
+        person=person,
+        dedup_key="test-key",
+    )
+
+    assert outcome == "sent"

--- a/tests/test_whatsapp_template_send_media.py
+++ b/tests/test_whatsapp_template_send_media.py
@@ -1,0 +1,155 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.whatsapp_media_assets_service import MediaAssetError
+from app.services.whatsapp_template_send_media import resolve_template_send_header_media
+
+
+def _template(*, header_format="IMAGE", default_asset_id=None):
+    components = [{"type": "BODY", "text": "Hola"}]
+    if header_format:
+        components.insert(0, {"type": "HEADER", "format": header_format})
+    return SimpleNamespace(
+        components=components,
+        default_header_media_asset_id=default_asset_id,
+    )
+
+
+def _asset(asset_id, kind="image", status="active", url=None):
+    return SimpleNamespace(
+        id=asset_id,
+        media_kind=kind,
+        status=status,
+        public_url=url or f"https://media.example.com/{asset_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_prefers_header_media_id_over_assets(monkeypatch):
+    async def fail_get_asset(_db, _asset_id):
+        raise AssertionError("asset lookup should not run when a media id is provided")
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fail_get_asset,
+    )
+
+    result = await resolve_template_send_header_media(
+        object(),
+        template=_template(default_asset_id=1),
+        override_media_asset_id=2,
+        legacy_header_media_url="https://legacy.example.com/header.png",
+        header_media_id="wamedia123",
+    )
+
+    assert result.media_format == "IMAGE"
+    assert result.media_id == "wamedia123"
+    assert result.media_url is None
+    assert result.source == "id"
+
+
+@pytest.mark.asyncio
+async def test_resolve_uses_override_asset(monkeypatch):
+    async def fake_get_asset(_db, asset_id):
+        return _asset(asset_id, kind="image")
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fake_get_asset,
+    )
+
+    result = await resolve_template_send_header_media(
+        object(),
+        template=_template(default_asset_id=1),
+        override_media_asset_id=2,
+    )
+
+    assert result.media_url == "https://media.example.com/2"
+    assert result.source == "override_asset"
+
+
+@pytest.mark.asyncio
+async def test_resolve_uses_template_default_asset(monkeypatch):
+    async def fake_get_asset(_db, asset_id):
+        return _asset(asset_id, kind="video")
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fake_get_asset,
+    )
+
+    result = await resolve_template_send_header_media(
+        object(),
+        template=_template(header_format="VIDEO", default_asset_id=7),
+    )
+
+    assert result.media_format == "VIDEO"
+    assert result.media_url == "https://media.example.com/7"
+    assert result.source == "template_default_asset"
+
+
+@pytest.mark.asyncio
+async def test_resolve_uses_legacy_url_when_no_assets():
+    result = await resolve_template_send_header_media(
+        object(),
+        template=_template(default_asset_id=None),
+        legacy_header_media_url="https://cdn.example.com/header.png",
+    )
+
+    assert result.media_url == "https://cdn.example.com/header.png"
+    assert result.source == "legacy_url"
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_wrong_override_kind(monkeypatch):
+    async def fake_get_asset(_db, asset_id):
+        return _asset(asset_id, kind="audio")
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fake_get_asset,
+    )
+
+    with pytest.raises(MediaAssetError, match="requiere image"):
+        await resolve_template_send_header_media(
+            object(),
+            template=_template(header_format="IMAGE"),
+            override_media_asset_id=3,
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_inactive_default_asset(monkeypatch):
+    async def fake_get_asset(_db, asset_id):
+        return _asset(asset_id, kind="image", status="archived")
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_template_send_media.media_crud.get_asset_model",
+        fake_get_asset,
+    )
+
+    with pytest.raises(MediaAssetError, match="no esta activo"):
+        await resolve_template_send_header_media(
+            object(),
+            template=_template(default_asset_id=4),
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_fails_when_required_media_has_no_source():
+    with pytest.raises(MediaAssetError, match="requiere media de encabezado"):
+        await resolve_template_send_header_media(
+            object(),
+            template=_template(default_asset_id=None),
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_media_for_text_only_template():
+    with pytest.raises(MediaAssetError, match="no requiere media"):
+        await resolve_template_send_header_media(
+            object(),
+            template=_template(header_format=None),
+            legacy_header_media_url="https://cdn.example.com/header.png",
+        )

--- a/tests/test_whatsapp_templates_crud.py
+++ b/tests/test_whatsapp_templates_crud.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.crud import whatsappTemplatesCrud as crud
+
+
+class _FakeDb:
+    async def flush(self):
+        return None
+
+    async def commit(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_upsert_from_meta_preserves_default_header_media_asset_id(monkeypatch):
+    template = SimpleNamespace(
+        template_name="renovacion",
+        template_namespace="old",
+        template_language="es_MX",
+        template_status="PENDING",
+        category="MARKETING",
+        components=[{"type": "BODY", "text": "old"}],
+        meta_template_id="meta-old",
+        default_header_media_asset_id=44,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    async def fake_get_by_name_language(_db, name, language):
+        assert name == "renovacion"
+        assert language == "es_MX"
+        return template
+
+    monkeypatch.setattr(crud, "get_by_name_language", fake_get_by_name_language)
+
+    updated = await crud.upsert_from_meta(
+        _FakeDb(),
+        name="renovacion",
+        language="es_MX",
+        namespace="new",
+        status="APPROVED",
+        category="MARKETING",
+        components=[{"type": "BODY", "text": "new"}],
+        meta_template_id="meta-new",
+        commit=False,
+    )
+
+    assert updated.default_header_media_asset_id == 44
+    assert updated.template_status == "APPROVED"
+    assert updated.meta_template_id == "meta-new"


### PR DESCRIPTION
## Summary
- Centralize WhatsApp template header media resolution
- Use default template media for test sends and notifications when no override is provided
- Allow notification settings to rely on template default media
- Add focused backend coverage for fallback/override behavior

## Test Plan
- python -m pytest tests/test_whatsapp_template_send_media.py tests/test_notification_settings_validation.py tests/test_whatsapp_template_send_flows.py tests/test_whatsapp_templates_crud.py tests/test_whatsapp_template_payload.py tests/test_whatsapp_media_assets.py -q
- python -m py_compile app/services/whatsapp_template_send_media.py app/services/whatsapp_media_assets_service.py app/graphql/whatsapp/template_mutations.py app/graphql/notifications/mutations.py app/services/notification_service.py