### PR TITLE
Membership plan CRUD + role-capability authorization

### DIFF
--- a/alembic/versions/b2c3d4e5f6a7_plan_type_and_role_capabilities.py
+++ b/alembic/versions/b2c3d4e5f6a7_plan_type_and_role_capabilities.py
@@ -1,0 +1,92 @@
+"""Add membership plan_type/is_active and role_capabilities grant table.
+
+Part A: membership_plans gains ``plan_type`` (fixed_schedule|flexible|credit_pack)
+and ``is_active`` (soft-delete flag). Existing rows are backfilled from
+``fixed_time_slot`` so current plans keep working.
+
+Part C: a ``role_capabilities`` table enables capability-based authorization
+(e.g. granting ``manage_membership_plans`` to non-admin roles). The ``admin``
+role is an implicit super-user in code; we seed its grant only for UI display.
+
+Revision ID: b2c3d4e5f6a7
+Revises: f7a8b9c0d1e2
+Create Date: 2026-06-19 12:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, None] = "f7a8b9c0d1e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    # --- Part A: membership_plans columns -------------------------------
+    op.execute(
+        f"""
+        ALTER TABLE {SCHEMA}.membership_plans
+        ADD COLUMN IF NOT EXISTS plan_type VARCHAR(20) NOT NULL DEFAULT 'fixed_schedule',
+        ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE
+        """
+    )
+    op.execute(
+        f"""
+        UPDATE {SCHEMA}.membership_plans
+        SET plan_type = CASE WHEN fixed_time_slot THEN 'fixed_schedule' ELSE 'flexible' END
+        """
+    )
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = 'ck_plan_type'
+            ) THEN
+                ALTER TABLE {SCHEMA}.membership_plans
+                ADD CONSTRAINT ck_plan_type
+                CHECK (plan_type IN ('fixed_schedule','flexible','credit_pack'));
+            END IF;
+        END $$;
+        """
+    )
+
+    # --- Part C: role_capabilities table --------------------------------
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {SCHEMA}.role_capabilities (
+            role_id    BIGINT NOT NULL REFERENCES {SCHEMA}.roles(id) ON DELETE CASCADE,
+            capability VARCHAR(60) NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (role_id, capability)
+        )
+        """
+    )
+    # Seed admin grant for display (admin is an implicit super-user in code).
+    op.execute(
+        f"""
+        INSERT INTO {SCHEMA}.role_capabilities (role_id, capability)
+        SELECT id, 'manage_membership_plans' FROM {SCHEMA}.roles WHERE code = 'admin'
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"DROP TABLE IF EXISTS {SCHEMA}.role_capabilities")
+    op.execute(
+        f"ALTER TABLE {SCHEMA}.membership_plans DROP CONSTRAINT IF EXISTS ck_plan_type"
+    )
+    op.execute(
+        f"""
+        ALTER TABLE {SCHEMA}.membership_plans
+        DROP COLUMN IF EXISTS plan_type,
+        DROP COLUMN IF EXISTS is_active
+        """
+    )

--- a/app/crud/memberships/data.py
+++ b/app/crud/memberships/data.py
@@ -14,7 +14,9 @@ class MembershipPlanData:
     duration_value: int
     duration_unit: str
     class_limit: Optional[int]
+    plan_type: str
     fixed_time_slot: bool
+    is_active: bool
     max_sessions_per_day: Optional[int]
     max_sessions_per_week: Optional[int]
     created_at: datetime
@@ -43,7 +45,9 @@ def _plan_to_data(plan: MembershipPlan) -> MembershipPlanData:
         duration_value=plan.duration_value,
         duration_unit=plan.duration_unit,
         class_limit=plan.class_limit,
+        plan_type=getattr(plan, "plan_type", "fixed_schedule") or "fixed_schedule",
         fixed_time_slot=plan.fixed_time_slot,
+        is_active=bool(getattr(plan, "is_active", True)),
         max_sessions_per_day=plan.max_sessions_per_day,
         max_sessions_per_week=plan.max_sessions_per_week,
         created_at=plan.created_at,

--- a/app/crud/memberships/plans.py
+++ b/app/crud/memberships/plans.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List, Optional
 
@@ -9,10 +10,25 @@ from app.models import MembershipPlan
 
 from .data import MembershipPlanData, _plan_to_data
 
+# Valid plan types and the rule that ties plan_type -> fixed_time_slot.
+PLAN_TYPES = ("fixed_schedule", "flexible", "credit_pack")
 
-async def get_membership_plans(db: AsyncSession) -> List[MembershipPlanData]:
-    """Get all available membership plans."""
-    result = await db.execute(select(MembershipPlan).order_by(MembershipPlan.price.asc()))
+
+def _derive_fixed_time_slot(plan_type: str) -> bool:
+    """fixed_time_slot is True only for the recurring fixed-schedule model."""
+    return plan_type == "fixed_schedule"
+
+
+async def get_membership_plans(
+    db: AsyncSession, include_inactive: bool = False
+) -> List[MembershipPlanData]:
+    """Get membership plans. By default only active plans are returned."""
+    query = select(MembershipPlan)
+    if not include_inactive:
+        query = query.where(MembershipPlan.is_active.is_(True))
+    query = query.order_by(MembershipPlan.price.asc())
+
+    result = await db.execute(query)
     plans = result.scalars().all()
 
     return [_plan_to_data(plan) for plan in plans]
