### PR TITLE
harden(chatbot/mercadopago): race-safe + refund-safe payment webhook

### DIFF
--- a/app/crud/chatbotPendingCrud.py
+++ b/app/crud/chatbotPendingCrud.py
@@ -17,6 +17,7 @@ from app.models.chatbotModel import (
     PENDING_STATUS_CANCELED,
     PENDING_STATUS_EXPIRED,
     PENDING_STATUS_PENDING,
+    PENDING_STATUS_PROCESSING,
 )
 
 DEFAULT_TTL_MINUTES = 30
@@ -51,15 +52,16 @@ async def get_pending(
 async def get_active_pending(
     db: AsyncSession, conversation_id: int
 ) -> Optional[ChatbotPendingAction]:
-    """Return the active action (status ``pending`` or ``awaiting_payment``), or None.
+    """Return the active action (``pending``, ``awaiting_payment`` or ``processing``), or None.
 
-    Used to inject the pending state into the agent context so it confirms / reminds-to-pay
-    instead of re-proposing. Expired rows are flagged and not returned.
+    Used to inject the pending state into the agent context so it confirms / reminds-to-pay /
+    waits-while-processing instead of re-proposing (a re-propose mid-``processing`` would clobber
+    the row the payment webhook is executing on). Expired rows are flagged and not returned.
     """
     stmt = select(ChatbotPendingAction).where(
         ChatbotPendingAction.conversation_id == conversation_id,
         ChatbotPendingAction.status.in_(
-            [PENDING_STATUS_PENDING, PENDING_STATUS_AWAITING_PAYMENT]
+            [PENDING_STATUS_PENDING, PENDING_STATUS_AWAITING_PAYMENT, PENDING_STATUS_PROCESSING]
         ),
     )
     row = (await db.execute(stmt)).scalars().first()
@@ -74,14 +76,21 @@ async def get_active_pending(
 
 
 async def get_by_external_reference(
-    db: AsyncSession, external_reference: str
+    db: AsyncSession, external_reference: str, *, for_update: bool = False
 ) -> Optional[ChatbotPendingAction]:
-    """Look up a pending action by its MercadoPago ``external_reference`` (webhook matching)."""
+    """Look up a pending action by its MercadoPago ``external_reference`` (webhook matching).
+
+    With ``for_update=True`` the row is locked (``SELECT ... FOR UPDATE``) so concurrent duplicate
+    webhooks for the same payment serialize: the second blocks until the first commits its claim.
+    Must be called inside a transaction.
+    """
     if not external_reference:
         return None
     stmt = select(ChatbotPendingAction).where(
         ChatbotPendingAction.external_reference == external_reference
     )
+    if for_update:
+        stmt = stmt.with_for_update()
     return (await db.execute(stmt)).scalars().first()
 
 

--- a/app/models/chatbotModel.py
+++ b/app/models/chatbotModel.py
@@ -30,6 +30,7 @@ from app.db.postgresql import Base
 # Pending action lifecycle.
 PENDING_STATUS_PENDING = "pending"
 PENDING_STATUS_AWAITING_PAYMENT = "awaiting_payment"  # MercadoPago link sent, awaiting webhook
+PENDING_STATUS_PROCESSING = "processing"  # claimed by the payment webhook; executing the purchase
 PENDING_STATUS_CONFIRMED = "confirmed"
 PENDING_STATUS_CANCELED = "canceled"
 PENDING_STATUS_EXPIRED = "expired"

--- a/app/services/chatbot/reply_service.py
+++ b/app/services/chatbot/reply_service.py
@@ -26,7 +26,10 @@ from app.crud import whatsappCrud as crud
 from app.crud.chatbotConfigCrud import ChatbotConfigData
 from app.db.postgresql import async_session_factory
 from app.models import Venue
-from app.models.chatbotModel import PENDING_STATUS_AWAITING_PAYMENT
+from app.models.chatbotModel import (
+    PENDING_STATUS_AWAITING_PAYMENT,
+    PENDING_STATUS_PROCESSING,
+)
 from app.services import whatsapp_cloud_service as cloud
 from app.services.chatbot.agent import run_agent
 from app.services.chatbot.tools import ChatbotContext, build_tools
@@ -112,6 +115,12 @@ async def _build_pending_note(db: AsyncSession, conversation_id: int) -> Optiona
     if pending is None:
         return None
     summary = pending.summary or "una compra"
+    if pending.status == PENDING_STATUS_PROCESSING:
+        return (
+            f"⏳ La compra «{summary}» tiene un pago que se está acreditando justo ahora. Pídele al "
+            "cliente que espere unos segundos; le confirmas en cuanto se procese. NO propongas una "
+            "compra nueva ni generes otro link (interrumpirías la compra en curso)."
+        )
     if pending.status == PENDING_STATUS_AWAITING_PAYMENT:
         link = pending.mp_init_point or "(link no disponible)"
         return (

--- a/app/services/mercadopago_service.py
+++ b/app/services/mercadopago_service.py
@@ -87,6 +87,30 @@ async def get_payment(payment_id) -> Dict[str, Any]:
     return resp.json()
 
 
+async def refund_payment(
+    payment_id, amount=None, *, idempotency_key: Optional[str] = None
+) -> Dict[str, Any]:
+    """Refund a payment (full if ``amount`` is None, otherwise partial).
+
+    Used when a purchase is paid but the booking can no longer be honored (e.g. the class filled
+    up between the payment link being sent and the webhook arriving). ``idempotency_key`` is sent
+    as ``X-Idempotency-Key`` so retried webhooks never double-refund.
+    """
+    if not cfg.is_configured():
+        raise MercadoPagoError("MercadoPago no está configurado (falta MP_ACCESS_TOKEN).")
+    url = f"{cfg.API_BASE}/v1/payments/{payment_id}/refunds"
+    headers = {**_auth_headers(), "Content-Type": "application/json"}
+    if idempotency_key:
+        headers["X-Idempotency-Key"] = idempotency_key
+    body: Dict[str, Any] = {} if amount is None else {"amount": float(amount)}
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(url, json=body, headers=headers)
+    if resp.status_code >= 400:
+        logger.warning("MercadoPago refund failed (%s): %s", resp.status_code, resp.text[:300])
+        raise MercadoPagoError(f"No se pudo reembolsar el pago (HTTP {resp.status_code}).")
+    return resp.json()
+
+
 def verify_webhook_signature(
     *, x_signature: Optional[str], x_request_id: Optional[str], data_id: Optional[str]
 ) -> bool:

--- a/app/webhooks/mercadopago_webhook.py
+++ b/app/webhooks/mercadopago_webhook.py
@@ -6,18 +6,30 @@ and (idempotently) execute the purchase + notify the customer on WhatsApp. Alway
 MercadoPago does not retry indefinitely.
 """
 import logging
+from datetime import datetime, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
+from sqlalchemy import select
 
 from app.crud import chatbotPendingCrud
 from app.crud import whatsappCrud
 from app.db.postgresql import async_session_factory
-from app.models.chatbotModel import PENDING_STATUS_AWAITING_PAYMENT, PENDING_STATUS_CONFIRMED
+from app.models.chatbotModel import (
+    ChatbotPendingAction,
+    PENDING_STATUS_AWAITING_PAYMENT,
+    PENDING_STATUS_CANCELED,
+    PENDING_STATUS_CONFIRMED,
+    PENDING_STATUS_PROCESSING,
+)
 from app.services import mercadopago_service
 
 logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
 
 router = APIRouter(tags=["mercadopago-webhook"])
 
@@ -91,17 +103,29 @@ async def _process_approved_payment(payment_id: str) -> None:
     from app.services.chatbot.tools import _execute_pending
 
     async with async_session_factory() as db:
-        pending = await chatbotPendingCrud.get_by_external_reference(db, external_reference)
-        if pending is None:
-            logger.warning("MercadoPago: no pending action for ref %s", external_reference)
-            return
-        if pending.status != PENDING_STATUS_AWAITING_PAYMENT:
-            # Idempotent: already confirmed/canceled/expired.
-            logger.info("MercadoPago: pending %s already %s; skipping", pending.id, pending.status)
-            return
-        # Capture before any rollback (rolled-back ORM attributes lazy-load -> MissingGreenlet).
-        pending_id = pending.id
-        conversation_id = pending.conversation_id
+        # --- Claim the pending row atomically. MercadoPago commonly delivers the same payment
+        #     notification more than once (and concurrently). We lock the row (FOR UPDATE) and flip
+        #     it to 'processing' inside one transaction, so a duplicate webhook blocks, then sees
+        #     'processing'/'confirmed' and skips instead of double-executing the purchase. ---
+        async with db.begin():
+            pending = await chatbotPendingCrud.get_by_external_reference(
+                db, external_reference, for_update=True
+            )
+            if pending is None:
+                await _record_unmatched_payment(db, payment, payment_id, external_reference)
+                return
+            if pending.status != PENDING_STATUS_AWAITING_PAYMENT:
+                # Idempotent: already processing/confirmed/canceled/expired.
+                logger.info("MercadoPago: pending %s already %s; skipping", pending.id, pending.status)
+                return
+            # Capture before any rollback (rolled-back ORM attributes lazy-load -> MissingGreenlet).
+            pending_id = pending.id
+            conversation_id = pending.conversation_id
+            pending.status = PENDING_STATUS_PROCESSING
+            pending.updated_at = _utcnow()
+        # Claim committed -> lock released. We now own this purchase exclusively.
+
+        pending = await db.get(ChatbotPendingAction, pending_id)
         try:
             result = await _execute_pending(
                 db,
@@ -111,9 +135,21 @@ async def _process_approved_payment(payment_id: str) -> None:
                 provider_payment_id=str(payment_id),
                 external_reference=external_reference,
             )
-        except Exception:  # noqa: BLE001
+        except ValueError as exc:
+            # Business/availability failure (e.g. the class filled up between the link being sent
+            # and the payment acreditando). The money WAS captured at MercadoPago -> refund
+            # automatically (unless a payment already committed -> _refund_and_notify guards that).
             await db.rollback()
-            logger.exception("MercadoPago: executing pending %s failed", pending_id)
+            await _refund_and_notify(
+                db, pending_id, conversation_id, str(payment_id), external_reference, str(exc)
+            )
+            return
+        except Exception:  # noqa: BLE001 - transient/unexpected -> release the claim so a retry runs
+            await db.rollback()
+            logger.exception("MercadoPago: executing pending %s failed (transient)", pending_id)
+            await chatbotPendingCrud.mark_status(
+                db, pending_id, PENDING_STATUS_AWAITING_PAYMENT, commit=True
+            )
             await _notify(
                 db, conversation_id,
                 "Recibimos tu pago, pero hubo un problema al confirmar tu lugar. "
@@ -122,6 +158,127 @@ async def _process_approved_payment(payment_id: str) -> None:
             return
         await chatbotPendingCrud.mark_status(db, pending_id, PENDING_STATUS_CONFIRMED, commit=True)
         await _notify(db, conversation_id, f"¡Pago acreditado! {result}")
+
+
+async def _refund_and_notify(
+    db, pending_id: int, conversation_id: int, payment_id: str,
+    external_reference: str, reason: str,
+) -> None:
+    """A captured payment whose booking failed: refund the money and tell the customer.
+
+    SAFETY GUARD: some flows (the fixed-slot *package* path) commit the enrollment mid-transaction
+    — ``generate_sessions_from_template`` commits — *before* the availability assertion raises, so
+    the prior ``db.rollback()`` cannot undo the person/subscription/payment. If a Payment row for
+    this purchase actually committed, we must NOT refund (that would hand out a paid membership for
+    free); we mark it confirmed and flag it for staff reconciliation instead. The clean day-pass
+    path commits nothing on failure, so no payment exists and the refund proceeds.
+    """
+    if await _committed_payment_exists(db, external_reference):
+        logger.error(
+            "MercadoPago: '%s' after a COMMITTED payment (pending %s, ref %s). NOT refunding; "
+            "confirming + flagging for reconciliation.", reason, pending_id, external_reference,
+        )
+        _reconcile(db, "mercadopago_partial_booking", payment_id, external_reference, detail=reason)
+        await chatbotPendingCrud.mark_status(db, pending_id, PENDING_STATUS_CONFIRMED, commit=True)
+        await _notify(
+            db, conversation_id,
+            "¡Pago acreditado! Tu inscripción quedó registrada. Un asesor confirmará los detalles "
+            "de tu horario en breve. 🙏",
+        )
+        return
+
+    logger.warning(
+        "MercadoPago: booking failed after payment (pending %s): %s -> refunding payment %s",
+        pending_id, reason, payment_id,
+    )
+    refunded = False
+    try:
+        await mercadopago_service.refund_payment(
+            payment_id, idempotency_key=f"refund-{payment_id}"
+        )
+        refunded = True
+    except Exception:  # noqa: BLE001 - refund API failure: leave a durable reconciliation record
+        logger.exception("MercadoPago: refund failed for payment %s", payment_id)
+        _reconcile(db, "mercadopago_refund_failed", payment_id, external_reference, detail=reason)
+
+    await chatbotPendingCrud.mark_status(db, pending_id, PENDING_STATUS_CANCELED, commit=True)
+
+    if refunded:
+        msg = (
+            "Lo sentimos 🙏 no pudimos confirmar tu lugar para esa clase (es posible que se haya "
+            "llenado). Te reembolsamos el importe automáticamente; puede tardar unos minutos en "
+            "reflejarse. ¿Te ayudo a reservar otro horario?"
+        )
+    else:
+        msg = (
+            "Lo sentimos 🙏 no pudimos confirmar tu lugar para esa clase. Un asesor gestionará tu "
+            "reembolso a la brevedad."
+        )
+    await _notify(db, conversation_id, msg)
+
+
+async def _committed_payment_exists(db, external_reference: str) -> bool:
+    """True if a Payment row for this purchase already committed (so refunding would be wrong)."""
+    if not external_reference:
+        return False
+    from app.models import Payment
+
+    stmt = select(Payment.id).where(
+        Payment.external_reference == external_reference
+    ).limit(1)
+    return (await db.execute(stmt)).first() is not None
+
+
+def _reconcile(
+    db, event_type: str, payment_id: str, external_reference: str, *, detail=None
+) -> None:
+    """Queue a ``webhook_logs`` reconciliation row (``processed=0``). Caller commits afterwards."""
+    from app.models.whatsappModel import WebhookLog
+
+    db.add(
+        WebhookLog(
+            event_type=event_type,
+            x_request_id=str(payment_id),
+            payload={
+                "payment_id": str(payment_id),
+                "external_reference": external_reference,
+                "detail": detail,
+            },
+            processed=0,
+        )
+    )
+
+
+async def _record_unmatched_payment(
+    db, payment: dict, payment_id: str, external_reference: str
+) -> None:
+    """Persist an approved payment that has no matching pending action, for manual reconciliation.
+
+    This happens if the pending row expired or was superseded before the payment acreditó. Without
+    this, the customer has paid but there is no booking, no payment record and no alert. We log at
+    ERROR and write a ``webhook_logs`` row (``processed=0``) so staff can reconcile/refund.
+    """
+    from app.models.whatsappModel import WebhookLog
+
+    logger.error(
+        "MercadoPago APPROVED payment %s has NO matching pending (ref=%s, amount=%s). "
+        "Recorded for reconciliation.",
+        payment_id, external_reference, payment.get("transaction_amount"),
+    )
+    db.add(
+        WebhookLog(
+            event_type="mercadopago_unmatched_payment",
+            x_request_id=str(payment_id),
+            payload={
+                "payment_id": str(payment_id),
+                "external_reference": external_reference,
+                "status": payment.get("status"),
+                "amount": payment.get("transaction_amount"),
+                "payer": payment.get("payer"),
+            },
+            processed=0,
+        )
+    )
 
 
 async def _notify(db, conversation_id: int, text: str) -> None:


### PR DESCRIPTION
## What
Three hardenings to the MercadoPago purchase webhook, surfaced by an adversarial review of the day-pass go-live test.

1. **Anti-duplicate claim** — `_process_approved_payment` locks the pending row (`SELECT … FOR UPDATE`) and flips it to a new `processing` status inside one transaction *before* executing. MercadoPago's duplicate/concurrent webhook deliveries now block, see `processing`/`confirmed`, and skip — no double-execute, no duplicate person/booking, no false-error-alongside-success.
2. **Auto-refund on availability failure** — if the booking can't be honored after payment (e.g. the class filled up between the link and the acreditación), the captured payment is refunded automatically (idempotent `X-Idempotency-Key`) and the customer is told. **Guarded by `_committed_payment_exists`**: never refunds when a payment actually committed (the fixed-slot *package* path commits the enrollment mid-transaction) — that case is confirmed + flagged for reconciliation instead.
3. **Reconciliation records** — approved payments with no matching pending, and failed auto-refunds, write a `webhook_logs` row (`processed=0`) for staff follow-up. Plus `processing` is surfaced in `get_active_pending` + a wait-note so the agent won't re-propose (and clobber the in-flight row) during the processing window.

## Notes
- **No migration**: `processing` reuses the existing `status` column (no CHECK constraint).
- Verified end-to-end in prod earlier: day-pass purchase → MP link → webhook → reserva #4548 + payment `provider=mercadopago`.
- Reviewed adversarially (concurrency / money-safety / edge); all findings fixed.

## Known follow-up (pre-existing, NOT in this PR)
The **package** (fixed-slot) path commits the enrollment mid-transaction (`generate_sessions_from_template` → `classSessionCrud` commit) *before* the availability assertion. This PR's refund-guard prevents money loss, but the underlying "paid membership committed even though materialization failed" bug affects the manual (MP-off) flow too and should be fixed separately (make session-generation flush-only / single outer commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)