### PR TITLE
feat(whatsapp): send voice notes

### DIFF
--- a/app/graphql/whatsapp/mutations.py
+++ b/app/graphql/whatsapp/mutations.py
@@ -182,8 +182,17 @@ class WhatsAppChatMutation:
         raw = await file.read()
         mime_type = _detect_mime_type(file, original_filename)
         media_kind = _media_kind_for_mime(mime_type)
+        voice_note = bool(getattr(input, "voice_note", False))
         caption = (input.caption or "").strip() or None
-        if media_kind == "audio":
+        if voice_note:
+            if media_kind != "audio" or Path(original_filename).suffix.lower() != ".ogg":
+                return SendMessageResult(
+                    success=False,
+                    error="La nota de voz debe ser un archivo de audio OGG/Opus.",
+                )
+            mime_type = "audio/ogg; codecs=opus"
+            caption = None
+        elif media_kind == "audio":
             caption = None  # the Cloud API rejects captions on audio
 
         try:
@@ -212,6 +221,7 @@ class WhatsAppChatMutation:
             media_id=media_id,
             caption=caption,
             filename=original_filename if media_kind == "document" else None,
+            voice=voice_note,
         )
         if not gw.ok:
             await db.rollback()

--- a/app/graphql/whatsapp/types.py
+++ b/app/graphql/whatsapp/types.py
@@ -155,6 +155,7 @@ class SendMediaMessageInput:
     conversation_id: Optional[int] = None
     wa_id: Optional[str] = None
     caption: Optional[str] = None
+    voice_note: bool = False
 
 
 @strawberry.input

--- a/app/services/whatsapp_cloud_service.py
+++ b/app/services/whatsapp_cloud_service.py
@@ -314,19 +314,25 @@ async def send_media(
     media_id: str,
     caption: Optional[str] = None,
     filename: Optional[str] = None,
+    voice: bool = False,
 ) -> Dict[str, Any]:
     """Send a previously uploaded media object. Returns {"wa_message_id": ...}.
 
     ``media_type`` must be one of image/audio/video/document. The Cloud API
     accepts ``caption`` only for image/video/document (audio rejects it) and
-    ``filename`` only for document.
+    ``filename`` only for document. ``voice=True`` marks an audio payload as a
+    WhatsApp voice message; Meta expects OGG/Opus media for that mode.
     """
     if not whatsapp_config.is_send_configured():
         raise WhatsAppError("WhatsApp Cloud API is not configured (missing phone id/token).")
     if media_type not in {"image", "audio", "video", "document"}:
         raise WhatsAppError(f"Tipo de media no soportado para envío: {media_type}")
+    if voice and media_type != "audio":
+        raise WhatsAppError("Las notas de voz solo pueden enviarse como audio.")
 
     media_obj: Dict[str, Any] = {"id": media_id}
+    if voice:
+        media_obj["voice"] = True
     if caption and media_type != "audio":
         media_obj["caption"] = caption
     if filename and media_type == "document":

