### PR TITLE
feat(whatsapp): reacciones de mensajes (render + envío)

### DIFF
--- a/app/crud/whatsappCrud.py
+++ b/app/crud/whatsappCrud.py
@@ -97,6 +97,7 @@ class ChatMessageData:
     text_content: Optional[str]
     timestamp: datetime
     wa_message_id: Optional[str]
+    context_message_id: Optional[str] = None
     media_url: Optional[str] = None
     media: Optional[ChatMediaData] = None
 
@@ -121,6 +122,7 @@ class ChatMessageData:
             text_content=m.text_content,
             timestamp=m.timestamp,
             wa_message_id=m.wa_message_id,
+            context_message_id=m.context_message_id,
             media_url=media.media_url if media else None,
             media=media,
         )
@@ -393,6 +395,7 @@ def _last_activity_subquery():
             Message.conversation_id.label("cid"),
             func.max(Message.timestamp).label("last_activity"),
         )
+        .where(Message.message_type != "reaction")  # reactions don't reorder the list
         .group_by(Message.conversation_id)
         .subquery()
     )
@@ -516,6 +519,7 @@ async def _latest_message_per_conversation(
         select(Message)
         .options(selectinload(Message.media))
         .where(Message.conversation_id.in_(conv_ids))
+        .where(Message.message_type != "reaction")  # reactions never become the preview
         .distinct(Message.conversation_id)
         .order_by(
             Message.conversation_id,
@@ -764,6 +768,7 @@ async def insert_outbound_message(
     wa_message_id: Optional[str] = None,
     message_type: str = "text",
     template_id: Optional[int] = None,
+    context_message_id: Optional[str] = None,
 ) -> Message:
     """Insert an outbound message after a successful Cloud API send. Caller commits."""
     now = datetime.utcnow()
@@ -775,6 +780,7 @@ async def insert_outbound_message(
         message_type=message_type,
         text_content=text,
         template_id=template_id,
+        context_message_id=context_message_id,
         timestamp=now,
         created_at=now,
         is_processed=1,

--- a/app/graphql/whatsapp/mutations.py
+++ b/app/graphql/whatsapp/mutations.py
@@ -13,6 +13,7 @@ from strawberry.types import Info
 from app.crud import whatsappCrud as crud
 from app.graphql.whatsapp.types import (
     SendMediaMessageInput,
+    SendReactionInput,
     SendTextMessageInput,
     SendMessageResult,
     ChatMessage,
@@ -102,6 +103,57 @@ class WhatsAppChatMutation:
             contact_id=contact.id,
             text=text,
             wa_message_id=result.get("wa_message_id"),
+        )
+        await db.commit()
+
+        return SendMessageResult(
+            success=True,
+            message=ChatMessage.from_data(crud.ChatMessageData.from_model(message)),
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def send_reaction(
+        self, info: Info, input: SendReactionInput
+    ) -> SendMessageResult:
+        """React to a message via the Cloud API and persist the outbound reaction.
+
+        ``input.emoji == ""`` removes a previously sent reaction. ``input.message_id``
+        is the wa_message_id of the target message.
+        """
+        db: AsyncSession = info.context.db
+
+        target_wa_id = (input.message_id or "").strip()
+        if not target_wa_id:
+            return SendMessageResult(success=False, error="Falta el mensaje a reaccionar.")
+
+        contact, conversation, error = await _resolve_target(
+            db, input.conversation_id, input.wa_id
+        )
+        if error:
+            return SendMessageResult(success=False, error=error)
+
+        emoji = input.emoji or ""
+        try:
+            result = await cloud.send_reaction(
+                to=contact.wa_id, message_id=target_wa_id, emoji=emoji
+            )
+        except cloud.WhatsAppError as e:
+            await db.rollback()
+            return SendMessageResult(success=False, error=e.message)
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            logger.exception("Unexpected error sending WhatsApp reaction")
+            return SendMessageResult(success=False, error=str(e))
+
+        # Persist the outbound reaction (the DB trigger fans it out to subscribers).
+        message = await crud.insert_outbound_message(
+            db,
+            conversation_id=conversation.id,
+            contact_id=contact.id,
+            text=emoji,
+            wa_message_id=result.get("wa_message_id"),
+            message_type="reaction",
+            context_message_id=target_wa_id,
         )
         await db.commit()
 

--- a/app/graphql/whatsapp/types.py
+++ b/app/graphql/whatsapp/types.py
@@ -79,6 +79,7 @@ class ChatMessage:
     text_content: Optional[str]
     timestamp: datetime
     wa_message_id: Optional[str]
+    context_message_id: Optional[str]  # reacted-to / referenced message wa id
     media_url: Optional[str]  # deprecated: kept for older clients, use ``media``
     media: Optional[ChatMessageMedia]
 
@@ -93,6 +94,7 @@ class ChatMessage:
             text_content=d.text_content,
             timestamp=d.timestamp,
             wa_message_id=d.wa_message_id,
+            context_message_id=d.context_message_id,
             media_url=d.media_url,
             media=ChatMessageMedia.from_data(d.media) if d.media else None,
         )
@@ -131,6 +133,14 @@ class SendMediaMessageInput:
     conversation_id: Optional[int] = None
     wa_id: Optional[str] = None
     caption: Optional[str] = None
+
+
+@strawberry.input
+class SendReactionInput:
+    message_id: str  # wa_message_id of the target message
+    emoji: str = ""  # empty string removes the reaction
+    conversation_id: Optional[int] = None
+    wa_id: Optional[str] = None
 
 
 @strawberry.type

--- a/app/services/whatsapp_cloud_service.py
+++ b/app/services/whatsapp_cloud_service.py
@@ -187,6 +187,41 @@ async def send_text(to: str, text: str) -> Dict[str, Any]:
     return {"wa_message_id": wa_message_id}
 
 
+async def send_reaction(to: str, message_id: str, emoji: str) -> Dict[str, Any]:
+    """React to a message with an emoji. Returns {"wa_message_id": ...}.
+
+    ``emoji=""`` removes a previously sent reaction. ``message_id`` is the
+    wa_message_id of the target message. Raises WhatsAppError on failure.
+    """
+    if not whatsapp_config.is_send_configured():
+        raise WhatsAppError("WhatsApp Cloud API is not configured (missing phone id/token).")
+
+    url = whatsapp_config.graph_url(f"{whatsapp_config.PHONE_NUMBER_ID}/messages")
+    payload = {
+        "messaging_product": "whatsapp",
+        "recipient_type": "individual",
+        "to": to,
+        "type": "reaction",
+        "reaction": {"message_id": message_id, "emoji": emoji},
+    }
+    headers = {**_auth_headers(), "Content-Type": "application/json"}
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(url, json=payload, headers=headers)
+
+    if resp.status_code >= 400:
+        error = _parse_api_error(resp)
+        logger.warning("WhatsApp reaction send failed (%s): %s", error.code, error.message)
+        raise error
+
+    data = resp.json()
+    try:
+        wa_message_id = data["messages"][0]["id"]
+    except (KeyError, IndexError):
+        raise WhatsAppError(f"Unexpected send response: {data}")
+    return {"wa_message_id": wa_message_id}
+
+
 async def send_template(
     to: str,
     template_name: str,

--- a/app/services/whatsapp_ingest_service.py
+++ b/app/services/whatsapp_ingest_service.py
@@ -87,13 +87,19 @@ async def _process_message(
 
     text_content: Optional[str] = None
     media_obj: Dict[str, Any] = {}
+    context_message_id = (msg.get("context") or {}).get("id")
     if msg_type == "text":
         text_content = (msg.get("text") or {}).get("body")
     elif msg_type in MEDIA_TYPES:
         media_obj = msg.get(msg_type) or {}
         text_content = media_obj.get("caption")
-
-    context_message_id = (msg.get("context") or {}).get("id")
+    elif msg_type == "reaction":
+        # Reactions carry a ``reaction`` object (not a ``context``): store the emoji
+        # in text_content and the reacted-to message id in context_message_id. An
+        # empty emoji means the reaction was removed (kept verbatim).
+        reaction = msg.get("reaction") or {}
+        text_content = reaction.get("emoji")
+        context_message_id = reaction.get("message_id")
 
     message = await crud.insert_inbound_message(
         db,

--- a/tests/test_whatsapp_reactions.py
+++ b/tests/test_whatsapp_reactions.py
@@ -1,0 +1,157 @@
+"""Tests for WhatsApp message reactions (inbound capture + outbound send).
+
+Inbound: the webhook ingest must store the reaction emoji in ``text_content`` and the
+reacted-to message id in ``context_message_id`` (no dedicated columns / migration).
+Outbound: the ``sendReaction`` mutation must call the Cloud API and persist an outbound
+reaction row carrying the same emoji + target.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from app.graphql.whatsapp.mutations import WhatsAppChatMutation
+from app.models import Message
+from app.services.whatsapp_ingest_service import _process_message
+
+WA_ID = "5218710000001"
+TARGET_WAMID = "wamid.target123"
+
+
+def _reaction_msg(wa_message_id: str, target: str, emoji: str) -> dict:
+    return {
+        "from": WA_ID,
+        "id": wa_message_id,
+        "timestamp": "1700000000",
+        "type": "reaction",
+        "reaction": {"message_id": target, "emoji": emoji},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Inbound ingest
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_ingest_reaction_stores_emoji_and_target(db):
+    msg_id = await _process_message(db, _reaction_msg("wamid.r1", TARGET_WAMID, "👍"), {}, [])
+    await db.flush()
+
+    row = (await db.execute(select(Message).where(Message.id == msg_id))).scalars().first()
+    assert row is not None
+    assert row.message_type == "reaction"
+    assert row.direction == "inbound"
+    assert row.text_content == "👍"
+    assert row.context_message_id == TARGET_WAMID
+
+
+@pytest.mark.asyncio
+async def test_ingest_reaction_removal_stores_empty_emoji(db):
+    # WhatsApp sends an empty emoji when the reaction is removed.
+    msg_id = await _process_message(db, _reaction_msg("wamid.r2", TARGET_WAMID, ""), {}, [])
+    await db.flush()
+
+    row = (await db.execute(select(Message).where(Message.id == msg_id))).scalars().first()
+    assert row is not None
+    assert row.message_type == "reaction"
+    assert row.text_content == ""  # not coerced to NULL — the frontend reads it as "remove"
+    assert row.context_message_id == TARGET_WAMID
+
+
+# ---------------------------------------------------------------------------
+# Outbound send mutation
+# ---------------------------------------------------------------------------
+class _FakeDb:
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+def _reaction_message(emoji: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        conversation_id=2,
+        contact_id=3,
+        direction="outbound",
+        message_type="reaction",
+        text_content=emoji,
+        timestamp=datetime.now(timezone.utc),
+        wa_message_id="wamid.react.out",
+        context_message_id=TARGET_WAMID,
+    )
+
+
+async def _run_send_reaction(monkeypatch, emoji: str) -> tuple:
+    cloud_kwargs: dict = {}
+    insert_kwargs: dict = {}
+
+    async def fake_get_conversation(_db, _cid):
+        return SimpleNamespace(id=2, contact=SimpleNamespace(id=3, wa_id="5215555555555"))
+
+    async def fake_send_reaction(**kwargs):
+        cloud_kwargs.update(kwargs)
+        return {"wa_message_id": "wamid.react.out"}
+
+    async def fake_insert_outbound_message(*_args, **kwargs):
+        insert_kwargs.update(kwargs)
+        return _reaction_message(emoji)
+
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.crud.get_conversation", fake_get_conversation
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.cloud.send_reaction", fake_send_reaction
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.crud.insert_outbound_message",
+        fake_insert_outbound_message,
+    )
+
+    info = SimpleNamespace(context=SimpleNamespace(db=_FakeDb()))
+    input_data = SimpleNamespace(
+        message_id=TARGET_WAMID, emoji=emoji, conversation_id=2, wa_id=None
+    )
+    result = await WhatsAppChatMutation().send_reaction(info, input_data)
+    return result, cloud_kwargs, insert_kwargs
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_persists_outbound_reaction(monkeypatch):
+    result, cloud_kwargs, insert_kwargs = await _run_send_reaction(monkeypatch, "👍")
+
+    assert result.success is True
+    assert result.message.message_type == "reaction"
+    assert result.message.text_content == "👍"
+    assert result.message.context_message_id == TARGET_WAMID
+
+    # Cloud API received the right reaction payload.
+    assert cloud_kwargs["message_id"] == TARGET_WAMID
+    assert cloud_kwargs["emoji"] == "👍"
+    assert cloud_kwargs["to"] == "5215555555555"
+
+    # Persisted as an outbound reaction with the target reference.
+    assert insert_kwargs["message_type"] == "reaction"
+    assert insert_kwargs["context_message_id"] == TARGET_WAMID
+    assert insert_kwargs["text"] == "👍"
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_removal_sends_empty_emoji(monkeypatch):
+    result, cloud_kwargs, insert_kwargs = await _run_send_reaction(monkeypatch, "")
+
+    assert result.success is True
+    assert cloud_kwargs["emoji"] == ""
+    assert insert_kwargs["text"] == ""
+    assert insert_kwargs["message_type"] == "reaction"
+
+
+@pytest.mark.asyncio
+async def test_send_reaction_requires_target(monkeypatch):
+    info = SimpleNamespace(context=SimpleNamespace(db=_FakeDb()))
+    input_data = SimpleNamespace(message_id="", emoji="👍", conversation_id=2, wa_id=None)
+    result = await WhatsAppChatMutation().send_reaction(info, input_data)
+    assert result.success is False


### PR DESCRIPTION
## Contexto / urgencia
El frontend desplegado ya consulta `contextMessageId` (feature de reacciones), pero el schema de prod no lo tiene → **el chat carga vacío y la suscripción WS entra en bucle de reconexión**. Este PR despliega el backend de reacciones y lo arregla.

## Cambios (sin migración)
Reusa columnas existentes de `messages`: emoji → `text_content`, wa_message_id objetivo → `context_message_id`, distinguido por `message_type='reaction'` (emoji vacío = removida).
- Ingest parsea el objeto `reaction` entrante.
- `ChatMessage` expone `context_message_id` (`contextMessageId`).
- Nuevo `cloud.send_reaction` + mutation `sendReaction` (`SendReactionInput`); `insert_outbound_message` recibe `context_message_id`.
- Reacciones excluidas de las queries de la lista de chats (no reordenan ni aparecen como preview).

## Verificación
Compila; el schema expone `contextMessageId`/`sendReaction`/`SendReactionInput`; tests unitarios de `tests/test_whatsapp_reactions.py` pasan (los 2 de ingest requieren Postgres local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)