### PR TITLE
fix(memberships): make fixed-slot package enrollment atomic

### DIFF
--- a/app/crud/classSessionCrud.py
+++ b/app/crud/classSessionCrud.py
@@ -107,9 +107,17 @@ async def generate_sessions_from_template(
     db: AsyncSession,
     template_id: int,
     start_date: date,
-    end_date: date
+    end_date: date,
+    *,
+    commit: bool = True,
 ) -> List[ClassSession]:
-    """Generate class sessions from a template for the given date range"""
+    """Generate class sessions from a template for the given date range.
+
+    ``commit=True`` (default) persists the new sessions and is what standalone callers
+    (admin session generation, rolling-window maintenance) expect. ``commit=False`` only
+    flushes, so a caller that owns the transaction (atomic enrollment) can include session
+    generation in a single outer commit and roll it back on failure.
+    """
 
     # Get the template
     template_query = select(ClassTemplate).options(
@@ -166,10 +174,15 @@ async def generate_sessions_from_template(
     if sessions_to_create:
         db.add_all(sessions_to_create)
         try:
-            await db.commit()
-            # Refresh all created sessions
-            for session in sessions_to_create:
-                await db.refresh(session)
+            if commit:
+                await db.commit()
+                # Refresh all created sessions
+                for session in sessions_to_create:
+                    await db.refresh(session)
+            else:
+                # Caller owns the transaction: only flush so the new sessions are visible
+                # in-transaction (for materialization) without committing them.
+                await db.flush()
         except SQLAlchemyError:
             await db.rollback()
             raise

--- a/app/crud/memberships/enrollment.py
+++ b/app/crud/memberships/enrollment.py
@@ -277,6 +277,7 @@ async def renew_subscription_with_standing_booking(
             template_id=template_id,
             seat_id=seat_id,
             auto_materialize=auto_materialize,
+            commit_sessions=False,  # defer to the single outer commit -> atomic enrollment
         )
         _assert_materialization_success(materialization_stats)
 
@@ -354,6 +355,7 @@ async def create_member_enrollment_with_standing_booking(
             template_id=template_id,
             seat_id=seat_id,
             auto_materialize=auto_materialize,
+            commit_sessions=False,  # defer to the single outer commit -> atomic enrollment
         )
         _assert_materialization_success(materialization_stats)
     elif plan.fixed_time_slot:

--- a/app/crud/memberships/standing_bookings.py
+++ b/app/crud/memberships/standing_bookings.py
@@ -133,6 +133,8 @@ async def _generate_sessions_for_templates(
     start_date: Optional[date] = None,
     end_date: Optional[date] = None,
     weeks_ahead: Optional[int] = None,
+    *,
+    commit: bool = True,
 ) -> dict:
     """
     Generate class sessions for multiple templates.
@@ -185,6 +187,7 @@ async def _generate_sessions_for_templates(
                 template_id=template_id,
                 start_date=start_date,
                 end_date=end_date,
+                commit=commit,
             )
 
             stats["templates_processed"] += 1
@@ -312,6 +315,7 @@ async def _handle_fixed_timeslot_effects(
     seat_id: Optional[int] = None,
     *,
     auto_materialize: bool = True,
+    commit_sessions: bool = True,
 ) -> tuple[Optional[int], dict]:
     """Common helper for fixed time-slot effects (group bookings + sessions + materialization).
 
@@ -354,6 +358,7 @@ async def _handle_fixed_timeslot_effects(
                 template_ids=[tid],
                 start_date=template_start,
                 end_date=window_end,
+                commit=commit_sessions,
             )
             created_total += int(gen_stats.get("sessions_created", 0))
         generation_stats["sessions_created"] = created_total

--- a/tests/test_session_generation_commit_flag.py
+++ b/tests/test_session_generation_commit_flag.py
@@ -1,0 +1,66 @@
+"""Regression test for the package-enrollment atomicity fix.
+
+``generate_sessions_from_template`` must COMMIT for standalone callers (admin session
+generation, rolling-window maintenance) but only FLUSH when ``commit=False``, so the
+fixed-slot enrollment flow can fold session generation into its single outer commit and
+roll everything back if materialization later fails. Before the fix it always committed
+mid-transaction, leaving a paid membership committed even when the class turned out full.
+
+DB-free: a fake AsyncSession records whether commit/flush was called (the local test DB is
+not available in every environment, and the commit-vs-flush decision is the crux of the fix).
+"""
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from app.crud import classSessionCrud
+
+# 2026-06-15 is a Monday (date.weekday() == 0), which matches a template whose
+# weekday field is 1 (their encoding is 0=Sunday..6=Saturday): (1 - 1) % 7 == 0.
+_MONDAY = datetime.date(2026, 6, 15)
+
+
+def _fake_template():
+    t = MagicMock()
+    t.is_active = True
+    t.weekday = 1
+    t.class_type_id = 10
+    t.venue_id = 20
+    t.instructor_id = None
+    t.name = "Spinning"
+    t.start_time_local = datetime.time(18, 0)
+    t.default_duration_min = 60
+    t.default_capacity = 14
+    return t
+
+
+def _fake_db():
+    """AsyncSession double: first execute() -> the template, second -> no existing session."""
+    db = AsyncMock()
+    tmpl_res = MagicMock()
+    tmpl_res.scalar_one_or_none.return_value = _fake_template()
+    exist_res = MagicMock()
+    exist_res.scalar_one_or_none.return_value = None  # nothing exists -> one session is created
+    db.execute = AsyncMock(side_effect=[tmpl_res, exist_res])
+    db.add_all = MagicMock()  # add_all is synchronous in SQLAlchemy
+    return db
+
+
+async def test_generate_sessions_flush_only_when_commit_false():
+    db = _fake_db()
+    created = await classSessionCrud.generate_sessions_from_template(
+        db, template_id=1, start_date=_MONDAY, end_date=_MONDAY, commit=False
+    )
+    assert len(created) == 1
+    db.flush.assert_awaited_once()
+    db.commit.assert_not_called()
+    db.refresh.assert_not_called()
+
+
+async def test_generate_sessions_commits_by_default():
+    db = _fake_db()
+    created = await classSessionCrud.generate_sessions_from_template(
+        db, template_id=1, start_date=_MONDAY, end_date=_MONDAY  # commit defaults to True
+    )
+    assert len(created) == 1
+    db.commit.assert_awaited_once()
+    db.flush.assert_not_called()


### PR DESCRIPTION
## Problem
The fixed-slot **package** enrollment/renewal was **not atomic**. `generate_sessions_from_template` did `await db.commit()` mid-transaction (whenever new sessions had to be created) **before** `_assert_materialization_success` validated seat/capacity. So if the class turned out full, the **person + subscription + payment + standing booking were already committed** → a paid membership with no/incomplete reservations (or a free membership + refund). Affected **both** the WhatsApp chatbot purchase flow **and** the manual Socios-tab enrollment/renewal (`create_member_enrollment` / `renew_subscription`).

This is the pre-existing root cause behind PR #19's `_committed_payment_exists` refund-guard.

## Fix
Thread the **existing `commit: bool` opt-out pattern** (already used by `create_payment` / `create_membership_subscription` / `create_member`) down the enrollment path so session generation only **flushes**, and the single outer commit in `enrollment.py` (`:285` renew / `:363` create) is the **only** commit. A materialization `ValueError` now rolls back everything → fully atomic.

- `classSessionCrud.generate_sessions_from_template(..., *, commit=True)` — flush instead of commit when `False`.
- `standing_bookings._generate_sessions_for_templates` / `_handle_fixed_timeslot_effects` — thread the flag.
- `enrollment.{create_member,renew_subscription}_with_standing_booking` — pass `commit_sessions=False`.

Standalone callers (admin session generation, rolling-window maintenance) call without `commit=` → keep `commit=True` and are unaffected.

## Why it's safe
- Flush keeps the new sessions **visible in-transaction** for the subsequent materialization (same `AsyncSession`).
- Rollback-on-failure already correct: the GraphQL resolvers wrap in `try/except` + `db.rollback()`, and the MercadoPago webhook does `db.rollback()` on `ValueError` (its `_committed_payment_exists` guard now correctly finds nothing committed → clean auto-refund).

## Tests / verification
- `python -m py_compile` clean on the 3 edited files.
- New `tests/test_session_generation_commit_flag.py` (DB-free, **passes**): asserts `commit=False` → `flush()` not `commit()`, and default → `commit()`. (Full DB-backed integration test not run here — the local test Postgres rejects auth in this environment; CI with a seeded DB should add the full-class rollback scenario.)

**No migration.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)