### PR TITLE
feat(chatbot): personalize replies with member name + membership status

### DIFF
--- a/app/services/chatbot/agent.py
+++ b/app/services/chatbot/agent.py
@@ -68,6 +68,7 @@ def build_system_prompt(
     business_info: str,
     member_id: Optional[int],
     pending_note: Optional[str] = None,
+    member_note: Optional[str] = None,
 ) -> str:
     parts: List[str] = []
     if config.system_prompt:
@@ -90,6 +91,8 @@ def build_system_prompt(
             "El cliente está identificado como socio. get_my_membership, list_my_reservations, "
             "renovación (propose_membership) y pase diario ya operan sobre su cuenta."
         )
+        if member_note:
+            parts.append(member_note)
     else:
         parts.append(
             "El cliente NO está registrado como socio. Para comprar un plan pídele su nombre "
@@ -124,10 +127,13 @@ async def run_agent(
     history: List[BaseMessage],
     user_text: str,
     pending_note: Optional[str] = None,
+    member_note: Optional[str] = None,
 ) -> Optional[str]:
     """Run one agent turn and return the reply text (or None if nothing to say)."""
     llm = build_llm(config)
-    system_prompt = build_system_prompt(config, business_info, member_id, pending_note)
+    system_prompt = build_system_prompt(
+        config, business_info, member_id, pending_note, member_note
+    )
     agent = create_react_agent(llm, tools, prompt=system_prompt)
 
     messages: List[BaseMessage] = list(history) + [HumanMessage(content=user_text)]

--- a/app/services/chatbot/reply_service.py
+++ b/app/services/chatbot/reply_service.py
@@ -137,6 +137,37 @@ async def _build_pending_note(db: AsyncSession, conversation_id: int) -> Optiona
     )
 
 
+def _build_member_note(member) -> Optional[str]:
+    """Personalization line for the system prompt: greet by name + adapt to membership.
+
+    ``member`` is the MemberData from ``membersCrud.get_member_by_id`` (or None). Returns
+    None when there's no member/name so the prompt keeps its generic non-member branch.
+    """
+    if member is None:
+        return None
+    name = (getattr(member, "full_name", None) or "").strip()
+    if not name:
+        return None
+    m = getattr(member, "active_membership", None)
+    status = (getattr(m, "status", None) or "").strip().lower() if m is not None else ""
+    days = getattr(m, "remaining_days", None) if m is not None else None
+
+    if status == "active":
+        detail = f"membresía ACTIVA, {days} días restantes" if days is not None else "membresía ACTIVA"
+        return (
+            f"Socio identificado: {name}. {detail}. Salúdalo por su nombre y personaliza tu "
+            "respuesta; no insistas en renovar salvo que falten pocos días."
+        )
+    if status == "expired":
+        detail = f"VENCIDA hace {abs(days)} días" if days is not None else "VENCIDA"
+        return (
+            f"Socio identificado: {name}. Su membresía está {detail}. Salúdalo por su nombre y, "
+            "con tacto, invítalo a renovar."
+        )
+    # inactive / desconocido / sin membresía activa
+    return f"Socio identificado: {name}. No tiene una membresía activa. Salúdalo por su nombre."
+
+
 async def _run_agent_reply(
     conversation_id: int,
     contact_id: int,
@@ -157,10 +188,16 @@ async def _run_agent_reply(
                 return
 
             member_id = await membersCrud.get_member_id_by_wa_id(db, contact_wa_id)
+            member = (
+                await membersCrud.get_member_by_id(db, member_id)
+                if member_id is not None
+                else None
+            )
             business_info = await build_business_info(db, config)
             history = await _load_history(db, conversation_id, exclude_message_id=message_id)
             require_mp = bool(config.require_mp_payment) and mercadopago_config.is_configured()
             pending_note = await _build_pending_note(db, conversation_id)
+            member_note = _build_member_note(member)
 
             ctx = ChatbotContext(
                 db=db,
@@ -171,7 +208,8 @@ async def _run_agent_reply(
             )
             tools = build_tools(ctx)
             reply = await run_agent(
-                config, tools, business_info, member_id, history, text, pending_note=pending_note
+                config, tools, business_info, member_id, history, text,
+                pending_note=pending_note, member_note=member_note,
             )
             if not reply:
                 return


### PR DESCRIPTION
## Personalización del chatbot con datos del socio

Hoy el chatbot solo sabe el nombre/estado de membresía si **decide** llamar la herramienta `get_my_membership`; en su contexto inicial solo recibe una bandera binaria "es socio / no es socio". Esto lo hace poco fiable para personalizar desde el primer mensaje.

**Cambio:** se inyecta en el system prompt **nombre + estado (activo/vencido/inactivo) + días restantes** del socio resuelto, para que salude por su nombre y adapte el mensaje (p. ej. invitar a renovar si está vencida) desde la primera respuesta.

- `reply_service.py`: carga el socio con `membersCrud.get_member_by_id` y arma `_build_member_note(...)` (espeja el patrón `pending_note`); lo pasa a `run_agent`.
- `agent.py`: `run_agent` y `build_system_prompt` reciben `member_note` y lo anexan en la rama "es socio". Fallback a la línea binaria si no hay socio.

Sin migración. La herramienta `get_my_membership` se conserva para detalle (plan/fecha/reservas).

Verificado: `py_compile` + prueba de las ramas de `_build_member_note` (activa/vencida/inactiva/None) extrayendo la función real vía AST (langchain no está instalado localmente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)