### PR TITLE
feat(whatsapp): persistir media de chat en object storage (MinIO)

### DIFF
--- a/app/graphql/whatsapp/mutations.py
+++ b/app/graphql/whatsapp/mutations.py
@@ -158,18 +158,23 @@ class WhatsAppChatMutation:
             logger.exception("Unexpected error sending WhatsApp media")
             return SendMessageResult(success=False, error=str(e))
 
-        # Local copy, same naming convention as inbound downloads.
+        # Persist a copy so the bubble renders immediately. Prefers object
+        # storage (MinIO/R2 — survives redeploys), falls back to local /uploads.
+        sha = hashlib.sha256(raw).hexdigest()
         ext = Path(original_filename).suffix.lower() or (
             mimetypes.guess_extension(mime_type) or ""
         )
-        stored_filename = f"{media_id}{ext}"
         try:
-            media_service.UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
-            (media_service.UPLOAD_DIR / stored_filename).write_bytes(raw)
-            local_url = f"/uploads/whatsapp/{stored_filename}"
-        except OSError:
-            logger.exception("Could not store local copy of sent media %s", media_id)
-            local_url = None
+            stored_url = await media_service.store_media_bytes(
+                raw,
+                sha256=sha,
+                ext=ext,
+                filename=f"{media_id}{ext}",
+                mime_type=mime_type,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("Could not store sent media %s", media_id)
+            stored_url = None
 
         message = await crud.insert_outbound_message(
             db,
@@ -186,8 +191,8 @@ class WhatsAppChatMutation:
             mime_type=mime_type,
             filename=original_filename,
             file_size=len(raw),
-            sha256=hashlib.sha256(raw).hexdigest(),
-            media_url=local_url,
+            sha256=sha,
+            media_url=stored_url,
             caption=caption,
             cloud_media_id=media_id,
         )

--- a/app/services/whatsapp_media_assets_service.py
+++ b/app/services/whatsapp_media_assets_service.py
@@ -236,6 +236,14 @@ async def _put_object(storage_key: str, raw: bytes, mime_type: str) -> None:
         raise MediaAssetError(f"No se pudo subir el archivo a R2/S3: {exc}") from exc
 
 
+async def store_object(storage_key: str, raw: bytes, mime_type: str) -> str:
+    """Upload arbitrary bytes to the configured object storage and return the
+    public URL. Reuses the same S3/R2/MinIO backend as template assets, so chat
+    media persists across container redeploys (unlike the local /uploads mount)."""
+    await _put_object(storage_key, raw, mime_type)
+    return public_url_from_key(storage_key)
+
+
 def _detect_mime_type(file, filename: str) -> str:
     content_type = str(getattr(file, "content_type", "") or "").split(";")[0].strip()
     if content_type:

--- a/app/services/whatsapp_media_service.py
+++ b/app/services/whatsapp_media_service.py
@@ -1,25 +1,46 @@
-"""Download inbound WhatsApp media to local storage.
+"""Download inbound WhatsApp media and persist it.
 
 Media arrives by reference (a media id) in the webhook. We resolve the id to a
-temporary URL, download the bytes (authenticated), store them under
-``backend/uploads/whatsapp/`` (served by the existing ``/uploads`` static mount) and
-update the ``media`` row. Downloads run as background tasks so the webhook can return
-200 immediately.
+temporary URL, download the bytes (authenticated), and store them. Storage
+prefers the configured object store (MinIO/R2 — survives container redeploys)
+and falls back to the local ``backend/uploads/whatsapp/`` mount for local dev.
+Downloads run as background tasks so the webhook can return 200 immediately.
 """
 import asyncio
 import hashlib
 import logging
 import mimetypes
 from pathlib import Path
-from typing import Set
+from typing import Optional, Set
 
+from app.core.media_storage_config import media_storage_config
 from app.db.postgresql import async_session_factory
 from app.services import whatsapp_cloud_service as cloud
+from app.services import whatsapp_media_assets_service as media_assets
 from app.crud.whatsappCrud import mark_media_downloaded, mark_media_failed
 
 logger = logging.getLogger(__name__)
 
 UPLOAD_DIR = Path(__file__).resolve().parent.parent.parent / "uploads" / "whatsapp"
+
+
+async def store_media_bytes(
+    data: bytes, *, sha256: str, ext: str, filename: str, mime_type: Optional[str]
+) -> str:
+    """Persist chat media bytes and return the value for ``media.media_url``.
+
+    Uses object storage (MinIO/R2, served via ``MEDIA_PUBLIC_BASE_URL``) when
+    configured so files survive redeploys; otherwise writes to the local
+    ``/uploads`` mount (dev). Used by both inbound downloads and outbound sends.
+    """
+    if media_storage_config.is_configured():
+        key = f"whatsapp/chat/{sha256}{ext}"
+        return await media_assets.store_object(
+            key, data, mime_type or "application/octet-stream"
+        )
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    (UPLOAD_DIR / filename).write_bytes(data)
+    return f"/uploads/whatsapp/{filename}"
 
 # Keep strong references so background tasks are not garbage-collected.
 _background_tasks: Set["asyncio.Task"] = set()
@@ -59,8 +80,9 @@ async def _download_and_store(media_row_id: int, cloud_media_id: str) -> None:
             ext = mimetypes.guess_extension(mime_type or "") or ""
             filename = f"{cloud_media_id}{ext}"
 
-            UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
-            (UPLOAD_DIR / filename).write_bytes(data)
+            stored_url = await store_media_bytes(
+                data, sha256=sha, ext=ext, filename=filename, mime_type=mime_type
+            )
 
             async with async_session_factory() as db:
                 await mark_media_downloaded(
@@ -69,7 +91,7 @@ async def _download_and_store(media_row_id: int, cloud_media_id: str) -> None:
                     sha256=sha,
                     filename=filename,
                     file_size=len(data),
-                    media_url=f"/uploads/whatsapp/{filename}",
+                    media_url=stored_url,
                     mime_type=mime_type,
                 )
                 await db.commit()


### PR DESCRIPTION
## Problema
La media de chat (descargas inbound y envíos outbound) se guardaba en el mount local `/uploads`, que es **efímero en Coolify**: cada redeploy borra los archivos y las imágenes ya renderizadas dan 404. Confirmado en prod: tras el último deploy, `/app/uploads` quedó vacío y las filas con `downloaded=1` apuntan a archivos inexistentes.

## Solución
Reutiliza el mismo backend S3/R2/MinIO que los assets de plantilla (que sí persisten y se sirven por `media.fitpilot.fit`):
- Nuevo helper `store_object()` en `whatsapp_media_assets_service`.
- Nuevo `store_media_bytes()` en `whatsapp_media_service`: sube a `whatsapp/chat/{sha256}{ext}` y devuelve la URL pública (`MEDIA_PUBLIC_BASE_URL`); cae a `/uploads` local solo si el object storage no está configurado (dev).
- Inbound (`_download_and_store`) y outbound (`sendMediaMessage`) usan el helper.

**Sin cambios de schema.** El frontend ya resuelve URLs absolutas (`ChatMedia.absolute_url`).

## Notas
- Media histórica ya borrada por redeploys: no se recupera sola; las filas con `cloud_media_id` se pueden re-descargar con `retryMediaDownload` (y ahora quedarán en MinIO).
- Requiere que `MEDIA_*` estén configuradas en el backend (ya lo están en prod: los assets de plantilla funcionan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)