### PR TITLE
feat(whatsapp): unread tracking + read receipts

### DIFF
--- a/alembic/versions/f7a8b9c0d1e2_message_read_state.py
+++ b/alembic/versions/f7a8b9c0d1e2_message_read_state.py
@@ -1,0 +1,68 @@
+"""Message read state: is_read + read_at on app.messages.
+
+Adds unread-message tracking for the Chats UI (WhatsApp-style unread badge + "No leídos"
+filter):
+
+* ``is_read`` (Boolean, default false) — whether staff/bot has read this inbound message.
+* ``read_at`` (naive TIMESTAMP, like the other columns on this externally-created table).
+
+The unread count is ``COUNT(*) WHERE direction='inbound' AND is_read=false`` per conversation,
+backed by the partial index added here.
+
+IMPORTANT: all pre-existing rows are backfilled to ``is_read = true`` so historical messages
+do NOT show up as unread on first deploy (only messages received after this migration count).
+
+Purely additive (add_column + index). Does not touch the externally-created realtime trigger.
+
+Revision ID: f7a8b9c0d1e2
+Revises: a7b8c9d0e1f2
+Create Date: 2026-06-17 00:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "f7a8b9c0d1e2"
+down_revision: Union[str, None] = "a7b8c9d0e1f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "messages",
+        sa.Column("is_read", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        schema=SCHEMA,
+    )
+    op.add_column(
+        "messages",
+        sa.Column("read_at", sa.TIMESTAMP(timezone=False), nullable=True),
+        schema=SCHEMA,
+    )
+
+    # Backfill: every existing message is considered read so we don't surface a huge
+    # unread backlog on first deploy. Only messages received after this counts as unread.
+    op.execute(sa.text("UPDATE app.messages SET is_read = true WHERE is_read = false"))
+
+    # Tiny partial index covering only genuinely-unread inbound rows — backs both the
+    # per-conversation COUNT and the mark-read UPDATE.
+    op.create_index(
+        "idx_messages_unread_inbound",
+        "messages",
+        ["conversation_id"],
+        unique=False,
+        schema=SCHEMA,
+        postgresql_where=sa.text("direction = 'inbound' AND is_read = false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_messages_unread_inbound", table_name="messages", schema=SCHEMA)
+    op.drop_column("messages", "read_at", schema=SCHEMA)
+    op.drop_column("messages", "is_read", schema=SCHEMA)

--- a/app/crud/whatsappCrud.py
+++ b/app/crud/whatsappCrud.py
@@ -12,7 +12,7 @@ from typing import Optional, List, Dict
 import json
 import logging
 
-from sqlalchemy import case, func, or_, select, and_, text as sql_text
+from sqlalchemy import case, func, or_, select, and_, update, text as sql_text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -532,6 +532,7 @@ async def get_conversations(
 
     conv_ids = [conv.id for conv, _ in rows]
     last_messages = await _latest_message_per_conversation(db, conv_ids)
+    unread_by_conv = await _unread_counts(db, conv_ids)
     contacts = [conv.contact for conv, _ in rows]
     member_by_contact_id = await _resolve_member_contacts(db, contacts)
 
@@ -546,7 +547,7 @@ async def get_conversations(
                 contact=_contact_data(conv.contact, member),
                 last_message=last,
                 last_activity=last_activity,
-                unread_count=0,  # reserved for a later phase
+                unread_count=unread_by_conv.get(conv.id, 0),
                 bot_enabled=bool(getattr(conv, "bot_enabled", True)),
             )
         )
@@ -575,6 +576,7 @@ async def get_conversation_data(
 
     conv, last_activity = row
     last_messages = await _latest_message_per_conversation(db, [conv.id])
+    unread_by_conv = await _unread_counts(db, [conv.id])
     member_by_contact_id = await _resolve_member_contacts(db, [conv.contact])
     member = member_by_contact_id.get(conv.contact_id)
     return ConversationData(
@@ -583,7 +585,7 @@ async def get_conversation_data(
         contact=_contact_data(conv.contact, member),
         last_message=last_messages.get(conv.id),
         last_activity=last_activity,
-        unread_count=0,  # reserved for a later phase
+        unread_count=unread_by_conv.get(conv.id, 0),
         bot_enabled=bool(getattr(conv, "bot_enabled", True)),
     )
 
@@ -618,6 +620,66 @@ async def _latest_message_per_conversation(
     for m in messages:
         latest[m.conversation_id] = ChatMessageData.from_model(m)
     return latest
+
+
+async def _unread_counts(db: AsyncSession, conv_ids: List[int]) -> Dict[int, int]:
+    """Count unread inbound messages per conversation in ONE grouped query.
+
+    Mirrors ``_latest_message_per_conversation``: filters ``direction='inbound'`` and
+    excludes reactions (a reaction never counts as an unread message). Backed by the
+    partial index ``idx_messages_unread_inbound``.
+    """
+    if not conv_ids:
+        return {}
+
+    stmt = (
+        select(Message.conversation_id, func.count(Message.id))
+        .where(Message.conversation_id.in_(conv_ids))
+        .where(Message.direction == "inbound")
+        .where(Message.is_read.is_(False))
+        .where(Message.message_type != "reaction")
+        .group_by(Message.conversation_id)
+    )
+    rows = (await db.execute(stmt)).all()
+    return {cid: int(count) for cid, count in rows}
+
+
+async def mark_conversation_read(
+    db: AsyncSession, conversation_id: int
+) -> tuple[Optional["Conversation"], Optional[str]]:
+    """Mark all unread inbound messages of a conversation as read. Commits.
+
+    Returns ``(conversation, latest_inbound_wa_message_id)`` so the caller can send a
+    Meta read receipt for the newest inbound message. ``latest`` is None when there were
+    no unread inbound messages (or none had a wa_message_id).
+    """
+    conv = await db.get(Conversation, conversation_id)
+    if conv is None:
+        return None, None
+
+    # Capture the newest unread inbound wa_message_id BEFORE flipping is_read (for the receipt).
+    latest_wa_id = (
+        await db.execute(
+            select(Message.wa_message_id)
+            .where(Message.conversation_id == conversation_id)
+            .where(Message.direction == "inbound")
+            .where(Message.is_read.is_(False))
+            .where(Message.message_type != "reaction")
+            .where(Message.wa_message_id.isnot(None))
+            .order_by(Message.timestamp.desc(), Message.id.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    await db.execute(
+        update(Message)
+        .where(Message.conversation_id == conversation_id)
+        .where(Message.direction == "inbound")
+        .where(Message.is_read.is_(False))
+        .values(is_read=True, read_at=datetime.utcnow())
+    )
+    await db.commit()
+    return conv, latest_wa_id
 
 
 async def get_conversation_messages(
@@ -894,6 +956,7 @@ async def insert_outbound_message(
         created_at=now,
         is_processed=1,
         is_temp=0,
+        is_read=True,  # outbound is never "unread" (count filters inbound anyway)
     )
     db.add(msg)
     await db.flush()

--- a/app/graphql/whatsapp/mutations.py
+++ b/app/graphql/whatsapp/mutations.py
@@ -325,3 +325,21 @@ class WhatsAppChatMutation:
             raise Exception("Conversación no encontrada.")
         data = await crud.get_conversation_data(db, conversation_id)
         return ChatConversation.from_data(data)
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def mark_conversation_read(
+        self, info: Info, conversation_id: int
+    ) -> ChatConversation:
+        """Mark a conversation's inbound messages as read and send a Meta read receipt.
+
+        Clears the unread badge in Chats; the read receipt (blue ticks) is best-effort
+        (only the latest inbound message, within the 24h window).
+        """
+        db: AsyncSession = info.context.db
+        conv, latest_wa_id = await crud.mark_conversation_read(db, conversation_id)
+        if conv is None:
+            raise Exception("Conversación no encontrada.")
+        if latest_wa_id:
+            await cloud.send_read_receipt(latest_wa_id)  # best-effort, never raises
+        data = await crud.get_conversation_data(db, conversation_id)
+        return ChatConversation.from_data(data)

--- a/app/models/whatsappModel.py
+++ b/app/models/whatsappModel.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from typing import Optional, List
 
 from sqlalchemy import (
-    BigInteger, Boolean, SmallInteger, String, Text, ForeignKey, TIMESTAMP, JSON, Index
+    BigInteger, Boolean, SmallInteger, String, Text, ForeignKey, TIMESTAMP, JSON, Index, text
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -79,6 +79,12 @@ class Message(Base):
     is_processed: Mapped[Optional[int]] = mapped_column(SmallInteger, default=0)
     processed_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP)
     is_temp: Mapped[Optional[int]] = mapped_column(SmallInteger, default=0)
+    # Unread tracking for the Chats UI. Inbound rows default to unread (false); staff/bot
+    # marks them read. The unread count filters direction='inbound' AND is_read=false.
+    is_read: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    read_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP)
     # Outbound coordination: 'transactional' | 'marketing' (NULL on legacy/inbound rows).
     # The marketing frequency cap counts outbound rows with message_class='marketing'.
     message_class: Mapped[Optional[str]] = mapped_column(String(30))

--- a/app/services/chatbot/reply_service.py
+++ b/app/services/chatbot/reply_service.py
@@ -65,6 +65,18 @@ async def send_and_persist_reply(
         message_class=outbound.CLASS_TRANSACTIONAL,
     )
     await db.commit()
+
+    # The bot just answered this conversation, so the customer's inbound messages are
+    # handled — mark them read (and send a read receipt) so they don't linger as unread
+    # for staff. Best-effort; never let it break the reply flow.
+    if result.ok:
+        try:
+            _conv, latest_wa_id = await crud.mark_conversation_read(db, conversation_id)
+            if latest_wa_id:
+                await cloud.send_read_receipt(latest_wa_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("post-reply mark-read failed for %s", conversation_id, exc_info=True)
+
     return result
 
 

--- a/app/services/whatsapp_cloud_service.py
+++ b/app/services/whatsapp_cloud_service.py
@@ -323,6 +323,37 @@ async def send_text(to: str, text: str) -> Dict[str, Any]:
     return {"wa_message_id": wa_message_id}
 
 
+async def send_read_receipt(wa_message_id: Optional[str]) -> bool:
+    """Mark an inbound message as read in WhatsApp (blue ticks). Best-effort.
+
+    Reuses the same ``/messages`` endpoint + bearer credentials as ``send_text``. Returns
+    True on success, False on any failure (missing config/id, expired 24h window, etc.) and
+    never raises — a read receipt must never break the UI flow.
+    """
+    if not wa_message_id or not whatsapp_config.is_send_configured():
+        return False
+
+    url = whatsapp_config.graph_url(f"{whatsapp_config.PHONE_NUMBER_ID}/messages")
+    payload = {
+        "messaging_product": "whatsapp",
+        "status": "read",
+        "message_id": wa_message_id,
+    }
+    headers = {**_auth_headers(), "Content-Type": "application/json"}
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(url, json=payload, headers=headers)
+        if resp.status_code >= 400:
+            error = _parse_api_error(resp)
+            logger.info("WhatsApp read receipt skipped (%s): %s", error.code, error.message)
+            return False
+        return True
+    except Exception:  # noqa: BLE001
+        logger.debug("WhatsApp read receipt failed for %s", wa_message_id, exc_info=True)
+        return False
+
+
 async def send_reaction(to: str, message_id: str, emoji: str) -> Dict[str, Any]:
     """React to a message with an emoji. Returns {"wa_message_id": ...}.
 


### PR DESCRIPTION
## Sistema de mensajes no leídos (backend)

- Nuevas columnas `messages.is_read` + `read_at` (migración `f7a8b9c0d1e2`: backfill de filas existentes a *leído* + índice parcial).
- `unread_count` real por conversación (antes fijo en 0) vía `_unread_counts`.
- Mutación `markConversationRead` + acuse de lectura a Meta (palomitas azules, best-effort).
- El chatbot marca la conversación como leída tras responder; campañas/auto-notificaciones no.

**Deploy:** correr la migración `f7a8b9c0d1e2` (head único de Alembic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)