### PR TITLE
feat(whatsapp): renderizar header de imagen en mensajes de plantilla

### DIFF
--- a/app/graphql/whatsapp/template_mutations.py
+++ b/app/graphql/whatsapp/template_mutations.py
@@ -352,9 +352,25 @@ class WhatsAppTemplateMutation:
             message_type="template",
             template_id=tpl.id,
         )
+        # Persist the header media so the chat bubble can render it (same public
+        # asset URL sent to Meta). Only when there is a fetchable URL.
+        if resolved_media.media_url and resolved_media.media_format:
+            await chat_crud.insert_outbound_media(
+                db,
+                message_id=message.id,
+                media_type=resolved_media.media_format.lower(),
+                mime_type=None,
+                filename=None,
+                file_size=None,
+                sha256=None,
+                media_url=resolved_media.media_url,
+                cloud_media_id=resolved_media.media_id,
+            )
         await db.commit()
 
+        # Re-fetch with the media relation eager-loaded so the result carries it.
+        data = await chat_crud.get_message_by_id(db, message.id)
         return SendMessageResult(
             success=True,
-            message=ChatMessage.from_data(chat_crud.ChatMessageData.from_model(message)),
+            message=ChatMessage.from_data(data) if data else None,
         )

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -305,7 +305,7 @@ async def dispatch(
             pass
         return "failed"
 
-    await chat_crud.insert_outbound_message(
+    message = await chat_crud.insert_outbound_message(
         db,
         conversation_id=conversation.id,
         contact_id=contact.id,
@@ -314,6 +314,20 @@ async def dispatch(
         message_type="template",
         template_id=tpl.id,
     )
+    # Persist the header media so the chat bubble can render it (the same public
+    # asset URL sent to Meta). Only when there is a fetchable URL (asset/legacy).
+    if resolved_media.media_url and resolved_media.media_format:
+        await chat_crud.insert_outbound_media(
+            db,
+            message_id=message.id,
+            media_type=resolved_media.media_format.lower(),
+            mime_type=None,
+            filename=None,
+            file_size=None,
+            sha256=None,
+            media_url=resolved_media.media_url,
+            cloud_media_id=resolved_media.media_id,
+        )
     await crud.mark_log(
         db, log, status="sent", wa_message_id=result.get("wa_message_id"), commit=True
     )


### PR DESCRIPTION
## Problema
Los mensajes salientes de plantilla (notificaciones automáticas y "Enviar prueba") se persistían como `message_type='template'` **sin fila `media`**, así que la burbuja del chat solo mostraba el texto del cuerpo — nunca la imagen del header, aunque sí se enviaba a Meta.

## Cambio (sin migración)
Tras `insert_outbound_message`, se persiste el header resuelto como fila `media` (`insert_outbound_media`, `downloaded=1`) usando la misma URL pública del asset que se manda a Meta (`resolve_template_send_header_media`), cuando hay URL servible. La mutation de prueba re-consulta el mensaje para que el resultado traiga la media.
- `app/services/notification_service.py` (`dispatch`)
- `app/graphql/whatsapp/template_mutations.py` (`send_template_test`)

Reusa `insert_outbound_media` y `get_message_by_id`. El frontend rinde la imagen con un ajuste de 1 línea (repo aparte). Solo aplica a envíos nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)