--- a/app/services/whatsapp_media_assets_service.py
+++ b/app/services/whatsapp_media_assets_service.py
@@ -38,7 +38,14 @@ MAX_BYTES = {
 ALLOWED_MIME_PREFIXES = {
     "image": ("image/jpeg", "image/png"),
     "video": ("video/mp4", "video/3gpp"),
-    "audio": ("audio/aac", "audio/amr", "audio/mpeg", "audio/mp4", "audio/ogg"),
+    "audio": (
+        "audio/aac",
+        "audio/amr",
+        "audio/mpeg",
+        "audio/mp4",
+        "audio/ogg",
+        "audio/ogg; codecs=opus",
+    ),
     "document": (
         "application/pdf",
         "application/msword",

--- a/app/services/whatsapp_outbound.py
+++ b/app/services/whatsapp_outbound.py
@@ -305,6 +305,7 @@ async def send_media(
     media_id: str,
     caption: Optional[str] = None,
     filename: Optional[str] = None,
+    voice: bool = False,
 ) -> OutboundResult:
     """Send media. ``persist=False``: the caller persists the message + media row (it owns the
     richer media bookkeeping); the gateway only serializes + sends."""
@@ -312,7 +313,12 @@ async def send_media(
         db, kind=kind, message_class=CLASS_TRANSACTIONAL,
         conversation_id=conversation_id, contact_id=contact_id, wa_id=wa_id,
         cloud_send=lambda: cloud.send_media(
-            to=wa_id, media_type=media_type, media_id=media_id, caption=caption, filename=filename,
+            to=wa_id,
+            media_type=media_type,
+            media_id=media_id,
+            caption=caption,
+            filename=filename,
+            voice=voice,
         ),
         persist=False,
     )

--- a/tests/test_whatsapp_voice_notes.py
+++ b/tests/test_whatsapp_voice_notes.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.graphql.whatsapp.mutations import WhatsAppChatMutation
+from app.services import whatsapp_cloud_service as cloud
+from app.services.whatsapp_media_assets_service import validate_media
+
+
+class _FakeDb:
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+class _UploadStub:
+    def __init__(self, filename: str, content_type: str, raw: bytes = b"voice-bytes"):
+        self.filename = filename
+        self.content_type = content_type
+        self._raw = raw
+
+    async def read(self) -> bytes:
+        return self._raw
+
+
+class _Response:
+    status_code = 200
+    text = '{"messages":[{"id":"wamid.voice"}]}'
+
+    def json(self):
+        return {"messages": [{"id": "wamid.voice"}]}
+
+
+@pytest.mark.asyncio
+async def test_cloud_send_media_sets_audio_voice_payload(monkeypatch):
+    captured: dict = {}
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, url, json=None, headers=None):
+            captured["url"] = url
+            captured["json"] = json
+            captured["headers"] = headers
+            return _Response()
+
+    monkeypatch.setattr(cloud.whatsapp_config.__class__, "PHONE_NUMBER_ID", "phone-123")
+    monkeypatch.setattr(cloud.whatsapp_config.__class__, "ACCESS_TOKEN", "token-123")
+    monkeypatch.setattr(cloud.httpx, "AsyncClient", FakeAsyncClient)
+
+    result = await cloud.send_media(
+        to="5215555555555",
+        media_type="audio",
+        media_id="media-123",
+        voice=True,
+    )
+
+    assert result == {"wa_message_id": "wamid.voice"}
+    assert captured["json"]["type"] == "audio"
+    assert captured["json"]["audio"] == {"id": "media-123", "voice": True}
+
+
+def test_validate_media_accepts_ogg_opus_voice_mime():
+    validate_media("audio", b"voice-bytes", "audio/ogg; codecs=opus")
+
+
+@pytest.mark.asyncio
+async def test_send_media_message_sends_voice_note_as_ogg_opus(monkeypatch):
+    captured: dict = {}
+
+    async def fake_get_conversation(_db, _conversation_id):
+        return SimpleNamespace(id=2, contact=SimpleNamespace(id=3, wa_id="5215555555555"))
+
+    async def fake_upload_media(raw, mime_type, filename):
+        captured["upload"] = {
+            "raw": raw,
+            "mime_type": mime_type,
+            "filename": filename,
+        }
+        return "media-voice-1"
+
+    async def fake_send_media(*_args, **kwargs):
+        captured["send"] = kwargs
+        return SimpleNamespace(ok=True, wa_message_id="wamid.voice")
+
+    async def fake_store_media_bytes(raw, **kwargs):
+        captured["store"] = {"raw": raw, **kwargs}
+        return "/uploads/whatsapp/media-voice-1.ogg"
+
+    async def fake_insert_outbound_message(*_args, **kwargs):
+        captured["message"] = kwargs
+        return SimpleNamespace(id=10)
+
+    async def fake_insert_outbound_media(*_args, **kwargs):
+        captured["media"] = kwargs
+        return SimpleNamespace(id=11)
+
+    async def fake_get_message_by_id(_db, _message_id):
+        return SimpleNamespace(
+            id=10,
+            conversation_id=2,
+            contact_id=3,
+            direction="outbound",
+            message_type="audio",
+            text_content=None,
+            timestamp=datetime.now(timezone.utc),
+            wa_message_id="wamid.voice",
+            context_message_id=None,
+            media_url="/uploads/whatsapp/media-voice-1.ogg",
+            media=SimpleNamespace(
+                id=11,
+                media_type="audio",
+                mime_type="audio/ogg; codecs=opus",
+                filename="note.ogg",
+                caption=None,
+                file_size=11,
+                media_url="/uploads/whatsapp/media-voice-1.ogg",
+                downloaded=True,
+                download_failed=False,
+            ),
+        )
+
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.crud.get_conversation",
+        fake_get_conversation,
+    )
+    monkeypatch.setattr("app.graphql.whatsapp.mutations.cloud.upload_media", fake_upload_media)
+    monkeypatch.setattr("app.graphql.whatsapp.mutations.outbound.send_media", fake_send_media)
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.media_service.store_media_bytes",
+        fake_store_media_bytes,
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.crud.insert_outbound_message",
+        fake_insert_outbound_message,
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.crud.insert_outbound_media",
+        fake_insert_outbound_media,
+    )
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.crud.get_message_by_id",
+        fake_get_message_by_id,
+    )
+
+    info = SimpleNamespace(context=SimpleNamespace(db=_FakeDb()))
+    input_data = SimpleNamespace(
+        conversation_id=2,
+        wa_id=None,
+        caption="caption ignored",
+        voice_note=True,
+    )
+
+    result = await WhatsAppChatMutation().send_media_message(
+        info,
+        input_data,
+        _UploadStub("note.ogg", "audio/ogg"),
+    )
+
+    assert result.success is True
+    assert result.message.message_type == "audio"
+    assert captured["upload"]["mime_type"] == "audio/ogg; codecs=opus"
+    assert captured["send"]["voice"] is True
+    assert captured["send"]["caption"] is None
+    assert captured["message"]["text"] is None
+    assert captured["media"]["mime_type"] == "audio/ogg; codecs=opus"
+    assert captured["media"]["caption"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_media_message_rejects_non_ogg_voice_note(monkeypatch):
+    async def fake_get_conversation(_db, _conversation_id):
+        return SimpleNamespace(id=2, contact=SimpleNamespace(id=3, wa_id="5215555555555"))
+
+    async def fail_upload_media(*_args, **_kwargs):
+        raise AssertionError("invalid voice notes must not upload to Meta")
+
+    monkeypatch.setattr(
+        "app.graphql.whatsapp.mutations.crud.get_conversation",
+        fake_get_conversation,
+    )
+    monkeypatch.setattr("app.graphql.whatsapp.mutations.cloud.upload_media", fail_upload_media)
+
+    info = SimpleNamespace(context=SimpleNamespace(db=_FakeDb()))
+    input_data = SimpleNamespace(
+        conversation_id=2,
+        wa_id=None,
+        caption=None,
+        voice_note=True,
+    )
+
+    result = await WhatsAppChatMutation().send_media_message(
+        info,
+        input_data,
+        _UploadStub("note.mp3", "audio/mpeg"),
+    )
+
+    assert result.success is False
+    assert "OGG/Opus" in result.error


### PR DESCRIPTION
## Summary
- add GraphQL voiceNote support for WhatsApp media sends
- mark outbound audio payloads as WhatsApp voice messages with audio.voice=true
- allow OGG/Opus MIME validation and route voice media through the outbound gateway

## Validation
- python -m pytest tests/test_whatsapp_voice_notes.py tests/test_whatsapp_media_assets.py tests/test_whatsapp_reactions.py::test_send_reaction_persists_outbound_reaction tests/test_whatsapp_reactions.py::test_send_reaction_removal_sends_empty_emoji tests/test_whatsapp_reactions.py::test_send_reaction_requires_target
- python -m py_compile app/graphql/whatsapp/types.py app/graphql/whatsapp/mutations.py app/services/whatsapp_cloud_service.py app/services/whatsapp_media_assets_service.py app/services/whatsapp_outbound.py tests/test_whatsapp_voice_notes.py