@@ -41,11 +57,24 @@ async def create_membership_plan(
     duration_unit: str,
     description: Optional[str] = None,
     class_limit: Optional[int] = None,
-    fixed_time_slot: bool = False,
+    plan_type: str = "fixed_schedule",
+    fixed_time_slot: Optional[bool] = None,
+    is_active: bool = True,
     max_sessions_per_day: Optional[int] = None,
     max_sessions_per_week: Optional[int] = None,
 ) -> MembershipPlan:
-    """Create a new membership plan."""
+    """Create a new membership plan.
+
+    ``plan_type`` is the source of truth for the booking model; ``fixed_time_slot``
+    is derived from it (unless explicitly provided for backward compatibility).
+    """
+    if plan_type not in PLAN_TYPES:
+        raise ValueError(f"plan_type inválido: {plan_type}")
+
+    resolved_fixed_slot = (
+        fixed_time_slot if fixed_time_slot is not None else _derive_fixed_time_slot(plan_type)
+    )
+
     plan = MembershipPlan(
         name=name,
         description=description,
@@ -53,12 +82,95 @@ async def create_membership_plan(
         duration_value=duration_value,
         duration_unit=duration_unit,
         class_limit=class_limit,
-        fixed_time_slot=fixed_time_slot,
+        plan_type=plan_type,
+        fixed_time_slot=resolved_fixed_slot,
+        is_active=is_active,
         max_sessions_per_day=max_sessions_per_day,
         max_sessions_per_week=max_sessions_per_week,
     )
 
     db.add(plan)
+    await db.commit()
+    await db.refresh(plan)
+    return plan
+
+
+# Sentinel so callers can distinguish "not provided" from "explicitly None".
+_UNSET = object()
+
+
+async def update_membership_plan(
+    db: AsyncSession,
+    plan_id: int,
+    name=_UNSET,
+    price=_UNSET,
+    duration_value=_UNSET,
+    duration_unit=_UNSET,
+    description=_UNSET,
+    class_limit=_UNSET,
+    plan_type=_UNSET,
+    is_active=_UNSET,
+    max_sessions_per_day=_UNSET,
+    max_sessions_per_week=_UNSET,
+) -> Optional[MembershipPlan]:
+    """Partial update of a membership plan. Only provided fields are changed."""
+    plan_id_value = coerce_int(plan_id)
+    if plan_id_value is None:
+        return None
+
+    result = await db.execute(select(MembershipPlan).where(MembershipPlan.id == plan_id_value))
+    plan = result.scalar_one_or_none()
+    if not plan:
+        return None
+
+    if name is not _UNSET:
+        plan.name = name
+    if description is not _UNSET:
+        plan.description = description
+    if price is not _UNSET and price is not None:
+        plan.price = Decimal(str(price))
+    if duration_value is not _UNSET and duration_value is not None:
+        plan.duration_value = duration_value
+    if duration_unit is not _UNSET and duration_unit is not None:
+        plan.duration_unit = duration_unit
+    if class_limit is not _UNSET:
+        plan.class_limit = class_limit
+    if plan_type is not _UNSET and plan_type is not None:
+        if plan_type not in PLAN_TYPES:
+            raise ValueError(f"plan_type inválido: {plan_type}")
+        plan.plan_type = plan_type
+        # Keep the derived flag consistent with the (possibly new) plan_type.
+        plan.fixed_time_slot = _derive_fixed_time_slot(plan_type)
+    if is_active is not _UNSET and is_active is not None:
+        plan.is_active = bool(is_active)
+    if max_sessions_per_day is not _UNSET:
+        plan.max_sessions_per_day = max_sessions_per_day
+    if max_sessions_per_week is not _UNSET:
+        plan.max_sessions_per_week = max_sessions_per_week
+
+    plan.updated_at = datetime.now(timezone.utc)
+
+    await db.commit()
+    await db.refresh(plan)
+    return plan
+
+
+async def set_membership_plan_active(
+    db: AsyncSession, plan_id: int, is_active: bool
+) -> Optional[MembershipPlan]:
+    """Soft-delete / restore a plan by toggling its is_active flag."""
+    plan_id_value = coerce_int(plan_id)
+    if plan_id_value is None:
+        return None
+
+    result = await db.execute(select(MembershipPlan).where(MembershipPlan.id == plan_id_value))
+    plan = result.scalar_one_or_none()
+    if not plan:
+        return None
+
+    plan.is_active = bool(is_active)
+    plan.updated_at = datetime.now(timezone.utc)
+
     await db.commit()
     await db.refresh(plan)
     return plan

--- a/app/crud/membershipsCrud.py
+++ b/app/crud/membershipsCrud.py
@@ -29,6 +29,8 @@ from app.crud.memberships.plans import (
     create_membership_plan,
     get_membership_plan_by_id,
     get_membership_plans,
+    update_membership_plan,
+    set_membership_plan_active,
 )
 from app.crud.memberships.standing_bookings import (
     STANDING_BOOKINGS_AVAILABLE,
@@ -69,6 +71,8 @@ __all__ = [
     "get_membership_plans",
     "get_membership_plan_by_id",
     "create_membership_plan",
+    "update_membership_plan",
+    "set_membership_plan_active",
     "create_membership_subscription",
     "create_payment",
     "get_payments",

--- a/app/crud/permissions.py
+++ b/app/crud/permissions.py
@@ -1,0 +1,138 @@
+"""Capability-based authorization helpers.
+
+Authorization is role-based with an optional per-role capability grant layer.
+The ``admin`` role is an implicit super-user: it always has every capability and
+its grants cannot be revoked. Other roles gain a capability only when an explicit
+row exists in ``role_capabilities``.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import People, Role, RoleCapability
+
+# --- Capability registry (used by the settings UI to render the matrix) ----
+MANAGE_MEMBERSHIP_PLANS = "manage_membership_plans"
+ALL_CAPABILITIES: List[str] = [MANAGE_MEMBERSHIP_PLANS]
+
+ADMIN_ROLE_CODE = "admin"
+
+
+def _person_role_codes(person: Optional[People]) -> Set[str]:
+    if not person or not getattr(person, "roles", None):
+        return set()
+    return {pr.role.code for pr in person.roles if pr.role}
+
+
+def _person_role_ids(person: Optional[People]) -> Set[int]:
+    if not person or not getattr(person, "roles", None):
+        return set()
+    return {pr.role_id for pr in person.roles if pr.role_id is not None}
+
+
+async def get_capabilities_for_person(db: AsyncSession, person: Optional[People]) -> Set[str]:
+    """Effective capability set for a person. Admin implies all capabilities."""
+    role_codes = _person_role_codes(person)
+    if ADMIN_ROLE_CODE in role_codes:
+        return set(ALL_CAPABILITIES)
+
+    role_ids = _person_role_ids(person)
+    if not role_ids:
+        return set()
+
+    result = await db.execute(
+        select(RoleCapability.capability).where(RoleCapability.role_id.in_(role_ids))
+    )
+    return set(result.scalars().all())
+
+
+async def person_can(db: AsyncSession, person: Optional[People], capability: str) -> bool:
+    """Authoritative check: does this person have the given capability?"""
+    if person is None:
+        return False
+    if ADMIN_ROLE_CODE in _person_role_codes(person):
+        return True
+    caps = await get_capabilities_for_person(db, person)
+    return capability in caps
+
+
+async def get_capabilities_for_person_id(db: AsyncSession, person_id: Any) -> Set[str]:
+    """Load the person (with roles) and return their effective capabilities."""
+    from app.crud.usersCrud import get_person_by_id
+
+    person = await get_person_by_id(db, person_id)
+    return await get_capabilities_for_person(db, person)
+
+
+async def list_role_capabilities(db: AsyncSession) -> List[Dict[str, Any]]:
+    """Return every role with its granted capabilities (admin shown with all)."""
+    roles = (await db.execute(select(Role).order_by(Role.code))).scalars().all()
+    grants = (await db.execute(select(RoleCapability))).scalars().all()
+
+    by_role: Dict[int, Set[str]] = {}
+    for grant in grants:
+        by_role.setdefault(grant.role_id, set()).add(grant.capability)
+
+    out: List[Dict[str, Any]] = []
+    for role in roles:
+        if role.code == ADMIN_ROLE_CODE:
+            caps = set(ALL_CAPABILITIES)
+            locked = True
+        else:
+            caps = by_role.get(role.id, set())
+            locked = False
+        out.append(
+            {
+                "role_code": role.code,
+                "role_description": role.description,
+                "capabilities": sorted(caps),
+                "locked": locked,
+            }
+        )
+    return out
+
+
+async def grant_role_capability(db: AsyncSession, role_code: str, capability: str) -> bool:
+    """Grant a capability to a role (idempotent)."""
+    if capability not in ALL_CAPABILITIES:
+        raise ValueError(f"Capacidad desconocida: {capability}")
+
+    role = (await db.execute(select(Role).where(Role.code == role_code))).scalar_one_or_none()
+    if not role:
+        raise ValueError(f"Rol desconocido: {role_code}")
+
+    existing = (
+        await db.execute(
+            select(RoleCapability).where(
+                RoleCapability.role_id == role.id,
+                RoleCapability.capability == capability,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if existing is None:
+        db.add(RoleCapability(role_id=role.id, capability=capability))
+        await db.commit()
+    return True
+
+
+async def revoke_role_capability(db: AsyncSession, role_code: str, capability: str) -> bool:
+    """Revoke a capability from a role. The admin role cannot be revoked."""
+    if role_code == ADMIN_ROLE_CODE:
+        raise ValueError("No se pueden revocar capacidades al rol admin")
+
+    role = (await db.execute(select(Role).where(Role.code == role_code))).scalar_one_or_none()
+    if not role:
+        raise ValueError(f"Rol desconocido: {role_code}")
+
+    await db.execute(
+        delete(RoleCapability).where(
+            RoleCapability.role_id == role.id,
+            RoleCapability.capability == capability,
+        )
+    )
+    await db.commit()
+    return True

--- a/app/graphql/auth/mutations.py
+++ b/app/graphql/auth/mutations.py
@@ -16,6 +16,8 @@ from app.security.jwt import (
     get_refresh_cookie_max_age_seconds,
 )
 from app.crud.authCrud import get_account_by_username
+from app.crud.usersCrud import get_person_by_id
+from app.crud.permissions import get_capabilities_for_person
 from app.crud.sessionCrud import create_session, revoke_session
 from app.graphql.auth.types import LoginInput, TokenResponse
 from app.models.sessionModel import Session
@@ -56,17 +58,24 @@ class AuthMutation:
         if not verify_password(password, account.password_hash):
             raise HTTPException(status_code=401, detail="Credentials not valid")
 
+        # Load the person's roles + effective capabilities so the client can
+        # gate its UI without an extra round-trip. The backend re-checks
+        # capabilities from the DB on every protected mutation, so these claims
+        # are a UX convenience, not the security boundary.
+        person = await get_person_by_id(db, account.person_id)
+        role_codes = sorted({pr.role.code for pr in (person.roles if person else []) if pr.role})
+        capabilities = sorted(await get_capabilities_for_person(db, person))
+
         session_id = f"session-id{uuid.uuid4().hex}"
-        refresh_token = create_refresh_token({
+        token_payload = {
             "person_id": str(account.person_id),
             "username": account.username,
-            "session_id": session_id
-        })
-        access_token = create_access_token({
-            "person_id": str(account.person_id),
-            "username": account.username,
-            "session_id": session_id
-        })
+            "session_id": session_id,
+            "roles": role_codes,
+            "capabilities": capabilities,
+        }
+        refresh_token = create_refresh_token(token_payload)
+        access_token = create_access_token(token_payload)
 
         payload_refresh = verify_refresh_token(refresh_token)
         exp_timestamp = payload_refresh.get("exp") if payload_refresh else None
@@ -128,6 +137,7 @@ class AuthMutation:
         """Manual refresh token mutation for edge cases"""
         request: Request = info.context.request
         response: Response = info.context.response
+        db = info.context.db
 
         refresh_token = request.cookies.get("refresh_token")
 
@@ -138,11 +148,20 @@ class AuthMutation:
         if not payload:
             raise HTTPException(status_code=401, detail="Invalid refresh token")
 
+        # Re-derive roles/capabilities from the DB so newly granted/revoked
+        # permissions take effect on the next refresh (not only on re-login).
+        person_id = payload.get("person_id")
+        person = await get_person_by_id(db, person_id) if person_id else None
+        role_codes = sorted({pr.role.code for pr in (person.roles if person else []) if pr.role})
+        capabilities = sorted(await get_capabilities_for_person(db, person))
+
         # Create new access token
         new_access_token = create_access_token({
-            "person_id": payload.get("person_id"),
+            "person_id": person_id,
             "username": payload.get("username"),
-            "session_id": payload.get("session_id")
+            "session_id": payload.get("session_id"),
+            "roles": role_codes,
+            "capabilities": capabilities,
         })
 
         # Configurar cookies seguras

--- a/app/graphql/auth/permissions.py
+++ b/app/graphql/auth/permissions.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import strawberry
 from strawberry.types import Info
 from strawberry.permission import BasePermission
@@ -7,4 +9,41 @@ class IsAuthenticated(BasePermission):
     message = "Authentication required."
 
     def has_permission(self, source, info: Info, **kwargs):
-        return bool(info.context.user) 
+        return bool(info.context.user)
+
+
+def _context_role_codes(info: Info) -> set:
+    """Role codes for the authenticated user loaded into the GraphQL context."""
+    user = getattr(info.context, "user", None)
+    if user is None or not getattr(user, "roles", None):
+        return set()
+    return {pr.role.code for pr in user.roles if pr.role}
+
+
+async def require_admin(info: Info) -> Optional[str]:
+    """Return an error message if the requester is not an admin, else None."""
+    user = getattr(info.context, "user", None)
+    if user is None:
+        return "Acceso no autorizado"
+    if "admin" not in _context_role_codes(info):
+        return "Se requiere rol de administrador"
+    return None
+
+
+async def require_capability(info: Info, capability: str) -> Optional[str]:
+    """Return an error message if the requester lacks ``capability``, else None.
+
+    This is the authoritative check: it reads roles/grants from the database
+    via the context user, so it does not trust any capability claim baked into
+    the access token.
+    """
+    user = getattr(info.context, "user", None)
+    if user is None:
+        return "Acceso no autorizado"
+
+    from app.crud.permissions import person_can
+
+    db = info.context.db
+    if not await person_can(db, user, capability):
+        return "No tienes permiso para gestionar planes de membresía"
+    return None

--- a/app/graphql/memberships/mutations.py
+++ b/app/graphql/memberships/mutations.py
@@ -16,6 +16,8 @@ from app.services.notification_service import dispatch_event_in_background
 
 from app.crud.membershipsCrud import (
     create_membership_plan,
+    update_membership_plan,
+    set_membership_plan_active,
     create_membership_subscription,
     get_membership_plan_by_id,
     create_member_enrollment,
@@ -26,16 +28,17 @@ from app.crud.membershipsCrud import (
     delete_payment
 )
 from app.crud.membersCrud import get_member_by_id
+from app.crud.permissions import MANAGE_MEMBERSHIP_PLANS
 from app.graphql.memberships.types import (
-    CreateMembershipPlanInput, CreateSubscriptionInput,
+    CreateMembershipPlanInput, UpdateMembershipPlanInput, CreateSubscriptionInput,
     CreateMemberEnrollmentInput, RenewSubscriptionInput,
-    MembershipPlanResponse, SubscriptionResponse,
+    MembershipPlanResponse, MembershipPlanMutationResponse, SubscriptionResponse,
     MemberEnrollmentResponse, SubscriptionRenewalResponse,
     MembershipPlan, Subscription, PaymentRecord,
     UpdatePaymentInput, PaymentMutationResponse
 )
 from app.graphql.members.types import Member
-from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
 
 
 def _classify_renewal_error(error_text: str) -> tuple[str, str]:
@@ -65,9 +68,13 @@ def _classify_renewal_error(error_text: str) -> tuple[str, str]:
 @strawberry.type
 class MembershipMutation:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    async def create_membership_plan(self, info: Info, input: CreateMembershipPlanInput) -> MembershipPlanResponse:
-        """Create a new membership plan"""
+    async def create_membership_plan(self, info: Info, input: CreateMembershipPlanInput) -> MembershipPlanMutationResponse:
+        """Create a new membership plan (requires the manage_membership_plans capability)."""
         db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_MEMBERSHIP_PLANS)
+        if error:
+            return MembershipPlanMutationResponse(success=False, plan=None, message=error)
 
         try:
             plan = await create_membership_plan(
@@ -78,7 +85,9 @@ class MembershipMutation:
                 duration_unit=input.duration_unit,
                 description=input.description,
                 class_limit=input.class_limit,
+                plan_type=input.plan_type,
                 fixed_time_slot=input.fixed_time_slot,
+                is_active=input.is_active,
                 max_sessions_per_day=input.max_sessions_per_day,
                 max_sessions_per_week=input.max_sessions_per_week
             )
@@ -86,17 +95,101 @@ class MembershipMutation:
             # Get plan data
             plan_data = await get_membership_plan_by_id(db=db, plan_id=plan.id)
 
-            return MembershipPlanResponse(
+            return MembershipPlanMutationResponse(
+                success=True,
                 plan=MembershipPlan.from_data(plan_data) if plan_data else None,
-                message="Plan de membresÃ­a creado exitosamente"
+                message="Plan de membresía creado exitosamente"
             )
 
         except Exception as e:
             # Rollback in case of error
             await db.rollback()
-            return MembershipPlanResponse(
+            return MembershipPlanMutationResponse(
+                success=False,
                 plan=None,
-                message=f"Error al crear plan de membresÃ­a: {str(e)}"
+                message=f"Error al crear plan de membresía: {str(e)}"
+            )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def update_membership_plan(self, info: Info, input: UpdateMembershipPlanInput) -> MembershipPlanMutationResponse:
+        """Update an existing membership plan (requires the manage_membership_plans capability)."""
+        db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_MEMBERSHIP_PLANS)
+        if error:
+            return MembershipPlanMutationResponse(success=False, plan=None, message=error)
+
+        _UNSET = object()
+
+        def _opt(value):
+            # Treat None as "not provided" so partial updates don't wipe fields,
+            # except for explicitly nullable fields handled below.
+            return value if value is not None else _UNSET
+
+        try:
+            plan = await update_membership_plan(
+                db=db,
+                plan_id=input.plan_id,
+                name=_opt(input.name),
+                price=_opt(input.price),
+                duration_value=_opt(input.duration_value),
+                duration_unit=_opt(input.duration_unit),
+                description=input.description if input.description is not None else _UNSET,
+                class_limit=input.class_limit if input.class_limit is not None else _UNSET,
+                plan_type=_opt(input.plan_type),
+                is_active=_opt(input.is_active),
+                max_sessions_per_day=input.max_sessions_per_day if input.max_sessions_per_day is not None else _UNSET,
+                max_sessions_per_week=input.max_sessions_per_week if input.max_sessions_per_week is not None else _UNSET,
+            )
+
+            if plan is None:
+                return MembershipPlanMutationResponse(
+                    success=False, plan=None, message="Plan no encontrado"
+                )
+
+            plan_data = await get_membership_plan_by_id(db=db, plan_id=plan.id)
+            return MembershipPlanMutationResponse(
+                success=True,
+                plan=MembershipPlan.from_data(plan_data) if plan_data else None,
+                message="Plan de membresía actualizado exitosamente"
+            )
+
+        except Exception as e:
+            await db.rollback()
+            return MembershipPlanMutationResponse(
+                success=False, plan=None,
+                message=f"Error al actualizar plan de membresía: {str(e)}"
+            )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def set_membership_plan_active(self, info: Info, plan_id: int, is_active: bool) -> MembershipPlanMutationResponse:
+        """Soft-delete (deactivate) or restore a membership plan."""
+        db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_MEMBERSHIP_PLANS)
+        if error:
+            return MembershipPlanMutationResponse(success=False, plan=None, message=error)
+
+        try:
+            plan = await set_membership_plan_active(db=db, plan_id=plan_id, is_active=is_active)
+            if plan is None:
+                return MembershipPlanMutationResponse(
+                    success=False, plan=None, message="Plan no encontrado"
+                )
+
+            plan_data = await get_membership_plan_by_id(db=db, plan_id=plan.id)
+            action = "reactivado" if is_active else "desactivado"
+            return MembershipPlanMutationResponse(
+                success=True,
+                plan=MembershipPlan.from_data(plan_data) if plan_data else None,
+                message=f"Plan {action} exitosamente"
+            )
+
+        except Exception as e:
+            await db.rollback()
+            return MembershipPlanMutationResponse(
+                success=False, plan=None,
+                message=f"Error al cambiar el estado del plan: {str(e)}"
             )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])

--- a/app/graphql/memberships/queries.py
+++ b/app/graphql/memberships/queries.py
@@ -23,10 +23,10 @@ from app.core.conversions import coerce_int
 @strawberry.type
 class MembershipsQuery:
     @strawberry.field(permission_classes=[IsAuthenticated])
-    async def membership_plans(self, info: Info) -> List[MembershipPlan]:
-        """Get all available membership plans"""
+    async def membership_plans(self, info: Info, include_inactive: bool = False) -> List[MembershipPlan]:
+        """Get membership plans. By default only active plans are returned."""
         db: AsyncSession = info.context.db
-        plans_data = await get_membership_plans(db=db)
+        plans_data = await get_membership_plans(db=db, include_inactive=include_inactive)
         return [MembershipPlan.from_data(plan_data) for plan_data in plans_data]
 
     @strawberry.field(permission_classes=[IsAuthenticated])

--- a/app/graphql/memberships/types.py
+++ b/app/graphql/memberships/types.py
@@ -16,7 +16,9 @@ class MembershipPlan:
     duration_value: int
     duration_unit: str
     class_limit: Optional[int]
+    plan_type: str
     fixed_time_slot: bool
+    is_active: bool
     max_sessions_per_day: Optional[int]
     max_sessions_per_week: Optional[int]
     created_at: datetime
@@ -31,7 +33,9 @@ class MembershipPlan:
             duration_value=data.duration_value,
             duration_unit=data.duration_unit,
             class_limit=data.class_limit,
+            plan_type=data.plan_type,
             fixed_time_slot=data.fixed_time_slot,
+            is_active=data.is_active,
             max_sessions_per_day=data.max_sessions_per_day,
             max_sessions_per_week=data.max_sessions_per_week,
             created_at=data.created_at
@@ -199,7 +203,24 @@ class CreateMembershipPlanInput:
     duration_unit: str
     description: Optional[str] = None
     class_limit: Optional[int] = None
-    fixed_time_slot: bool = False
+    plan_type: str = "fixed_schedule"
+    fixed_time_slot: Optional[bool] = None  # derived from plan_type when omitted
+    is_active: bool = True
+    max_sessions_per_day: Optional[int] = None
+    max_sessions_per_week: Optional[int] = None
+
+
+@strawberry.input
+class UpdateMembershipPlanInput:
+    plan_id: int
+    name: Optional[str] = None
+    price: Optional[float] = None
+    duration_value: Optional[int] = None
+    duration_unit: Optional[str] = None
+    description: Optional[str] = None
+    class_limit: Optional[int] = None
+    plan_type: Optional[str] = None
+    is_active: Optional[bool] = None
     max_sessions_per_day: Optional[int] = None
     max_sessions_per_week: Optional[int] = None
 
@@ -248,6 +269,13 @@ class RenewSubscriptionInput:
 
 @strawberry.type
 class MembershipPlanResponse:
+    plan: Optional[MembershipPlan]
+    message: str
+
+
+@strawberry.type
+class MembershipPlanMutationResponse:
+    success: bool
     plan: Optional[MembershipPlan]
     message: str
 

--- a/app/graphql/permissions/mutations.py
+++ b/app/graphql/permissions/mutations.py
@@ -1,0 +1,44 @@
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud.permissions import grant_role_capability, revoke_role_capability
+from app.graphql.auth.permissions import IsAuthenticated, require_admin
+from app.graphql.permissions.types import CapabilityMutationResponse
+
+
+@strawberry.type
+class PermissionsMutation:
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def grant_role_capability(
+        self, info: Info, role_code: str, capability: str
+    ) -> CapabilityMutationResponse:
+        """Grant a capability to a role (admin only)."""
+        error = await require_admin(info)
+        if error:
+            return CapabilityMutationResponse(success=False, message=error)
+
+        db: AsyncSession = info.context.db
+        try:
+            await grant_role_capability(db, role_code, capability)
+            return CapabilityMutationResponse(success=True, message="Permiso concedido")
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            return CapabilityMutationResponse(success=False, message=str(exc))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def revoke_role_capability(
+        self, info: Info, role_code: str, capability: str
+    ) -> CapabilityMutationResponse:
+        """Revoke a capability from a role (admin only)."""
+        error = await require_admin(info)
+        if error:
+            return CapabilityMutationResponse(success=False, message=error)
+
+        db: AsyncSession = info.context.db
+        try:
+            await revoke_role_capability(db, role_code, capability)
+            return CapabilityMutationResponse(success=True, message="Permiso revocado")
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            return CapabilityMutationResponse(success=False, message=str(exc))

--- a/app/graphql/permissions/queries.py
+++ b/app/graphql/permissions/queries.py
@@ -1,0 +1,48 @@
+from typing import List
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud.permissions import (
+    ALL_CAPABILITIES,
+    get_capabilities_for_person,
+    list_role_capabilities,
+)
+from app.graphql.auth.permissions import IsAuthenticated, require_admin
+from app.graphql.permissions.types import RoleCapabilities
+
+
+@strawberry.type
+class PermissionsQuery:
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def role_capabilities(self, info: Info) -> List[RoleCapabilities]:
+        """Matrix of roles and their granted capabilities (admin only)."""
+        error = await require_admin(info)
+        if error:
+            return []
+
+        db: AsyncSession = info.context.db
+        rows = await list_role_capabilities(db)
+        return [
+            RoleCapabilities(
+                role_code=row["role_code"],
+                role_description=row["role_description"],
+                capabilities=row["capabilities"],
+                locked=row["locked"],
+            )
+            for row in rows
+        ]
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def all_capabilities(self, info: Info) -> List[str]:
+        """The catalog of capabilities the system knows about."""
+        return list(ALL_CAPABILITIES)
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def my_capabilities(self, info: Info) -> List[str]:
+        """Effective capabilities for the current user (fresh from DB)."""
+        db: AsyncSession = info.context.db
+        user = getattr(info.context, "user", None)
+        caps = await get_capabilities_for_person(db, user)
+        return sorted(caps)

--- a/app/graphql/permissions/types.py
+++ b/app/graphql/permissions/types.py
@@ -1,0 +1,19 @@
+from typing import List, Optional
+
+import strawberry
+
+
+@strawberry.type
+class RoleCapabilities:
+    """A role and the capabilities currently granted to it."""
+
+    role_code: str
+    role_description: Optional[str]
+    capabilities: List[str]
+    locked: bool  # True for admin (implicit super-user; not editable)
+
+
+@strawberry.type
+class CapabilityMutationResponse:
+    success: bool
+    message: str

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -34,6 +34,8 @@ from app.graphql.chatbot.queries import ChatbotConfigQuery
 from app.graphql.chatbot.mutations import ChatbotConfigMutation
 from app.graphql.campaigns.queries import CampaignsQuery
 from app.graphql.campaigns.mutations import CampaignsMutation
+from app.graphql.permissions.queries import PermissionsQuery
+from app.graphql.permissions.mutations import PermissionsMutation
 
 logger = logging.getLogger(__name__)
 
@@ -56,13 +58,13 @@ except ImportError as e:
         pass
 
 @strawberry.type
-class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery):
+class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery, PermissionsQuery):
     @strawberry.field
     def hello(self) -> str:
         return "Hello from GraphQL!"
 
 @strawberry.type
-class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation):
+class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation):
     pass
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,5 @@
 # Modern FitPilot models - Modular architecture
-from app.models.userModel import People, Role, PersonRole, Account
+from app.models.userModel import People, Role, PersonRole, Account, RoleCapability
 from app.models.membershipsModel import MembershipPlan, MembershipSubscription, Payment
 from app.models.venueModel import (
     Venue, Seat, SeatType, Asset, AssetType, AssetModel, AssetSeatAssignment, AssetEvent
@@ -21,7 +21,7 @@ from app.models.chatbotModel import ChatbotConfig, ChatbotPendingAction
 from app.models.campaignsModel import Campaign, CampaignVariant, CampaignRecipient
 
 __all__ = [
-    "People", "Role", "PersonRole", "Account",
+    "People", "Role", "PersonRole", "Account", "RoleCapability",
     "MembershipPlan", "MembershipSubscription", "Payment",
     "Venue", "Seat", "SeatType", "Asset", "AssetType", "AssetModel", "AssetSeatAssignment", "AssetEvent",
     "ClassType", "ClassTemplate", "ClassSession", "Reservation", "StandingBooking", "StandingBookingException",

--- a/app/models/membershipsModel.py
+++ b/app/models/membershipsModel.py
@@ -31,7 +31,13 @@ class MembershipPlan(Base):
     duration_value: Mapped[int] = mapped_column(Integer, nullable=False)
     duration_unit: Mapped[str] = mapped_column(String(10), nullable=False)
     class_limit: Mapped[Optional[int]] = mapped_column(Integer)
+    # plan_type discriminates the booking model the plan follows:
+    #   'fixed_schedule' -> recurring weekly slot (uses standing bookings; fixed_time_slot=True)
+    #   'flexible'       -> open time-based access, no fixed slot, no credit limit
+    #   'credit_pack'    -> prepaid credits / pay-per-session (class_limit = number of credits)
+    plan_type: Mapped[str] = mapped_column(String(20), nullable=False, default="fixed_schedule")
     fixed_time_slot: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     max_sessions_per_day: Mapped[Optional[int]] = mapped_column(Integer)
     max_sessions_per_week: Mapped[Optional[int]] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
@@ -42,6 +48,10 @@ class MembershipPlan(Base):
 
     __table_args__ = (
         CheckConstraint("duration_unit IN ('day','week','month')", name="ck_duration_unit"),
+        CheckConstraint(
+            "plan_type IN ('fixed_schedule','flexible','credit_pack')",
+            name="ck_plan_type",
+        ),
     )
 
 

--- a/app/models/userModel.py
+++ b/app/models/userModel.py
@@ -85,6 +85,28 @@ class PersonRole(Base):
     role: Mapped["Role"] = relationship(back_populates="person_roles")
 
 
+class RoleCapability(Base):
+    """Capabilities granted to a role (capability-based authorization).
+
+    A role can be granted named capabilities (e.g. ``manage_membership_plans``).
+    The ``admin`` role is treated as an implicit super-user in code and does not
+    depend on rows here, but it may be seeded for display purposes.
+    """
+
+    __tablename__ = "role_capabilities"
+
+    role_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("roles.id", ondelete="CASCADE"), primary_key=True
+    )
+    capability: Mapped[str] = mapped_column(String(60), primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=datetime.utcnow
+    )
+
+    # Relationships
+    role: Mapped["Role"] = relationship()
+
+
 class Account(Base):
     """Login accounts for system users"""
 


### PR DESCRIPTION
## Qué hace

Convierte la pestaña Membresías en un CRUD real y añade autorización por capacidad.

### Planes (catálogo)
- `membership_plans`: nuevos campos `plan_type` (`fixed_schedule` | `flexible` | `credit_pack`) e `is_active` (soft-delete). `fixed_time_slot` se deriva de `plan_type`.
- `credit_pack` = **pago por sesión / créditos prepagados** (`class_limit` = nº de créditos, `duration_*` = vigencia). El consumo de créditos en runtime queda como Fase 2.
- CRUD: `update_membership_plan`, `set_membership_plan_active`, `get_membership_plans(include_inactive)`.
- GraphQL: `createMembershipPlan` / `updateMembershipPlan` / `setMembershipPlanActive` → `MembershipPlanMutationResponse`, query con `includeInactive`.

### Autorización por capacidad
- Tabla `role_capabilities` + `crud/permissions.py` (rol `admin` = super-usuario implícito; otros roles requieren grant).
- Paquete `graphql/permissions/`: query `roleCapabilities` / `allCapabilities` / `myCapabilities`; mutaciones `grantRoleCapability` / `revokeRoleCapability` (admin-only).
- Las mutaciones de planes exigen la capacidad `manage_membership_plans` vía `require_capability`.
- El JWT (login + refresh) ahora incluye claims `roles` y `capabilities`.

### Migración
- `b2c3d4e5f6a7` (revisa `f7a8b9c0d1e2`): **aditiva e idempotente** — añade columnas con backfill, crea `role_capabilities` y siembra el grant de `admin`.
- ⚠️ Prerrequisito duro: el código nuevo selecciona `plan_type`/`is_active` y el login consulta `role_capabilities`. Coolify la aplica en el deploy (`alembic upgrade head`).

## Verificación
- Backend compila y el esquema GraphQL se construye; el SDL expone los campos/argumentos esperados.
- Cambios de frontend (desktop) van en su propio repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)