### PR TITLE
feat(whatsapp): soporte multimedia end-to-end en el chat

### DIFF
--- a/alembic/versions/e7a8b9c0d1f2_media_cloud_media_id.py
+++ b/alembic/versions/e7a8b9c0d1f2_media_cloud_media_id.py
@@ -1,0 +1,42 @@
+"""Persist the Meta Cloud API media id on chat media rows.
+
+Needed to retry downloads after a restart (the temporary download URL
+expires in minutes, but the media id stays valid ~30 days).
+
+Revision ID: e7a8b9c0d1f2
+Revises: d4e5f6a7b8c9
+Create Date: 2026-06-12 00:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "e7a8b9c0d1f2"
+down_revision: Union[str, None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        ALTER TABLE {SCHEMA}.media
+        ADD COLUMN IF NOT EXISTS cloud_media_id VARCHAR(100)
+        """
+    )
+    op.execute(
+        f"""
+        CREATE INDEX IF NOT EXISTS idx_media_cloud_media_id
+            ON {SCHEMA}.media (cloud_media_id)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP INDEX IF EXISTS {SCHEMA}.idx_media_cloud_media_id")
+    op.execute(f"ALTER TABLE {SCHEMA}.media DROP COLUMN IF EXISTS cloud_media_id")

--- a/app/crud/whatsappCrud.py
+++ b/app/crud/whatsappCrud.py
@@ -9,9 +9,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Dict
 
+import json
 import logging
 
-from sqlalchemy import case, func, or_, select, and_
+from sqlalchemy import case, func, or_, select, and_, text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -58,6 +59,35 @@ class _MemberCandidate:
 
 
 @dataclass
+class ChatMediaData:
+    """Metadata of a message attachment, exposed to the desktop client."""
+
+    id: int
+    media_type: str
+    mime_type: Optional[str]
+    filename: Optional[str]
+    caption: Optional[str]
+    file_size: Optional[int]
+    media_url: Optional[str]
+    downloaded: bool
+    download_failed: bool
+
+    @classmethod
+    def from_model(cls, m: Media) -> "ChatMediaData":
+        return cls(
+            id=m.id,
+            media_type=m.media_type,
+            mime_type=m.mime_type,
+            filename=m.filename,
+            caption=m.caption,
+            file_size=m.file_size,
+            media_url=m.media_url,
+            downloaded=bool(m.downloaded),
+            download_failed=bool(m.download_failed),
+        )
+
+
+@dataclass
 class ChatMessageData:
     id: int
     conversation_id: int
@@ -68,17 +98,20 @@ class ChatMessageData:
     timestamp: datetime
     wa_message_id: Optional[str]
     media_url: Optional[str] = None
+    media: Optional[ChatMediaData] = None
 
     @classmethod
     def from_model(cls, m: Message) -> "ChatMessageData":
-        media_url = None
-        # ``m.media`` is only populated when eager-loaded; guard against lazy access.
+        # WhatsApp delivers one attachment per message; expose the first media
+        # row. ``m.media`` is only populated when eager-loaded; guard against
+        # lazy access on an async session.
+        media = None
         try:
             media_items = m.__dict__.get("media")
             if media_items:
-                media_url = media_items[0].media_url
+                media = ChatMediaData.from_model(media_items[0])
         except Exception:  # noqa: BLE001
-            media_url = None
+            media = None
         return cls(
             id=m.id,
             conversation_id=m.conversation_id,
@@ -88,7 +121,8 @@ class ChatMessageData:
             text_content=m.text_content,
             timestamp=m.timestamp,
             wa_message_id=m.wa_message_id,
-            media_url=media_url,
+            media_url=media.media_url if media else None,
+            media=media,
         )
 
 
@@ -480,6 +514,7 @@ async def _latest_message_per_conversation(
 
     stmt = (
         select(Message)
+        .options(selectinload(Message.media))
         .where(Message.conversation_id.in_(conv_ids))
         .distinct(Message.conversation_id)
         .order_by(
@@ -725,7 +760,7 @@ async def insert_outbound_message(
     db: AsyncSession,
     conversation_id: int,
     contact_id: int,
-    text: str,
+    text: Optional[str],
     wa_message_id: Optional[str] = None,
     message_type: str = "text",
     template_id: Optional[int] = None,
@@ -788,6 +823,7 @@ async def insert_media(
     media_type: str,
     mime_type: Optional[str] = None,
     caption: Optional[str] = None,
+    cloud_media_id: Optional[str] = None,
 ) -> Media:
     """Insert a media row (pre-download). Caller commits."""
     media = Media(
@@ -795,6 +831,7 @@ async def insert_media(
         media_type=media_type,
         mime_type=mime_type,
         caption=caption,
+        cloud_media_id=cloud_media_id,
         created_at=datetime.utcnow(),
         downloaded=0,
         download_failed=0,
@@ -802,6 +839,34 @@ async def insert_media(
     db.add(media)
     await db.flush()
     return media
+
+
+async def notify_media_event(db: AsyncSession, media: Media, status: str) -> None:
+    """Publish a ``media_updated`` event on the realtime channel.
+
+    Uses ``pg_notify`` from the application (no extra DB trigger) so the event
+    reuses the existing ``whatsapp_events`` listener. NOTIFY is transactional:
+    it is delivered when the caller commits, i.e. once the media row update is
+    visible to other connections.
+    """
+    conversation_id = (
+        await db.execute(
+            select(Message.conversation_id).where(Message.id == media.message_id)
+        )
+    ).scalar_one_or_none()
+    payload = json.dumps(
+        {
+            "type": "media_updated",
+            "id": media.message_id,
+            "media_id": media.id,
+            "conversation_id": conversation_id,
+            "status": status,
+        }
+    )
+    await db.execute(
+        sql_text("SELECT pg_notify('whatsapp_events', :payload)"),
+        {"payload": payload},
+    )
 
 
 async def mark_media_downloaded(
@@ -828,6 +893,7 @@ async def mark_media_downloaded(
     media.download_failed = 0
     media.download_time = datetime.utcnow()
     await db.flush()
+    await notify_media_event(db, media, "downloaded")
 
 
 async def mark_media_failed(db: AsyncSession, media_id: int) -> None:
@@ -837,3 +903,45 @@ async def mark_media_failed(db: AsyncSession, media_id: int) -> None:
     media.download_failed = 1
     media.download_time = datetime.utcnow()
     await db.flush()
+    await notify_media_event(db, media, "failed")
+
+
+async def get_media_for_retry(db: AsyncSession, message_id: int) -> Optional[Media]:
+    """Return the media row of a message that can be re-downloaded from Meta."""
+    stmt = select(Media).where(Media.message_id == message_id).order_by(Media.id.asc())
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def insert_outbound_media(
+    db: AsyncSession,
+    message_id: int,
+    media_type: str,
+    *,
+    mime_type: Optional[str],
+    filename: Optional[str],
+    file_size: Optional[int],
+    sha256: Optional[str],
+    media_url: Optional[str],
+    caption: Optional[str] = None,
+    cloud_media_id: Optional[str] = None,
+) -> Media:
+    """Insert the media row of a sent message (file already stored locally). Caller commits."""
+    now = datetime.utcnow()
+    media = Media(
+        message_id=message_id,
+        media_type=media_type,
+        mime_type=mime_type,
+        filename=filename,
+        file_size=file_size,
+        sha256=sha256,
+        media_url=media_url,
+        caption=caption,
+        cloud_media_id=cloud_media_id,
+        created_at=now,
+        downloaded=1,
+        download_time=now,
+        download_failed=0,
+    )
+    db.add(media)
+    await db.flush()
+    return media

--- a/app/graphql/whatsapp/mutations.py
+++ b/app/graphql/whatsapp/mutations.py
@@ -1,20 +1,68 @@
 """GraphQL mutations for the WhatsApp chat feature."""
+import hashlib
 import logging
+import mimetypes
+from pathlib import Path
+from typing import Optional, Tuple
 
 import strawberry
 from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.file_uploads import Upload
 from strawberry.types import Info
 
 from app.crud import whatsappCrud as crud
 from app.graphql.whatsapp.types import (
+    SendMediaMessageInput,
     SendTextMessageInput,
     SendMessageResult,
     ChatMessage,
 )
 from app.graphql.auth.permissions import IsAuthenticated
+from app.models import Contact, Conversation
 from app.services import whatsapp_cloud_service as cloud
+from app.services import whatsapp_media_service as media_service
+from app.services.whatsapp_media_assets_service import (
+    MediaAssetError,
+    _detect_mime_type,
+    validate_media,
+)
 
 logger = logging.getLogger(__name__)
+
+# WhatsApp message types that map directly from a MIME prefix. Anything else
+# (pdf, office docs, plain text, ...) is sent as a document.
+_MIME_PREFIX_TO_KIND = {"image/": "image", "audio/": "audio", "video/": "video"}
+
+
+async def _resolve_target(
+    db: AsyncSession, conversation_id: Optional[int], wa_id: Optional[str]
+) -> Tuple[Optional[Contact], Optional[Conversation], Optional[str]]:
+    """Resolve the destination contact + conversation for a send.
+
+    Returns (contact, conversation, error). Exactly one of the pair
+    (contact+conversation) or error is set.
+    """
+    if conversation_id:
+        conversation = await crud.get_conversation(db, conversation_id)
+        if conversation is None:
+            return None, None, "Conversación no encontrada."
+        return conversation.contact, conversation, None
+    if wa_id:
+        # Resolve by normalized number (52/521 aware) so a send never spawns a
+        # duplicate contact/conversation for a number that already exists.
+        contact = await crud.upsert_contact(
+            db, wa_id=wa_id, phone_number=wa_id, authoritative=False
+        )
+        conversation = await crud.get_or_open_conversation(db, contact.id)
+        return contact, conversation, None
+    return None, None, "Falta conversationId o waId."
+
+
+def _media_kind_for_mime(mime_type: str) -> str:
+    for prefix, kind in _MIME_PREFIX_TO_KIND.items():
+        if mime_type.startswith(prefix):
+            return kind
+    return "document"
 
 
 @strawberry.type
@@ -30,23 +78,11 @@ class WhatsAppChatMutation:
         if not text:
             return SendMessageResult(success=False, error="El mensaje está vacío.")
 
-        # Resolve the target contact + conversation.
-        contact = None
-        conversation = None
-        if input.conversation_id:
-            conversation = await crud.get_conversation(db, input.conversation_id)
-            if conversation is None:
-                return SendMessageResult(success=False, error="Conversación no encontrada.")
-            contact = conversation.contact
-        elif input.wa_id:
-            # Resolve by normalized number (52/521 aware) so a send never spawns a
-            # duplicate contact/conversation for a number that already exists.
-            contact = await crud.upsert_contact(
-                db, wa_id=input.wa_id, phone_number=input.wa_id, authoritative=False
-            )
-            conversation = await crud.get_or_open_conversation(db, contact.id)
-        else:
-            return SendMessageResult(success=False, error="Falta conversationId o waId.")
+        contact, conversation, error = await _resolve_target(
+            db, input.conversation_id, input.wa_id
+        )
+        if error:
+            return SendMessageResult(success=False, error=error)
 
         # Send via the Cloud API.
         try:
@@ -72,4 +108,120 @@ class WhatsAppChatMutation:
         return SendMessageResult(
             success=True,
             message=ChatMessage.from_data(crud.ChatMessageData.from_model(message)),
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def send_media_message(
+        self, info: Info, input: SendMediaMessageInput, file: Upload
+    ) -> SendMessageResult:
+        """Send a media message (image/audio/video/document) via the Cloud API.
+
+        Uploads the binary to Meta, sends it, stores a local copy under
+        ``/uploads/whatsapp/`` (so the bubble renders immediately) and persists
+        the Message + Media rows.
+        """
+        db: AsyncSession = info.context.db
+
+        contact, conversation, error = await _resolve_target(
+            db, input.conversation_id, input.wa_id
+        )
+        if error:
+            return SendMessageResult(success=False, error=error)
+
+        original_filename = Path(getattr(file, "filename", "") or "archivo").name
+        raw = await file.read()
+        mime_type = _detect_mime_type(file, original_filename)
+        media_kind = _media_kind_for_mime(mime_type)
+        caption = (input.caption or "").strip() or None
+        if media_kind == "audio":
+            caption = None  # the Cloud API rejects captions on audio
+
+        try:
+            validate_media(media_kind, raw, mime_type)
+        except MediaAssetError as e:
+            return SendMessageResult(success=False, error=str(e))
+
+        try:
+            media_id = await cloud.upload_media(raw, mime_type, original_filename)
+            result = await cloud.send_media(
+                to=contact.wa_id,
+                media_type=media_kind,
+                media_id=media_id,
+                caption=caption,
+                filename=original_filename if media_kind == "document" else None,
+            )
+        except cloud.WhatsAppError as e:
+            await db.rollback()
+            return SendMessageResult(success=False, error=e.message)
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            logger.exception("Unexpected error sending WhatsApp media")
+            return SendMessageResult(success=False, error=str(e))
+
+        # Local copy, same naming convention as inbound downloads.
+        ext = Path(original_filename).suffix.lower() or (
+            mimetypes.guess_extension(mime_type) or ""
+        )
+        stored_filename = f"{media_id}{ext}"
+        try:
+            media_service.UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+            (media_service.UPLOAD_DIR / stored_filename).write_bytes(raw)
+            local_url = f"/uploads/whatsapp/{stored_filename}"
+        except OSError:
+            logger.exception("Could not store local copy of sent media %s", media_id)
+            local_url = None
+
+        message = await crud.insert_outbound_message(
+            db,
+            conversation_id=conversation.id,
+            contact_id=contact.id,
+            text=caption,
+            wa_message_id=result.get("wa_message_id"),
+            message_type=media_kind,
+        )
+        await crud.insert_outbound_media(
+            db,
+            message_id=message.id,
+            media_type=media_kind,
+            mime_type=mime_type,
+            filename=original_filename,
+            file_size=len(raw),
+            sha256=hashlib.sha256(raw).hexdigest(),
+            media_url=local_url,
+            caption=caption,
+            cloud_media_id=media_id,
+        )
+        await db.commit()
+
+        # Re-fetch with the media relation eager-loaded so the result (and the
+        # realtime fan-out) carries the attachment metadata.
+        data = await crud.get_message_by_id(db, message.id)
+        return SendMessageResult(
+            success=True,
+            message=ChatMessage.from_data(data) if data else None,
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def retry_media_download(self, info: Info, message_id: int) -> SendMessageResult:
+        """Re-download the attachment of a message from Meta (after a failure
+        or a lost local file). Requires the stored cloud media id."""
+        db: AsyncSession = info.context.db
+
+        media = await crud.get_media_for_retry(db, message_id)
+        if media is None:
+            return SendMessageResult(success=False, error="El mensaje no tiene archivo adjunto.")
+        if not media.cloud_media_id:
+            return SendMessageResult(
+                success=False,
+                error="No se puede reintentar: el id de media de Meta no está disponible.",
+            )
+
+        media.download_failed = 0
+        await db.commit()
+        media_service.schedule_download(media.id, media.cloud_media_id)
+
+        data = await crud.get_message_by_id(db, message_id)
+        return SendMessageResult(
+            success=True,
+            message=ChatMessage.from_data(data) if data else None,
         )

--- a/app/graphql/whatsapp/subscriptions.py
+++ b/app/graphql/whatsapp/subscriptions.py
@@ -67,3 +67,34 @@ class WhatsAppChatSubscription:
                 yield ChatMessage.from_data(data)
         finally:
             broadcaster.unsubscribe(queue)
+
+    @strawberry.subscription
+    async def message_updated(
+        self, info: Info, conversation_id: Optional[int] = None
+    ) -> AsyncGenerator[ChatMessage, None]:
+        """Stream messages whose media finished downloading (or failed).
+
+        Emitted by ``notify_media_event`` (application-level pg_notify) so the
+        client can swap the "receiving..." placeholder for the real attachment.
+        """
+        if not _is_authorized(info):
+            raise Exception("Authentication required.")
+
+        queue = broadcaster.subscribe()
+        try:
+            while True:
+                event = await queue.get()
+                if event.get("type") != "media_updated":
+                    continue
+                if conversation_id is not None and event.get("conversation_id") != conversation_id:
+                    continue
+                msg_id = event.get("id")
+                if msg_id is None:
+                    continue
+                async with async_session_factory() as db:
+                    data = await get_message_by_id(db, int(msg_id))
+                if data is None:
+                    continue
+                yield ChatMessage.from_data(data)
+        finally:
+            broadcaster.unsubscribe(queue)

--- a/app/graphql/whatsapp/types.py
+++ b/app/graphql/whatsapp/types.py
@@ -9,7 +9,12 @@ from typing import Optional
 
 import strawberry
 
-from app.crud.whatsappCrud import ChatContactData, ChatMessageData, ConversationData
+from app.crud.whatsappCrud import (
+    ChatContactData,
+    ChatMediaData,
+    ChatMessageData,
+    ConversationData,
+)
 
 
 @strawberry.type
@@ -36,6 +41,35 @@ class ChatContact:
 
 
 @strawberry.type
+class ChatMessageMedia:
+    """Attachment metadata of a chat message (one per message in practice)."""
+
+    id: int
+    media_type: str
+    mime_type: Optional[str]
+    filename: Optional[str]
+    caption: Optional[str]
+    file_size: Optional[int]
+    media_url: Optional[str]
+    downloaded: bool
+    download_failed: bool
+
+    @classmethod
+    def from_data(cls, d: ChatMediaData) -> "ChatMessageMedia":
+        return cls(
+            id=d.id,
+            media_type=d.media_type,
+            mime_type=d.mime_type,
+            filename=d.filename,
+            caption=d.caption,
+            file_size=d.file_size,
+            media_url=d.media_url,
+            downloaded=d.downloaded,
+            download_failed=d.download_failed,
+        )
+
+
+@strawberry.type
 class ChatMessage:
     id: int
     conversation_id: int
@@ -45,7 +79,8 @@ class ChatMessage:
     text_content: Optional[str]
     timestamp: datetime
     wa_message_id: Optional[str]
-    media_url: Optional[str]
+    media_url: Optional[str]  # deprecated: kept for older clients, use ``media``
+    media: Optional[ChatMessageMedia]
 
     @classmethod
     def from_data(cls, d: ChatMessageData) -> "ChatMessage":
@@ -59,6 +94,7 @@ class ChatMessage:
             timestamp=d.timestamp,
             wa_message_id=d.wa_message_id,
             media_url=d.media_url,
+            media=ChatMessageMedia.from_data(d.media) if d.media else None,
         )
 
 
@@ -88,6 +124,13 @@ class SendTextMessageInput:
     text: str
     conversation_id: Optional[int] = None
     wa_id: Optional[str] = None
+
+
+@strawberry.input
+class SendMediaMessageInput:
+    conversation_id: Optional[int] = None
+    wa_id: Optional[str] = None
+    caption: Optional[str] = None
 
 
 @strawberry.type

--- a/app/models/whatsappModel.py
+++ b/app/models/whatsappModel.py
@@ -112,6 +112,9 @@ class Media(Base):
     file_size: Mapped[Optional[int]] = mapped_column(BigInteger)
     media_url: Mapped[Optional[str]] = mapped_column(String(255))
     caption: Mapped[Optional[str]] = mapped_column(Text)
+    # Meta Cloud API media id; kept so failed downloads can be retried later
+    # (the temporary URL expires in minutes, the id stays valid ~30 days).
+    cloud_media_id: Mapped[Optional[str]] = mapped_column(String(100))
     created_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP, default=datetime.utcnow)
     downloaded: Mapped[Optional[int]] = mapped_column(SmallInteger, default=0)
     download_time: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP)

--- a/app/services/whatsapp_cloud_service.py
+++ b/app/services/whatsapp_cloud_service.py
@@ -246,6 +246,83 @@ async def send_template(
     return {"wa_message_id": wa_message_id}
 
 
+async def upload_media(content: bytes, mime_type: str, filename: str) -> str:
+    """Upload binary media to Meta and return its media id.
+
+    The id is then referenced in a media message send; Meta keeps the binary
+    ~30 days. Raises WhatsAppError on failure.
+    """
+    if not whatsapp_config.is_send_configured():
+        raise WhatsAppError("WhatsApp Cloud API is not configured (missing phone id/token).")
+
+    url = whatsapp_config.graph_url(f"{whatsapp_config.PHONE_NUMBER_ID}/media")
+    files = {"file": (filename, content, mime_type)}
+    data = {"messaging_product": "whatsapp"}
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(url, data=data, files=files, headers=_auth_headers())
+
+    if resp.status_code >= 400:
+        error = _parse_api_error(resp)
+        logger.warning("WhatsApp media upload failed (%s): %s", error.code, error.message)
+        raise error
+
+    media_id = resp.json().get("id")
+    if not media_id:
+        raise WhatsAppError(f"Unexpected media upload response: {resp.text}")
+    return str(media_id)
+
+
+async def send_media(
+    to: str,
+    media_type: str,
+    media_id: str,
+    caption: Optional[str] = None,
+    filename: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Send a previously uploaded media object. Returns {"wa_message_id": ...}.
+
+    ``media_type`` must be one of image/audio/video/document. The Cloud API
+    accepts ``caption`` only for image/video/document (audio rejects it) and
+    ``filename`` only for document.
+    """
+    if not whatsapp_config.is_send_configured():
+        raise WhatsAppError("WhatsApp Cloud API is not configured (missing phone id/token).")
+    if media_type not in {"image", "audio", "video", "document"}:
+        raise WhatsAppError(f"Tipo de media no soportado para envío: {media_type}")
+
+    media_obj: Dict[str, Any] = {"id": media_id}
+    if caption and media_type != "audio":
+        media_obj["caption"] = caption
+    if filename and media_type == "document":
+        media_obj["filename"] = filename
+
+    url = whatsapp_config.graph_url(f"{whatsapp_config.PHONE_NUMBER_ID}/messages")
+    payload = {
+        "messaging_product": "whatsapp",
+        "recipient_type": "individual",
+        "to": to,
+        "type": media_type,
+        media_type: media_obj,
+    }
+    headers = {**_auth_headers(), "Content-Type": "application/json"}
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(url, json=payload, headers=headers)
+
+    if resp.status_code >= 400:
+        error = _parse_api_error(resp)
+        logger.warning("WhatsApp media send failed (%s): %s", error.code, error.message)
+        raise error
+
+    data = resp.json()
+    try:
+        wa_message_id = data["messages"][0]["id"]
+    except (KeyError, IndexError):
+        raise WhatsAppError(f"Unexpected send response: {data}")
+    return {"wa_message_id": wa_message_id}
+
+
 async def get_media_metadata(media_id: str) -> Dict[str, Any]:
     """Resolve a media id to its temporary download URL and metadata."""
     url = whatsapp_config.graph_url(media_id)

--- a/app/services/whatsapp_ingest_service.py
+++ b/app/services/whatsapp_ingest_service.py
@@ -116,6 +116,7 @@ async def _process_message(
             media_type=msg_type,
             mime_type=media_obj.get("mime_type"),
             caption=media_obj.get("caption"),
+            cloud_media_id=media_obj["id"],
         )
         pending_media.append((media_row.id, media_obj["id"]))
 

--- a/app/services/whatsapp_media_service.py
+++ b/app/services/whatsapp_media_service.py
@@ -37,8 +37,16 @@ def schedule_download(media_row_id: int, cloud_media_id: str) -> None:
     task.add_done_callback(_background_tasks.discard)
 
 
+MAX_ATTEMPTS = 3
+
+
 async def _download_and_store(media_row_id: int, cloud_media_id: str) -> None:
-    async with async_session_factory() as db:
+    last_error: Exception | None = None
+    for attempt in range(MAX_ATTEMPTS):
+        if attempt:
+            # 2s then 8s. Re-resolving the metadata below is mandatory: the
+            # temporary download URL Meta returns expires within minutes.
+            await asyncio.sleep(2 * 4 ** (attempt - 1))
         try:
             meta = await cloud.get_media_metadata(cloud_media_id)
             media_url = meta.get("url")
@@ -54,21 +62,30 @@ async def _download_and_store(media_row_id: int, cloud_media_id: str) -> None:
             UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
             (UPLOAD_DIR / filename).write_bytes(data)
 
-            await mark_media_downloaded(
-                db,
-                media_row_id,
-                sha256=sha,
-                filename=filename,
-                file_size=len(data),
-                media_url=f"/uploads/whatsapp/{filename}",
-                mime_type=mime_type,
-            )
-            await db.commit()
-            logger.info("Downloaded WhatsApp media %s -> %s", cloud_media_id, filename)
-        except Exception as e:  # noqa: BLE001
-            logger.warning("Failed to download media %s: %s", cloud_media_id, e)
-            try:
-                await mark_media_failed(db, media_row_id)
+            async with async_session_factory() as db:
+                await mark_media_downloaded(
+                    db,
+                    media_row_id,
+                    sha256=sha,
+                    filename=filename,
+                    file_size=len(data),
+                    media_url=f"/uploads/whatsapp/{filename}",
+                    mime_type=mime_type,
+                )
                 await db.commit()
-            except Exception:  # noqa: BLE001
-                await db.rollback()
+            logger.info("Downloaded WhatsApp media %s -> %s", cloud_media_id, filename)
+            return
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            logger.warning(
+                "Failed to download media %s (attempt %d/%d): %s",
+                cloud_media_id, attempt + 1, MAX_ATTEMPTS, e,
+            )
+
+    logger.error("Giving up on media %s: %s", cloud_media_id, last_error)
+    async with async_session_factory() as db:
+        try:
+            await mark_media_failed(db, media_row_id)
+            await db.commit()
+        except Exception:  # noqa: BLE001
+            await db.rollback()


### PR DESCRIPTION
## Resumen
Soporte multimedia end-to-end para el chat de WhatsApp (recepción + envío).

- **Metadatos de media en GraphQL**: `ChatMessage` ahora expone objeto anidado `media { mediaType mimeType filename caption fileSize mediaUrl downloaded downloadFailed }` (se conserva `mediaUrl` plano por compatibilidad). Actualizado CRUD y eager-load del último mensaje.
- **Envío outbound**: `cloud.upload_media` / `cloud.send_media` + mutation `sendMediaMessage` (Upload multipart) con validación de MIME/tamaño reusando `validate_media`. Guarda copia local en `/uploads/whatsapp/` para render inmediato.
- **Evento realtime `media_updated`**: `pg_notify` a nivel de aplicación desde `mark_media_downloaded`/`mark_media_failed` (sin trigger DDL nuevo) + nueva suscripción `messageUpdated`.
- **Reintentos de descarga**: backoff re-resolviendo la metadata de Meta (la URL temporal expira en minutos) + mutation `retryMediaDownload`. Persiste `cloud_media_id`.
- **Migración `e7a8b9c0d1f2`**: agrega `app.media.cloud_media_id` (+ índice). Idempotente (`IF NOT EXISTS`). Padre: `d4e5f6a7b8c9` (estado actual de prod).

## Deploy / migración
Tras mergear a `main` y que Coolify reconstruya, correr dentro del contenedor:
`alembic upgrade head` (aplicará solo `e7a8b9c0d1f2`).

## Notas
- `/uploads/whatsapp/` es disco local del contenedor → montar volumen persistente o los archivos se pierden en redeploy.
- El frontend (cliente de escritorio) va en repo aparte; este PR es solo backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)