### PR TITLE
[codex] Add configurable WhatsApp owner agent backend

### DIFF
--- a/alembic/versions/c3d4e5f6a7b8_owner_agent_config.py
+++ b/alembic/versions/c3d4e5f6a7b8_owner_agent_config.py
@@ -1,0 +1,325 @@
+"""Owner/admin WhatsApp agent configuration and state.
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-20 10:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+_DEFAULT_SYSTEM_PROMPT = (
+    "Eres el agente administrativo de FitPilot. Respondes por WhatsApp al dueno o "
+    "administradores autorizados. Puedes consultar datos reales del negocio usando "
+    "herramientas y resumirlos de forma breve y accionable. Nunca inventes metricas, "
+    "pagos, horarios, disponibilidad ni datos de socios. Para cualquier accion que "
+    "cambie datos, primero presenta un resumen claro y pide confirmacion explicita."
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "owner_agent_config",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column(
+            "require_confirmation",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "model",
+            sa.String(length=80),
+            nullable=False,
+            server_default=sa.text("'claude-sonnet-4-6'"),
+        ),
+        sa.Column("system_prompt", sa.Text(), nullable=True),
+        sa.Column("history_limit", sa.Integer(), nullable=False, server_default=sa.text("30")),
+        sa.Column("max_tokens", sa.Integer(), nullable=False, server_default=sa.text("1024")),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        schema=SCHEMA,
+    )
+    op.bulk_insert(
+        sa.table(
+            "owner_agent_config",
+            sa.column("enabled", sa.Boolean),
+            sa.column("require_confirmation", sa.Boolean),
+            sa.column("model", sa.String),
+            sa.column("system_prompt", sa.Text),
+            sa.column("history_limit", sa.Integer),
+            sa.column("max_tokens", sa.Integer),
+            schema=SCHEMA,
+        ),
+        [
+            {
+                "enabled": False,
+                "require_confirmation": True,
+                "model": "claude-sonnet-4-6",
+                "system_prompt": _DEFAULT_SYSTEM_PROMPT,
+                "history_limit": 30,
+                "max_tokens": 1024,
+            }
+        ],
+    )
+
+    op.create_table(
+        "owner_agent_authorized_phone",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("label", sa.String(length=120), nullable=False),
+        sa.Column("phone_number", sa.String(length=40), nullable=False),
+        sa.Column("normalized_wa_id", sa.String(length=30), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_by", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(["created_by"], [f"{SCHEMA}.accounts.id"]),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_owner_agent_authorized_phone_wa",
+        "owner_agent_authorized_phone",
+        ["normalized_wa_id"],
+        unique=True,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_owner_agent_authorized_phone_enabled",
+        "owner_agent_authorized_phone",
+        ["enabled"],
+        unique=False,
+        schema=SCHEMA,
+    )
+    op.bulk_insert(
+        sa.table(
+            "owner_agent_authorized_phone",
+            sa.column("label", sa.String),
+            sa.column("phone_number", sa.String),
+            sa.column("normalized_wa_id", sa.String),
+            sa.column("enabled", sa.Boolean),
+            schema=SCHEMA,
+        ),
+        [
+            {
+                "label": "Dueno",
+                "phone_number": "8719708890",
+                "normalized_wa_id": "5218719708890",
+                "enabled": True,
+            }
+        ],
+    )
+
+    op.create_table(
+        "owner_agent_pending_action",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("conversation_id", sa.BigInteger(), nullable=False),
+        sa.Column("authorized_phone_id", sa.BigInteger(), nullable=True),
+        sa.Column("action_type", sa.String(length=50), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=True),
+        sa.Column("summary", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["authorized_phone_id"],
+            [f"{SCHEMA}.owner_agent_authorized_phone.id"],
+            ondelete="SET NULL",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_owner_agent_pending_conversation",
+        "owner_agent_pending_action",
+        ["conversation_id"],
+        unique=True,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_owner_agent_pending_status",
+        "owner_agent_pending_action",
+        ["status"],
+        unique=False,
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "owner_agent_audit_log",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("conversation_id", sa.BigInteger(), nullable=True),
+        sa.Column("message_id", sa.BigInteger(), nullable=True),
+        sa.Column("authorized_phone_id", sa.BigInteger(), nullable=True),
+        sa.Column("tool_name", sa.String(length=100), nullable=True),
+        sa.Column("action_type", sa.String(length=50), nullable=True),
+        sa.Column("payload", sa.JSON(), nullable=True),
+        sa.Column("result_summary", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default=sa.text("'ok'")),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["authorized_phone_id"],
+            [f"{SCHEMA}.owner_agent_authorized_phone.id"],
+            ondelete="SET NULL",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_owner_agent_audit_phone_created",
+        "owner_agent_audit_log",
+        ["authorized_phone_id", "created_at"],
+        unique=False,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_owner_agent_audit_conversation",
+        "owner_agent_audit_log",
+        ["conversation_id"],
+        unique=False,
+        schema=SCHEMA,
+    )
+
+    op.create_table(
+        "owner_tasks",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("title", sa.String(length=240), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default=sa.text("'open'")),
+        sa.Column("due_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_by_phone_id", sa.BigInteger(), nullable=True),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["created_by_phone_id"],
+            [f"{SCHEMA}.owner_agent_authorized_phone.id"],
+            ondelete="SET NULL",
+        ),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_owner_tasks_status_due",
+        "owner_tasks",
+        ["status", "due_at"],
+        unique=False,
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "idx_owner_tasks_created_by",
+        "owner_tasks",
+        ["created_by_phone_id"],
+        unique=False,
+        schema=SCHEMA,
+    )
+
+    op.execute(
+        f"""
+        INSERT INTO {SCHEMA}.role_capabilities (role_id, capability)
+        SELECT id, 'manage_owner_agent' FROM {SCHEMA}.roles WHERE code = 'admin'
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"DELETE FROM {SCHEMA}.role_capabilities WHERE capability = 'manage_owner_agent'"
+    )
+    op.drop_index("idx_owner_tasks_created_by", table_name="owner_tasks", schema=SCHEMA)
+    op.drop_index("idx_owner_tasks_status_due", table_name="owner_tasks", schema=SCHEMA)
+    op.drop_table("owner_tasks", schema=SCHEMA)
+    op.drop_index(
+        "idx_owner_agent_audit_conversation",
+        table_name="owner_agent_audit_log",
+        schema=SCHEMA,
+    )
+    op.drop_index(
+        "idx_owner_agent_audit_phone_created",
+        table_name="owner_agent_audit_log",
+        schema=SCHEMA,
+    )
+    op.drop_table("owner_agent_audit_log", schema=SCHEMA)
+    op.drop_index(
+        "idx_owner_agent_pending_status",
+        table_name="owner_agent_pending_action",
+        schema=SCHEMA,
+    )
+    op.drop_index(
+        "uq_owner_agent_pending_conversation",
+        table_name="owner_agent_pending_action",
+        schema=SCHEMA,
+    )
+    op.drop_table("owner_agent_pending_action", schema=SCHEMA)
+    op.drop_index(
+        "idx_owner_agent_authorized_phone_enabled",
+        table_name="owner_agent_authorized_phone",
+        schema=SCHEMA,
+    )
+    op.drop_index(
+        "uq_owner_agent_authorized_phone_wa",
+        table_name="owner_agent_authorized_phone",
+        schema=SCHEMA,
+    )
+    op.drop_table("owner_agent_authorized_phone", schema=SCHEMA)
+    op.drop_table("owner_agent_config", schema=SCHEMA)

--- a/app/crud/ownerAgentCrud.py
+++ b/app/crud/ownerAgentCrud.py
@@ -1,0 +1,526 @@
+"""CRUD and normalization helpers for the owner/admin WhatsApp agent."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    OwnerAgentAuditLog,
+    OwnerAgentAuthorizedPhone,
+    OwnerAgentConfig,
+    OwnerAgentPendingAction,
+    OwnerTask,
+)
+from app.models.ownerAgentModel import (
+    OWNER_PENDING_STATUS_CANCELED,
+    OWNER_PENDING_STATUS_PENDING,
+    OWNER_TASK_STATUS_CANCELED,
+    OWNER_TASK_STATUS_DONE,
+    OWNER_TASK_STATUS_OPEN,
+)
+
+
+DEFAULT_OWNER_SYSTEM_PROMPT = (
+    "Eres el agente administrativo de FitPilot. Respondes por WhatsApp al dueno o "
+    "administradores autorizados. Puedes consultar datos reales del negocio usando "
+    "herramientas y resumirlos de forma breve y accionable. Nunca inventes metricas, "
+    "pagos, horarios, disponibilidad ni datos de socios. Para cualquier accion que "
+    "cambie datos, primero presenta un resumen claro y pide confirmacion explicita."
+)
+
+
+@dataclass
+class OwnerAgentConfigData:
+    id: Optional[int]
+    enabled: bool
+    require_confirmation: bool
+    model: str
+    system_prompt: Optional[str]
+    history_limit: int
+    max_tokens: int
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+
+    @classmethod
+    def from_model(cls, model: OwnerAgentConfig) -> "OwnerAgentConfigData":
+        return cls(
+            id=model.id,
+            enabled=bool(model.enabled),
+            require_confirmation=bool(model.require_confirmation),
+            model=model.model,
+            system_prompt=model.system_prompt,
+            history_limit=int(model.history_limit or 30),
+            max_tokens=int(model.max_tokens or 1024),
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+
+@dataclass
+class OwnerAgentAuthorizedPhoneData:
+    id: int
+    label: str
+    phone_number: str
+    normalized_wa_id: str
+    enabled: bool
+    created_by: Optional[int]
+    created_at: Optional[datetime]
+    updated_at: Optional[datetime]
+
+    @classmethod
+    def from_model(cls, model: OwnerAgentAuthorizedPhone) -> "OwnerAgentAuthorizedPhoneData":
+        return cls(
+            id=model.id,
+            label=model.label,
+            phone_number=model.phone_number,
+            normalized_wa_id=model.normalized_wa_id,
+            enabled=bool(model.enabled),
+            created_by=model.created_by,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )
+
+
+def digits_only(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    return "".join(ch for ch in str(value) if ch.isdigit())
+
+
+def phone_match_keys(value: Optional[str]) -> set[str]:
+    """Return phone variants used by Meta/Mexico WhatsApp formats.
+
+    Mexico numbers may arrive as local 10 digits, 52 + local, or 521 + local.
+    Keeping all variants here lets the configurable allowlist remain stable even
+    if Meta sends a different representation than the admin typed.
+    """
+    digits = digits_only(value)
+    if not digits:
+        return set()
+
+    keys = {digits}
+    if len(digits) >= 10:
+        local = digits[-10:]
+        keys.update({local, f"52{local}", f"521{local}"})
+
+    if digits.startswith("521") and len(digits) >= 13:
+        local = digits[3:]
+        keys.update({local, f"52{local}"})
+    elif digits.startswith("52") and len(digits) >= 12:
+        local = digits[2:]
+        keys.update({local, f"521{local}"})
+
+    return {key for key in keys if key}
+
+
+def normalize_owner_phone(value: Optional[str]) -> str:
+    """Canonical WhatsApp id stored for an authorized owner phone."""
+    digits = digits_only(value)
+    if len(digits) < 10:
+        raise ValueError("Telefono invalido: captura al menos 10 digitos.")
+
+    local = digits[-10:]
+    if digits.startswith("521") and len(digits) >= 13:
+        return f"521{local}"
+    if digits.startswith("52") and len(digits) >= 12:
+        return f"521{local}"
+    if len(digits) == 10:
+        return f"521{local}"
+    return digits
+
+
+def _clamp_int(value: Any, default: int, min_value: int, max_value: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(min_value, min(parsed, max_value))
+
+
+async def get_config_model(db: AsyncSession) -> Optional[OwnerAgentConfig]:
+    stmt = select(OwnerAgentConfig).order_by(OwnerAgentConfig.id.asc()).limit(1)
+    return (await db.execute(stmt)).scalars().first()
+
+
+async def get_or_create_config_model(db: AsyncSession) -> OwnerAgentConfig:
+    config = await get_config_model(db)
+    if config is not None:
+        return config
+    now = datetime.now(timezone.utc)
+    config = OwnerAgentConfig(
+        enabled=False,
+        require_confirmation=True,
+        model="claude-sonnet-4-6",
+        system_prompt=DEFAULT_OWNER_SYSTEM_PROMPT,
+        history_limit=30,
+        max_tokens=1024,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(config)
+    await db.flush()
+    return config
+
+
+async def get_config(db: AsyncSession) -> OwnerAgentConfigData:
+    model = await get_config_model(db)
+    if model is None:
+        return OwnerAgentConfigData(
+            id=None,
+            enabled=False,
+            require_confirmation=True,
+            model="claude-sonnet-4-6",
+            system_prompt=DEFAULT_OWNER_SYSTEM_PROMPT,
+            history_limit=30,
+            max_tokens=1024,
+            created_at=None,
+            updated_at=None,
+        )
+    return OwnerAgentConfigData.from_model(model)
+
+
+async def upsert_config(db: AsyncSession, *, commit: bool = True, **fields) -> OwnerAgentConfig:
+    config = await get_config_model(db)
+    if config is None:
+        now = datetime.now(timezone.utc)
+        config = OwnerAgentConfig(
+            enabled=False,
+            require_confirmation=True,
+            model="claude-sonnet-4-6",
+            system_prompt=DEFAULT_OWNER_SYSTEM_PROMPT,
+            history_limit=30,
+            max_tokens=1024,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(config)
+        await db.flush()
+    if "enabled" in fields and fields["enabled"] is not None:
+        config.enabled = bool(fields["enabled"])
+    if "require_confirmation" in fields and fields["require_confirmation"] is not None:
+        config.require_confirmation = bool(fields["require_confirmation"])
+    if "model" in fields and fields["model"] is not None:
+        model = str(fields["model"]).strip()
+        if model:
+            config.model = model[:80]
+    if "system_prompt" in fields and fields["system_prompt"] is not None:
+        config.system_prompt = str(fields["system_prompt"]).strip() or None
+    if "history_limit" in fields and fields["history_limit"] is not None:
+        config.history_limit = _clamp_int(fields["history_limit"], 30, 1, 100)
+    if "max_tokens" in fields and fields["max_tokens"] is not None:
+        config.max_tokens = _clamp_int(fields["max_tokens"], 1024, 256, 4096)
+    config.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(config)
+    return config
+
+
+async def list_authorized_phones(db: AsyncSession) -> list[OwnerAgentAuthorizedPhoneData]:
+    stmt = select(OwnerAgentAuthorizedPhone).order_by(
+        OwnerAgentAuthorizedPhone.enabled.desc(),
+        OwnerAgentAuthorizedPhone.label.asc(),
+        OwnerAgentAuthorizedPhone.id.asc(),
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    return [OwnerAgentAuthorizedPhoneData.from_model(row) for row in rows]
+
+
+async def get_authorized_phone_model(
+    db: AsyncSession, phone_id: int
+) -> Optional[OwnerAgentAuthorizedPhone]:
+    return await db.get(OwnerAgentAuthorizedPhone, int(phone_id))
+
+
+async def add_authorized_phone(
+    db: AsyncSession,
+    *,
+    label: str,
+    phone_number: str,
+    created_by: Optional[int] = None,
+    enabled: bool = True,
+    commit: bool = True,
+) -> OwnerAgentAuthorizedPhone:
+    normalized = normalize_owner_phone(phone_number)
+    existing = (
+        await db.execute(
+            select(OwnerAgentAuthorizedPhone).where(
+                OwnerAgentAuthorizedPhone.normalized_wa_id == normalized
+            )
+        )
+    ).scalars().first()
+    now = datetime.now(timezone.utc)
+    clean_label = (label or "").strip() or normalized
+    clean_phone = (phone_number or "").strip() or normalized
+
+    if existing is None:
+        existing = OwnerAgentAuthorizedPhone(
+            label=clean_label[:120],
+            phone_number=clean_phone[:40],
+            normalized_wa_id=normalized,
+            enabled=bool(enabled),
+            created_by=created_by,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(existing)
+    else:
+        existing.label = clean_label[:120]
+        existing.phone_number = clean_phone[:40]
+        existing.enabled = bool(enabled)
+        if existing.created_by is None:
+            existing.created_by = created_by
+        existing.updated_at = now
+
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(existing)
+    return existing
+
+
+async def update_authorized_phone(
+    db: AsyncSession,
+    *,
+    phone_id: int,
+    label: Optional[str] = None,
+    phone_number: Optional[str] = None,
+    enabled: Optional[bool] = None,
+    commit: bool = True,
+) -> Optional[OwnerAgentAuthorizedPhone]:
+    model = await get_authorized_phone_model(db, phone_id)
+    if model is None:
+        return None
+    if label is not None:
+        model.label = (label.strip() or model.normalized_wa_id)[:120]
+    if phone_number is not None:
+        model.phone_number = (phone_number.strip() or model.phone_number)[:40]
+        model.normalized_wa_id = normalize_owner_phone(phone_number)
+    if enabled is not None:
+        model.enabled = bool(enabled)
+    model.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(model)
+    return model
+
+
+async def disable_authorized_phone(
+    db: AsyncSession, *, phone_id: int, commit: bool = True
+) -> Optional[OwnerAgentAuthorizedPhone]:
+    return await update_authorized_phone(
+        db, phone_id=phone_id, enabled=False, commit=commit
+    )
+
+
+async def resolve_authorized_phone(
+    db: AsyncSession, wa_id: Optional[str]
+) -> Optional[OwnerAgentAuthorizedPhoneData]:
+    keys = phone_match_keys(wa_id)
+    if not keys:
+        return None
+    stmt = (
+        select(OwnerAgentAuthorizedPhone)
+        .where(OwnerAgentAuthorizedPhone.enabled.is_(True))
+        .where(OwnerAgentAuthorizedPhone.normalized_wa_id.in_(keys))
+        .limit(1)
+    )
+    row = (await db.execute(stmt)).scalars().first()
+    return OwnerAgentAuthorizedPhoneData.from_model(row) if row else None
+
+
+async def audit_event(
+    db: AsyncSession,
+    *,
+    conversation_id: Optional[int],
+    message_id: Optional[int],
+    authorized_phone_id: Optional[int],
+    tool_name: Optional[str] = None,
+    action_type: Optional[str] = None,
+    payload: Optional[dict] = None,
+    result_summary: Optional[str] = None,
+    status: str = "ok",
+    error: Optional[str] = None,
+    commit: bool = False,
+) -> OwnerAgentAuditLog:
+    row = OwnerAgentAuditLog(
+        conversation_id=conversation_id,
+        message_id=message_id,
+        authorized_phone_id=authorized_phone_id,
+        tool_name=tool_name,
+        action_type=action_type,
+        payload=payload or {},
+        result_summary=(result_summary or "")[:4000] if result_summary else None,
+        status=status[:20],
+        error=(error or "")[:4000] if error else None,
+    )
+    db.add(row)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(row)
+    return row
+
+
+async def get_pending_action(
+    db: AsyncSession, conversation_id: int
+) -> Optional[OwnerAgentPendingAction]:
+    stmt = select(OwnerAgentPendingAction).where(
+        OwnerAgentPendingAction.conversation_id == int(conversation_id)
+    )
+    pending = (await db.execute(stmt)).scalars().first()
+    if pending is None or pending.status != OWNER_PENDING_STATUS_PENDING:
+        return None
+    if pending.expires_at is not None and pending.expires_at < datetime.now(timezone.utc):
+        pending.status = "expired"
+        pending.updated_at = datetime.now(timezone.utc)
+        await db.flush()
+        return None
+    return pending
+
+
+async def upsert_pending_action(
+    db: AsyncSession,
+    *,
+    conversation_id: int,
+    authorized_phone_id: Optional[int],
+    action_type: str,
+    payload: dict,
+    summary: str,
+    ttl_minutes: int = 30,
+    commit: bool = True,
+) -> OwnerAgentPendingAction:
+    pending = (
+        await db.execute(
+            select(OwnerAgentPendingAction).where(
+                OwnerAgentPendingAction.conversation_id == int(conversation_id)
+            )
+        )
+    ).scalars().first()
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(minutes=max(1, min(int(ttl_minutes or 30), 240)))
+    if pending is None:
+        pending = OwnerAgentPendingAction(
+            conversation_id=int(conversation_id),
+            authorized_phone_id=authorized_phone_id,
+            action_type=action_type[:50],
+            payload=payload or {},
+            summary=summary,
+            status=OWNER_PENDING_STATUS_PENDING,
+            expires_at=expires_at,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(pending)
+    else:
+        pending.authorized_phone_id = authorized_phone_id
+        pending.action_type = action_type[:50]
+        pending.payload = payload or {}
+        pending.summary = summary
+        pending.status = OWNER_PENDING_STATUS_PENDING
+        pending.expires_at = expires_at
+        pending.updated_at = now
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(pending)
+    return pending
+
+
+async def mark_pending_action(
+    db: AsyncSession, pending_id: int, status: str, *, commit: bool = True
+) -> bool:
+    pending = await db.get(OwnerAgentPendingAction, int(pending_id))
+    if pending is None:
+        return False
+    pending.status = status
+    pending.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+    if commit:
+        await db.commit()
+    return True
+
+
+async def cancel_pending_action(
+    db: AsyncSession, conversation_id: int, *, commit: bool = True
+) -> bool:
+    pending = await get_pending_action(db, conversation_id)
+    if pending is None:
+        return False
+    return await mark_pending_action(
+        db, pending.id, OWNER_PENDING_STATUS_CANCELED, commit=commit
+    )
+
+
+async def list_owner_tasks(
+    db: AsyncSession, *, include_done: bool = False, limit: int = 20
+) -> list[OwnerTask]:
+    statuses = [OWNER_TASK_STATUS_OPEN]
+    if include_done:
+        statuses.extend([OWNER_TASK_STATUS_DONE, OWNER_TASK_STATUS_CANCELED])
+    stmt = (
+        select(OwnerTask)
+        .where(OwnerTask.status.in_(statuses))
+        .order_by(OwnerTask.status.asc(), OwnerTask.due_at.asc().nullslast(), OwnerTask.id.desc())
+        .limit(max(1, min(int(limit or 20), 100)))
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def create_owner_task(
+    db: AsyncSession,
+    *,
+    title: str,
+    description: Optional[str] = None,
+    due_at: Optional[datetime] = None,
+    created_by_phone_id: Optional[int] = None,
+    commit: bool = True,
+) -> OwnerTask:
+    clean_title = (title or "").strip()
+    if not clean_title:
+        raise ValueError("La tarea necesita titulo.")
+    now = datetime.now(timezone.utc)
+    task = OwnerTask(
+        title=clean_title[:240],
+        description=(description or "").strip() or None,
+        status=OWNER_TASK_STATUS_OPEN,
+        due_at=due_at,
+        created_by_phone_id=created_by_phone_id,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(task)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(task)
+    return task
+
+
+async def set_owner_task_status(
+    db: AsyncSession,
+    *,
+    task_id: int,
+    status: str,
+    commit: bool = True,
+) -> Optional[OwnerTask]:
+    if status not in {OWNER_TASK_STATUS_OPEN, OWNER_TASK_STATUS_DONE, OWNER_TASK_STATUS_CANCELED}:
+        raise ValueError(f"Estado de tarea invalido: {status}")
+    task = await db.get(OwnerTask, int(task_id))
+    if task is None:
+        return None
+    task.status = status
+    now = datetime.now(timezone.utc)
+    task.completed_at = now if status == OWNER_TASK_STATUS_DONE else None
+    task.updated_at = now
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(task)
+    return task

--- a/app/crud/permissions.py
+++ b/app/crud/permissions.py
@@ -16,7 +16,8 @@ from app.models import People, Role, RoleCapability
 
 # --- Capability registry (used by the settings UI to render the matrix) ----
 MANAGE_MEMBERSHIP_PLANS = "manage_membership_plans"
-ALL_CAPABILITIES: List[str] = [MANAGE_MEMBERSHIP_PLANS]
+MANAGE_OWNER_AGENT = "manage_owner_agent"
+ALL_CAPABILITIES: List[str] = [MANAGE_MEMBERSHIP_PLANS, MANAGE_OWNER_AGENT]
 
 ADMIN_ROLE_CODE = "admin"
 

--- a/app/crud/whatsappCrud.py
+++ b/app/crud/whatsappCrud.py
@@ -63,7 +63,7 @@ class _MemberCandidate:
     phone_number: Optional[str]
     active_membership_rank: int
     latest_membership_end: Optional[datetime]
-    membership: Optional[ChatMembershipData]
+    membership: Optional[ChatMembershipData] = None
 
 
 @dataclass

--- a/app/graphql/auth/permissions.py
+++ b/app/graphql/auth/permissions.py
@@ -45,5 +45,5 @@ async def require_capability(info: Info, capability: str) -> Optional[str]:
 
     db = info.context.db
     if not await person_can(db, user, capability):
-        return "No tienes permiso para gestionar planes de membresía"
+        return "No tienes permiso para realizar esta accion"
     return None

--- a/app/graphql/owner_agent/__init__.py
+++ b/app/graphql/owner_agent/__init__.py
@@ -1,0 +1,1 @@
+"""GraphQL API for owner/admin WhatsApp agent configuration."""

--- a/app/graphql/owner_agent/mutations.py
+++ b/app/graphql/owner_agent/mutations.py
@@ -1,0 +1,137 @@
+"""GraphQL mutations for owner/admin agent configuration."""
+from __future__ import annotations
+
+import logging
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud import ownerAgentCrud as crud
+from app.crud.permissions import MANAGE_OWNER_AGENT
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
+from app.graphql.owner_agent.types import (
+    AddOwnerAgentAuthorizedPhoneInput,
+    OwnerAgentAuthorizedPhoneResult,
+    OwnerAgentAuthorizedPhoneType,
+    OwnerAgentConfigResult,
+    OwnerAgentConfigType,
+    SaveOwnerAgentConfigInput,
+    UpdateOwnerAgentAuthorizedPhoneInput,
+)
+from app.services.owner_agent.env import owner_agent_env
+
+logger = logging.getLogger(__name__)
+
+
+@strawberry.type
+class OwnerAgentMutation:
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def save_owner_agent_config(
+        self, info: Info, input: SaveOwnerAgentConfigInput
+    ) -> OwnerAgentConfigResult:
+        error = await require_capability(info, MANAGE_OWNER_AGENT)
+        if error:
+            return OwnerAgentConfigResult(success=False, error=error)
+        db: AsyncSession = info.context.db
+        try:
+            await crud.upsert_config(
+                db,
+                enabled=input.enabled,
+                require_confirmation=input.require_confirmation,
+                model=input.model,
+                system_prompt=input.system_prompt,
+                history_limit=input.history_limit,
+                max_tokens=input.max_tokens,
+            )
+            data = await crud.get_config(db)
+            return OwnerAgentConfigResult(
+                success=True,
+                config=OwnerAgentConfigType.from_data(
+                    data, server_enabled=owner_agent_env.SERVER_ENABLED
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            logger.exception("Error saving owner agent config")
+            return OwnerAgentConfigResult(success=False, error=str(exc))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def add_owner_agent_authorized_phone(
+        self, info: Info, input: AddOwnerAgentAuthorizedPhoneInput
+    ) -> OwnerAgentAuthorizedPhoneResult:
+        error = await require_capability(info, MANAGE_OWNER_AGENT)
+        if error:
+            return OwnerAgentAuthorizedPhoneResult(success=False, error=error)
+        db: AsyncSession = info.context.db
+        try:
+            model = await crud.add_authorized_phone(
+                db,
+                label=input.label,
+                phone_number=input.phone_number,
+                enabled=input.enabled,
+                created_by=getattr(info.context, "account_id", None),
+            )
+            return OwnerAgentAuthorizedPhoneResult(
+                success=True,
+                phone=OwnerAgentAuthorizedPhoneType.from_data(
+                    crud.OwnerAgentAuthorizedPhoneData.from_model(model)
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            return OwnerAgentAuthorizedPhoneResult(success=False, error=str(exc))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def update_owner_agent_authorized_phone(
+        self, info: Info, input: UpdateOwnerAgentAuthorizedPhoneInput
+    ) -> OwnerAgentAuthorizedPhoneResult:
+        error = await require_capability(info, MANAGE_OWNER_AGENT)
+        if error:
+            return OwnerAgentAuthorizedPhoneResult(success=False, error=error)
+        db: AsyncSession = info.context.db
+        try:
+            model = await crud.update_authorized_phone(
+                db,
+                phone_id=input.phone_id,
+                label=input.label,
+                phone_number=input.phone_number,
+                enabled=input.enabled,
+            )
+            if model is None:
+                return OwnerAgentAuthorizedPhoneResult(
+                    success=False, error="Telefono autorizado no encontrado"
+                )
+            return OwnerAgentAuthorizedPhoneResult(
+                success=True,
+                phone=OwnerAgentAuthorizedPhoneType.from_data(
+                    crud.OwnerAgentAuthorizedPhoneData.from_model(model)
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            return OwnerAgentAuthorizedPhoneResult(success=False, error=str(exc))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def disable_owner_agent_authorized_phone(
+        self, info: Info, phone_id: int
+    ) -> OwnerAgentAuthorizedPhoneResult:
+        error = await require_capability(info, MANAGE_OWNER_AGENT)
+        if error:
+            return OwnerAgentAuthorizedPhoneResult(success=False, error=error)
+        db: AsyncSession = info.context.db
+        try:
+            model = await crud.disable_authorized_phone(db, phone_id=phone_id)
+            if model is None:
+                return OwnerAgentAuthorizedPhoneResult(
+                    success=False, error="Telefono autorizado no encontrado"
+                )
+            return OwnerAgentAuthorizedPhoneResult(
+                success=True,
+                phone=OwnerAgentAuthorizedPhoneType.from_data(
+                    crud.OwnerAgentAuthorizedPhoneData.from_model(model)
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            return OwnerAgentAuthorizedPhoneResult(success=False, error=str(exc))

--- a/app/graphql/owner_agent/queries.py
+++ b/app/graphql/owner_agent/queries.py
@@ -1,0 +1,44 @@
+"""GraphQL queries for owner/admin agent configuration."""
+from __future__ import annotations
+
+from typing import List, Optional
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud import ownerAgentCrud as crud
+from app.crud.permissions import MANAGE_OWNER_AGENT
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
+from app.graphql.owner_agent.types import (
+    OwnerAgentAuthorizedPhoneType,
+    OwnerAgentConfigType,
+)
+from app.services.owner_agent.env import owner_agent_env
+
+
+@strawberry.type
+class OwnerAgentQuery:
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def owner_agent_config(self, info: Info) -> Optional[OwnerAgentConfigType]:
+        error = await require_capability(info, MANAGE_OWNER_AGENT)
+        if error:
+            return None
+        db: AsyncSession = info.context.db
+        data = await crud.get_config(db)
+        return OwnerAgentConfigType.from_data(
+            data, server_enabled=owner_agent_env.SERVER_ENABLED
+        )
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def owner_agent_authorized_phones(
+        self, info: Info
+    ) -> List[OwnerAgentAuthorizedPhoneType]:
+        error = await require_capability(info, MANAGE_OWNER_AGENT)
+        if error:
+            return []
+        db: AsyncSession = info.context.db
+        return [
+            OwnerAgentAuthorizedPhoneType.from_data(row)
+            for row in await crud.list_authorized_phones(db)
+        ]

--- a/app/graphql/owner_agent/types.py
+++ b/app/graphql/owner_agent/types.py
@@ -1,0 +1,96 @@
+"""GraphQL types for the owner/admin WhatsApp agent."""
+from __future__ import annotations
+
+from typing import Optional
+
+import strawberry
+
+from app.crud.ownerAgentCrud import (
+    OwnerAgentAuthorizedPhoneData,
+    OwnerAgentConfigData,
+)
+
+
+@strawberry.type
+class OwnerAgentConfigType:
+    id: Optional[int]
+    enabled: bool
+    require_confirmation: bool
+    model: str
+    system_prompt: Optional[str]
+    history_limit: int
+    max_tokens: int
+    server_enabled: bool
+
+    @classmethod
+    def from_data(cls, data: OwnerAgentConfigData, *, server_enabled: bool) -> "OwnerAgentConfigType":
+        return cls(
+            id=data.id,
+            enabled=bool(data.enabled),
+            require_confirmation=bool(data.require_confirmation),
+            model=data.model,
+            system_prompt=data.system_prompt,
+            history_limit=int(data.history_limit),
+            max_tokens=int(data.max_tokens),
+            server_enabled=bool(server_enabled),
+        )
+
+
+@strawberry.type
+class OwnerAgentAuthorizedPhoneType:
+    id: int
+    label: str
+    phone_number: str
+    normalized_wa_id: str
+    enabled: bool
+    created_by: Optional[int]
+
+    @classmethod
+    def from_data(cls, data: OwnerAgentAuthorizedPhoneData) -> "OwnerAgentAuthorizedPhoneType":
+        return cls(
+            id=data.id,
+            label=data.label,
+            phone_number=data.phone_number,
+            normalized_wa_id=data.normalized_wa_id,
+            enabled=bool(data.enabled),
+            created_by=data.created_by,
+        )
+
+
+@strawberry.input
+class SaveOwnerAgentConfigInput:
+    enabled: Optional[bool] = None
+    require_confirmation: Optional[bool] = None
+    model: Optional[str] = None
+    system_prompt: Optional[str] = None
+    history_limit: Optional[int] = None
+    max_tokens: Optional[int] = None
+
+
+@strawberry.input
+class AddOwnerAgentAuthorizedPhoneInput:
+    label: str
+    phone_number: str
+    enabled: bool = True
+
+
+@strawberry.input
+class UpdateOwnerAgentAuthorizedPhoneInput:
+    phone_id: int
+    label: Optional[str] = None
+    phone_number: Optional[str] = None
+    enabled: Optional[bool] = None
+
+
+@strawberry.type
+class OwnerAgentConfigResult:
+    success: bool = False
+    config: Optional[OwnerAgentConfigType] = None
+    error: Optional[str] = None
+
+
+@strawberry.type
+class OwnerAgentAuthorizedPhoneResult:
+    success: bool = False
+    phone: Optional[OwnerAgentAuthorizedPhoneType] = None
+    error: Optional[str] = None

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -36,6 +36,8 @@ from app.graphql.campaigns.queries import CampaignsQuery
 from app.graphql.campaigns.mutations import CampaignsMutation
 from app.graphql.permissions.queries import PermissionsQuery
 from app.graphql.permissions.mutations import PermissionsMutation
+from app.graphql.owner_agent.queries import OwnerAgentQuery
+from app.graphql.owner_agent.mutations import OwnerAgentMutation
 
 logger = logging.getLogger(__name__)
 
@@ -58,13 +60,13 @@ except ImportError as e:
         pass
 
 @strawberry.type
-class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery, PermissionsQuery):
+class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery, PermissionsQuery, OwnerAgentQuery):
     @strawberry.field
     def hello(self) -> str:
         return "Hello from GraphQL!"
 
 @strawberry.type
-class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation):
+class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation, OwnerAgentMutation):
     pass
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -19,6 +19,13 @@ from app.models.whatsappModel import (
 from app.models.notificationModel import NotificationSetting, NotificationLog
 from app.models.chatbotModel import ChatbotConfig, ChatbotPendingAction
 from app.models.campaignsModel import Campaign, CampaignVariant, CampaignRecipient
+from app.models.ownerAgentModel import (
+    OwnerAgentConfig,
+    OwnerAgentAuthorizedPhone,
+    OwnerAgentPendingAction,
+    OwnerAgentAuditLog,
+    OwnerTask,
+)
 
 __all__ = [
     "People", "Role", "PersonRole", "Account", "RoleCapability",
@@ -32,5 +39,7 @@ __all__ = [
     "WhatsAppTemplate", "WhatsAppMediaAsset",
     "NotificationSetting", "NotificationLog",
     "ChatbotConfig", "ChatbotPendingAction",
-    "Campaign", "CampaignVariant", "CampaignRecipient"
+    "Campaign", "CampaignVariant", "CampaignRecipient",
+    "OwnerAgentConfig", "OwnerAgentAuthorizedPhone", "OwnerAgentPendingAction",
+    "OwnerAgentAuditLog", "OwnerTask",
 ]

--- a/app/models/ownerAgentModel.py
+++ b/app/models/ownerAgentModel.py
@@ -1,0 +1,164 @@
+"""Models for the owner/admin WhatsApp agent.
+
+The customer-facing chatbot and the owner-facing admin agent intentionally keep
+separate configuration, pending-action, audit, and task state. The owner agent is
+allowed to inspect business data and execute operational commands only for
+allowlisted WhatsApp senders.
+"""
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    TIMESTAMP,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.postgresql import Base
+
+
+OWNER_PENDING_STATUS_PENDING = "pending"
+OWNER_PENDING_STATUS_CONFIRMED = "confirmed"
+OWNER_PENDING_STATUS_CANCELED = "canceled"
+OWNER_PENDING_STATUS_EXPIRED = "expired"
+
+OWNER_TASK_STATUS_OPEN = "open"
+OWNER_TASK_STATUS_DONE = "done"
+OWNER_TASK_STATUS_CANCELED = "canceled"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class OwnerAgentConfig(Base):
+    """Single-row runtime configuration for the owner/admin agent."""
+
+    __tablename__ = "owner_agent_config"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    require_confirmation: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    model: Mapped[str] = mapped_column(String(80), nullable=False, default="claude-sonnet-4-6")
+    system_prompt: Mapped[Optional[str]] = mapped_column(Text)
+    history_limit: Mapped[int] = mapped_column(Integer, nullable=False, default=30)
+    max_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=1024)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+
+
+class OwnerAgentAuthorizedPhone(Base):
+    """A WhatsApp sender allowed to use the owner/admin agent."""
+
+    __tablename__ = "owner_agent_authorized_phone"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    label: Mapped[str] = mapped_column(String(120), nullable=False)
+    phone_number: Mapped[str] = mapped_column(String(40), nullable=False)
+    normalized_wa_id: Mapped[str] = mapped_column(String(30), nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_by: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("accounts.id"))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+
+    __table_args__ = (
+        Index("uq_owner_agent_authorized_phone_wa", "normalized_wa_id", unique=True),
+        Index("idx_owner_agent_authorized_phone_enabled", "enabled"),
+    )
+
+
+class OwnerAgentPendingAction(Base):
+    """A proposed admin action awaiting explicit confirmation."""
+
+    __tablename__ = "owner_agent_pending_action"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    conversation_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    authorized_phone_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("owner_agent_authorized_phone.id", ondelete="SET NULL")
+    )
+    action_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    payload: Mapped[Optional[dict]] = mapped_column(JSON)
+    summary: Mapped[Optional[str]] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default=OWNER_PENDING_STATUS_PENDING)
+    expires_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+
+    __table_args__ = (
+        Index("uq_owner_agent_pending_conversation", "conversation_id", unique=True),
+        Index("idx_owner_agent_pending_status", "status"),
+    )
+
+
+class OwnerAgentAuditLog(Base):
+    """Audit trail for owner-agent tools and command outcomes."""
+
+    __tablename__ = "owner_agent_audit_log"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    conversation_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    message_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    authorized_phone_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("owner_agent_authorized_phone.id", ondelete="SET NULL")
+    )
+    tool_name: Mapped[Optional[str]] = mapped_column(String(100))
+    action_type: Mapped[Optional[str]] = mapped_column(String(50))
+    payload: Mapped[Optional[dict]] = mapped_column(JSON)
+    result_summary: Mapped[Optional[str]] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="ok")
+    error: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+
+    __table_args__ = (
+        Index("idx_owner_agent_audit_phone_created", "authorized_phone_id", "created_at"),
+        Index("idx_owner_agent_audit_conversation", "conversation_id"),
+    )
+
+
+class OwnerTask(Base):
+    """Simple owner-managed task created from WhatsApp commands."""
+
+    __tablename__ = "owner_tasks"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    title: Mapped[str] = mapped_column(String(240), nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default=OWNER_TASK_STATUS_OPEN)
+    due_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    created_by_phone_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("owner_agent_authorized_phone.id", ondelete="SET NULL")
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, default=_utcnow
+    )
+
+    __table_args__ = (
+        Index("idx_owner_tasks_status_due", "status", "due_at"),
+        Index("idx_owner_tasks_created_by", "created_by_phone_id"),
+    )

--- a/app/services/owner_agent/__init__.py
+++ b/app/services/owner_agent/__init__.py
@@ -1,0 +1,1 @@
+"""Owner/admin WhatsApp agent package."""

--- a/app/services/owner_agent/agent.py
+++ b/app/services/owner_agent/agent.py
@@ -1,0 +1,114 @@
+"""LangGraph ReAct runner for the owner/admin WhatsApp agent."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from app.crud.ownerAgentCrud import OwnerAgentConfigData
+from app.services.chatbot.timefmt import fmt_now_es
+from app.services.owner_agent.env import owner_agent_env
+
+logger = logging.getLogger(__name__)
+
+_BASE_RULES = (
+    "Eres un agente administrativo de FitPilot. Respondes solo al dueno o a administradores "
+    "autorizados por telefono. Usa herramientas para obtener datos reales; no inventes numeros, "
+    "ingresos, pagos, socios, horarios, disponibilidad ni estados. Responde en espanol, breve y "
+    "con estructura clara. Si una herramienta devuelve ids, puedes citarlos."
+)
+
+_ACTION_RULES = (
+    "Regla de acciones: cualquier cambio real debe pasar por propuesta y confirmacion. "
+    "Para crear/completar/cancelar tareas o ejecutar barridos, llama primero a la herramienta "
+    "propose_* correspondiente. Si ya hay una accion pendiente y el usuario confirma con 'si', "
+    "llama a confirm_action. Si rechaza, llama a cancel_action. Nunca ejecutes acciones por texto "
+    "sin herramienta."
+)
+
+
+def _extract_text(message: Any) -> str:
+    content = getattr(message, "content", "")
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, list):
+        texts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                texts.append(block.get("text", ""))
+            elif isinstance(block, str):
+                texts.append(block)
+        return "\n".join(t for t in texts if t).strip()
+    return str(content).strip()
+
+
+def build_system_prompt(
+    config: OwnerAgentConfigData,
+    *,
+    pending_note: Optional[str] = None,
+) -> str:
+    parts = [
+        _BASE_RULES,
+        f"Fecha y hora actual: {fmt_now_es()} (America/Mexico_City). Usa esta fecha para interpretar hoy, manana, esta semana y este mes.",
+        _ACTION_RULES,
+    ]
+    if config.system_prompt:
+        parts.append("Instrucciones configuradas:\n" + config.system_prompt.strip())
+    if pending_note:
+        parts.append(pending_note)
+    return "\n\n".join(parts)
+
+
+async def run_agent(
+    *,
+    config: OwnerAgentConfigData,
+    tools: list,
+    history: list[tuple[str, str]],
+    user_text: str,
+    pending_note: Optional[str] = None,
+) -> Optional[str]:
+    """Run one owner-agent turn and return the text response."""
+    try:
+        from langchain_anthropic import ChatAnthropic
+        from langchain_core.messages import AIMessage, HumanMessage
+        from langgraph.prebuilt import create_react_agent
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Owner agent LangChain imports failed")
+        return (
+            "El agente admin no puede iniciar porque faltan dependencias de LangChain/"
+            f"LangGraph o Anthropic: {exc}"
+        )
+
+    if not owner_agent_env.ANTHROPIC_API_KEY:
+        return "Falta ANTHROPIC_API_KEY en el backend para usar el agente admin."
+
+    llm = ChatAnthropic(
+        model=config.model or owner_agent_env.DEFAULT_MODEL,
+        max_tokens=int(config.max_tokens or 1024),
+        api_key=owner_agent_env.ANTHROPIC_API_KEY,
+        timeout=60,
+    )
+    system_prompt = build_system_prompt(config, pending_note=pending_note)
+    agent = create_react_agent(llm, tools, prompt=system_prompt)
+
+    messages = []
+    for role, text in history:
+        clean = (text or "").strip()
+        if not clean:
+            continue
+        if role == "inbound":
+            messages.append(HumanMessage(content=clean))
+        else:
+            messages.append(AIMessage(content=clean))
+    messages.append(HumanMessage(content=(user_text or "").strip()))
+
+    result = await agent.ainvoke(
+        {"messages": messages},
+        config={"recursion_limit": int(owner_agent_env.RECURSION_LIMIT or 12)},
+    )
+    out_messages = result.get("messages", []) if isinstance(result, dict) else []
+    for message in reversed(out_messages):
+        if message.__class__.__name__ == "AIMessage":
+            text = _extract_text(message)
+            if text:
+                return text
+    return None

--- a/app/services/owner_agent/env.py
+++ b/app/services/owner_agent/env.py
@@ -1,0 +1,27 @@
+"""Deploy-level switches for the owner/admin WhatsApp agent."""
+import os
+
+from app.core.env import load_environment
+
+load_environment()
+
+
+def _as_bool(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+class OwnerAgentEnv:
+    # Absolute server kill-switch. DB config can only enable the agent when this is true.
+    SERVER_ENABLED: bool = _as_bool(os.getenv("OWNER_AGENT_SERVER_ENABLED"), default=False)
+    ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
+    DEFAULT_MODEL: str = os.getenv("OWNER_AGENT_MODEL", "claude-sonnet-4-6")
+    RECURSION_LIMIT: int = int(os.getenv("OWNER_AGENT_RECURSION_LIMIT", "12"))
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        return bool(cls.SERVER_ENABLED and cls.ANTHROPIC_API_KEY)
+
+
+owner_agent_env = OwnerAgentEnv()

--- a/app/services/owner_agent/reply_service.py
+++ b/app/services/owner_agent/reply_service.py
@@ -1,0 +1,171 @@
+"""Background orchestration for the owner/admin WhatsApp agent."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional, Set
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import ownerAgentCrud
+from app.crud import whatsappCrud as whatsapp_crud
+from app.db.postgresql import async_session_factory
+from app.models.ownerAgentModel import OWNER_PENDING_STATUS_PENDING
+from app.services import whatsapp_cloud_service as cloud
+from app.services import whatsapp_outbound as outbound
+from app.services.owner_agent.env import owner_agent_env
+
+logger = logging.getLogger(__name__)
+
+_background_tasks: Set["asyncio.Task"] = set()
+
+
+async def send_and_persist_reply(
+    db: AsyncSession,
+    *,
+    conversation_id: int,
+    contact_id: int,
+    to_wa_id: str,
+    text: str,
+) -> outbound.OutboundResult:
+    result = await outbound.send_text(
+        db,
+        kind=outbound.KIND_OWNER_AGENT_REPLY,
+        conversation_id=conversation_id,
+        contact_id=contact_id,
+        wa_id=to_wa_id,
+        text=text,
+        persist=True,
+        message_class=outbound.CLASS_TRANSACTIONAL,
+    )
+    await db.commit()
+    if result.ok:
+        try:
+            _conv, latest_wa_id = await whatsapp_crud.mark_conversation_read(db, conversation_id)
+            if latest_wa_id:
+                await cloud.send_read_receipt(latest_wa_id)
+        except Exception:  # noqa: BLE001
+            logger.debug("owner-agent post-reply mark-read failed", exc_info=True)
+    return result
+
+
+async def _load_history(
+    db: AsyncSession, conversation_id: int, exclude_message_id: Optional[int], limit: int
+) -> list[tuple[str, str]]:
+    rows = await whatsapp_crud.get_conversation_messages(
+        db, conversation_id, limit=max(1, min(int(limit or 30), 100))
+    )
+    history: list[tuple[str, str]] = []
+    for row in rows:
+        if exclude_message_id is not None and row.id == exclude_message_id:
+            continue
+        if row.message_type == "reaction":
+            continue
+        text = (row.text_content or "").strip()
+        if not text:
+            continue
+        history.append((row.direction, text))
+    return history
+
+
+async def _pending_note(db: AsyncSession, conversation_id: int) -> Optional[str]:
+    pending = await ownerAgentCrud.get_pending_action(db, conversation_id)
+    if pending is None:
+        return None
+    summary = pending.summary or "una accion administrativa"
+    if pending.status == OWNER_PENDING_STATUS_PENDING:
+        return (
+            f"Hay una accion pendiente: {summary}. Si el usuario confirma con si/ok/dale, "
+            "llama a confirm_action. Si responde no/cancelar, llama a cancel_action. "
+            "No vuelvas a proponer la misma accion."
+        )
+    return None
+
+
+async def _run_agent_reply(
+    *,
+    conversation_id: int,
+    contact_id: int,
+    contact_wa_id: str,
+    authorized_phone_id: int,
+    message_id: int,
+    text: str,
+) -> None:
+    try:
+        text = (text or "").strip()
+        if not text:
+            return
+
+        async with async_session_factory() as db:
+            config = await ownerAgentCrud.get_config(db)
+            if not owner_agent_env.SERVER_ENABLED or not config.enabled:
+                logger.info(
+                    "Owner agent suppressed: server=%s db=%s",
+                    owner_agent_env.SERVER_ENABLED,
+                    config.enabled,
+                )
+                return
+            if not owner_agent_env.ANTHROPIC_API_KEY:
+                logger.warning("Owner agent enabled without ANTHROPIC_API_KEY")
+                return
+
+            from app.services.owner_agent.agent import run_agent
+            from app.services.owner_agent.tools import OwnerAgentContext, build_tools
+
+            history = await _load_history(db, conversation_id, message_id, config.history_limit)
+            pending_note = await _pending_note(db, conversation_id)
+            ctx = OwnerAgentContext(
+                db=db,
+                conversation_id=conversation_id,
+                authorized_phone_id=authorized_phone_id,
+                message_id=message_id,
+                require_confirmation=bool(config.require_confirmation),
+            )
+            tools = build_tools(ctx)
+            reply = await run_agent(
+                config=config,
+                tools=tools,
+                history=history,
+                user_text=text,
+                pending_note=pending_note,
+            )
+            if not reply:
+                return
+            await send_and_persist_reply(
+                db,
+                conversation_id=conversation_id,
+                contact_id=contact_id,
+                to_wa_id=contact_wa_id,
+                text=reply,
+            )
+    except cloud.WhatsAppError as exc:
+        logger.warning("Owner agent WhatsApp send failed (%s): %s", exc.code, exc.message)
+    except Exception:  # noqa: BLE001
+        logger.exception("Owner agent reply failed for conversation %s", conversation_id)
+
+
+def schedule_agent_reply(
+    *,
+    conversation_id: int,
+    contact_id: int,
+    contact_wa_id: str,
+    authorized_phone_id: int,
+    message_id: int,
+    text: str,
+) -> None:
+    try:
+        task = asyncio.create_task(
+            _run_agent_reply(
+                conversation_id=conversation_id,
+                contact_id=contact_id,
+                contact_wa_id=contact_wa_id,
+                authorized_phone_id=authorized_phone_id,
+                message_id=message_id,
+                text=text,
+            )
+        )
+    except RuntimeError:
+        logger.warning("owner schedule_agent_reply called without running loop; skipped")
+        return
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)

--- a/app/services/owner_agent/tools.py
+++ b/app/services/owner_agent/tools.py
@@ -1,0 +1,537 @@
+"""LangChain tools for the owner/admin WhatsApp agent."""
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.crud import ownerAgentCrud as owner_crud
+from app.crud.dashboard_metrics import get_dashboard_metrics
+from app.crud.memberships.payment_metrics import get_payment_metrics
+from app.models import Conversation, Lead, Message, People
+from app.models.classModel import ClassSession, Reservation
+from app.models.campaignsModel import Campaign
+from app.models.membershipsModel import MembershipSubscription
+from app.models.ownerAgentModel import (
+    OWNER_PENDING_STATUS_CONFIRMED,
+    OWNER_TASK_STATUS_CANCELED,
+    OWNER_TASK_STATUS_DONE,
+)
+from app.models.userModel import PersonRole, Role
+
+logger = logging.getLogger(__name__)
+
+_TZ = ZoneInfo("America/Mexico_City")
+
+ACTION_CREATE_TASK = "create_task"
+ACTION_COMPLETE_TASK = "complete_task"
+ACTION_CANCEL_TASK = "cancel_task"
+ACTION_NOTIFICATION_SWEEP = "notification_sweep"
+ACTION_CAMPAIGN_SWEEP = "campaign_sweep"
+
+
+@dataclass
+class OwnerAgentContext:
+    db: AsyncSession
+    conversation_id: int
+    authorized_phone_id: int
+    message_id: Optional[int] = None
+    require_confirmation: bool = True
+
+
+def _now_local() -> datetime:
+    return datetime.now(_TZ)
+
+
+def _to_utc(dt: datetime) -> datetime:
+    return dt.astimezone(timezone.utc)
+
+
+def _period_range(period: str = "today") -> tuple[datetime, datetime, str]:
+    p = (period or "today").strip().lower()
+    now = _now_local()
+    if p in {"hoy", "today", "dia"}:
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        label = "hoy"
+    elif p in {"ayer", "yesterday"}:
+        end_local = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        start = end_local - timedelta(days=1)
+        return _to_utc(start), _to_utc(end_local), "ayer"
+    elif p in {"semana", "esta semana", "week", "this_week"}:
+        start = (now - timedelta(days=now.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+        label = "esta semana"
+    elif p in {"mes", "este mes", "month", "this_month"}:
+        start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        label = "este mes"
+    elif p in {"30d", "last_30_days", "ultimos 30 dias"}:
+        start = now - timedelta(days=30)
+        label = "ultimos 30 dias"
+    elif p in {"ano", "año", "year", "this_year"}:
+        start = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
+        label = "este ano"
+    else:
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+        label = "hoy"
+    return _to_utc(start), _to_utc(now), label
+
+
+def _money(value: float) -> str:
+    return f"${float(value or 0):,.2f}"
+
+
+def _fmt_dt(value: Optional[datetime]) -> str:
+    if value is None:
+        return "sin fecha"
+    local = value.astimezone(_TZ) if value.tzinfo else value.replace(tzinfo=timezone.utc).astimezone(_TZ)
+    return local.strftime("%Y-%m-%d %H:%M")
+
+
+async def _audit(
+    ctx: OwnerAgentContext,
+    *,
+    tool_name: str,
+    payload: Optional[dict],
+    result: Optional[str] = None,
+    status: str = "ok",
+    error: Optional[str] = None,
+) -> None:
+    try:
+        await owner_crud.audit_event(
+            ctx.db,
+            conversation_id=ctx.conversation_id,
+            message_id=ctx.message_id,
+            authorized_phone_id=ctx.authorized_phone_id,
+            tool_name=tool_name,
+            payload=payload or {},
+            result_summary=result,
+            status=status,
+            error=error,
+            commit=True,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("owner agent audit failed", exc_info=True)
+
+
+def _wrap_tool(ctx: OwnerAgentContext, name: str, fn):
+    @wraps(fn)
+    async def _inner(*args, **kwargs):
+        payload = {"args": list(args), "kwargs": kwargs}
+        try:
+            result = await fn(*args, **kwargs)
+            await _audit(ctx, tool_name=name, payload=payload, result=str(result)[:4000])
+            return result
+        except Exception as exc:  # noqa: BLE001
+            await ctx.db.rollback()
+            await _audit(
+                ctx,
+                tool_name=name,
+                payload=payload,
+                status="error",
+                error=str(exc),
+            )
+            logger.exception("owner tool %s failed", name)
+            return f"No pude ejecutar {name}: {exc}"
+
+    return _inner
+
+
+def build_tools(ctx: OwnerAgentContext) -> list:
+    from langchain_core.tools import StructuredTool
+
+    db = ctx.db
+
+    async def get_business_report(period: str = "today") -> str:
+        """KPIs generales del negocio para un periodo: socios, ingresos, reservas y ocupacion."""
+        start, end, label = _period_range(period)
+        metrics = await get_dashboard_metrics(db=db, start_date=start, end_date=end)
+        lines = [
+            f"Reporte {label} ({_fmt_dt(start)} a {_fmt_dt(end)}):",
+            f"- Ingresos: {_money(metrics.period_revenue)}",
+            f"- Reservas: {metrics.period_reservations}",
+            f"- Socios activos: {metrics.active_members}",
+            f"- Nuevos socios: {metrics.new_members}",
+            f"- Ocupacion promedio: {metrics.avg_occupancy:.1f}%",
+        ]
+        if metrics.top_membership_sales_period:
+            top = metrics.top_membership_sales_period
+            lines.append(f"- Plan mas vendido: {top.plan_name} ({top.count}, {_money(top.total)})")
+        return "\n".join(lines)
+
+    async def get_payments_report(period: str = "today") -> str:
+        """Reporte financiero: pagos, total, metodos, pendientes, huerfanos y duplicados sospechosos."""
+        start, end, label = _period_range(period)
+        metrics = await get_payment_metrics(db, start_date=start, end_date=end)
+        methods = ", ".join(
+            f"{b.method}: {b.count} / {_money(b.total)}" for b in metrics.by_method[:5]
+        ) or "sin pagos"
+        return "\n".join(
+            [
+                f"Finanzas {label}:",
+                f"- Total: {_money(metrics.total_amount)} en {metrics.total_count} pago(s)",
+                f"- Completado: {_money(metrics.completed_amount)}",
+                f"- Ticket promedio: {_money(metrics.avg_amount)}",
+                f"- Pendientes: {metrics.pending_count} / {_money(metrics.pending_amount)}",
+                f"- Fallidos: {metrics.failed_count}; reembolsados: {metrics.refunded_count}",
+                f"- Huerfanos: {metrics.orphan_count}; duplicados sospechosos: {metrics.duplicate_suspect_count}",
+                f"- Por metodo: {methods}",
+            ]
+        )
+
+    async def get_members_report(days_ahead: int = 14) -> str:
+        """Socios activos, vencidos y proximos vencimientos."""
+        now = datetime.now(timezone.utc)
+        ahead = now + timedelta(days=max(1, min(int(days_ahead or 14), 60)))
+        member_role = (
+            select(PersonRole.person_id)
+            .join(Role, Role.id == PersonRole.role_id)
+            .where(Role.code == "member")
+        )
+        active_count = int(
+            (
+                await db.execute(
+                    select(func.count(MembershipSubscription.id)).where(
+                        MembershipSubscription.status == "active",
+                        MembershipSubscription.start_at <= now,
+                        MembershipSubscription.end_at > now,
+                    )
+                )
+            ).scalar_one()
+            or 0
+        )
+        expired_count = int(
+            (
+                await db.execute(
+                    select(func.count(MembershipSubscription.id)).where(
+                        MembershipSubscription.status == "active",
+                        MembershipSubscription.end_at <= now,
+                    )
+                )
+            ).scalar_one()
+            or 0
+        )
+        expiring = (
+            await db.execute(
+                select(People.full_name, MembershipSubscription.end_at)
+                .join(MembershipSubscription, MembershipSubscription.person_id == People.id)
+                .where(People.id.in_(member_role))
+                .where(People.deleted_at.is_(None))
+                .where(MembershipSubscription.status == "active")
+                .where(MembershipSubscription.end_at > now)
+                .where(MembershipSubscription.end_at <= ahead)
+                .order_by(MembershipSubscription.end_at.asc())
+                .limit(10)
+            )
+        ).all()
+        lines = [
+            "Socios:",
+            f"- Suscripciones activas: {active_count}",
+            f"- Suscripciones vencidas sin cerrar: {expired_count}",
+            f"- Vencen en {days_ahead} dias: {len(expiring)}",
+        ]
+        for name, end_at in expiring:
+            lines.append(f"  - {name or 'Sin nombre'}: {_fmt_dt(end_at)}")
+        return "\n".join(lines)
+
+    async def get_classes_report(period: str = "today") -> str:
+        """Reporte de clases, reservas y ocupacion por periodo."""
+        start, end, label = _period_range(period)
+        sessions = int(
+            (
+                await db.execute(
+                    select(func.count(ClassSession.id)).where(
+                        ClassSession.start_at >= start,
+                        ClassSession.start_at <= end,
+                        ClassSession.status.in_(("scheduled", "completed")),
+                    )
+                )
+            ).scalar_one()
+            or 0
+        )
+        reservations = int(
+            (
+                await db.execute(
+                    select(func.count(Reservation.id))
+                    .join(ClassSession, ClassSession.id == Reservation.session_id)
+                    .where(
+                        ClassSession.start_at >= start,
+                        ClassSession.start_at <= end,
+                        Reservation.status.in_(("reserved", "checked_in")),
+                    )
+                )
+            ).scalar_one()
+            or 0
+        )
+        metrics = await get_dashboard_metrics(db=db, start_date=start, end_date=end)
+        top = metrics.occupancy_by_class[:5]
+        lines = [
+            f"Clases {label}:",
+            f"- Sesiones: {sessions}",
+            f"- Reservas/check-ins: {reservations}",
+            f"- Ocupacion promedio: {metrics.avg_occupancy:.1f}%",
+        ]
+        for b in top:
+            lines.append(f"  - {b.class_name}: {b.reserved}/{b.capacity} ({b.occupancy_pct:.1f}%)")
+        return "\n".join(lines)
+
+    async def get_leads_report(period: str = "this_month") -> str:
+        """Resumen de leads por estado y conversiones."""
+        start, end, label = _period_range(period)
+        total = int(
+            (
+                await db.execute(
+                    select(func.count(Lead.id)).where(Lead.created_at >= start, Lead.created_at <= end)
+                )
+            ).scalar_one()
+            or 0
+        )
+        rows = (
+            await db.execute(
+                select(Lead.status, func.count(Lead.id))
+                .where(Lead.created_at >= start, Lead.created_at <= end)
+                .group_by(Lead.status)
+                .order_by(func.count(Lead.id).desc())
+            )
+        ).all()
+        converted = int(
+            (
+                await db.execute(
+                    select(func.count(Lead.id)).where(
+                        Lead.converted_at >= start, Lead.converted_at <= end
+                    )
+                )
+            ).scalar_one()
+            or 0
+        )
+        by_status = ", ".join(f"{status}: {count}" for status, count in rows) or "sin leads"
+        return f"Leads {label}: total {total}; convertidos {converted}; por estado: {by_status}."
+
+    async def get_campaigns_report() -> str:
+        """Estado resumido de campanas de marketing."""
+        rows = (
+            await db.execute(
+                select(Campaign.status, func.count(Campaign.id))
+                .group_by(Campaign.status)
+                .order_by(func.count(Campaign.id).desc())
+            )
+        ).all()
+        total = sum(int(count or 0) for _status, count in rows)
+        by_status = ", ".join(f"{status}: {count}" for status, count in rows) or "sin campanas"
+        return f"Campanas: {total} total; {by_status}."
+
+    async def get_whatsapp_report() -> str:
+        """Conversaciones y mensajes de WhatsApp pendientes/no leidos."""
+        unread = int(
+            (
+                await db.execute(
+                    select(func.count(Message.id)).where(
+                        Message.direction == "inbound",
+                        Message.is_read.is_(False),
+                    )
+                )
+            ).scalar_one()
+            or 0
+        )
+        active_conversations = int(
+            (
+                await db.execute(
+                    select(func.count(Conversation.id)).where(Conversation.status == "active")
+                )
+            ).scalar_one()
+            or 0
+        )
+        latest = (
+            await db.execute(
+                select(Message.text_content, Message.timestamp)
+                .where(Message.direction == "inbound")
+                .where(Message.message_type == "text")
+                .order_by(Message.timestamp.desc(), Message.id.desc())
+                .limit(5)
+            )
+        ).all()
+        lines = [
+            "WhatsApp:",
+            f"- Conversaciones activas: {active_conversations}",
+            f"- Mensajes entrantes no leidos: {unread}",
+        ]
+        for text, ts in latest:
+            snippet = (text or "").strip().replace("\n", " ")[:80]
+            lines.append(f"  - {_fmt_dt(ts)}: {snippet}")
+        return "\n".join(lines)
+
+    async def list_tasks(include_done: bool = False) -> str:
+        """Lista tareas administrativas del agente."""
+        tasks = await owner_crud.list_owner_tasks(db, include_done=include_done)
+        if not tasks:
+            return "No hay tareas pendientes."
+        lines = ["Tareas:"]
+        for task in tasks:
+            due = f", vence {_fmt_dt(task.due_at)}" if task.due_at else ""
+            lines.append(f"- #{task.id} [{task.status}] {task.title}{due}")
+        return "\n".join(lines)
+
+    async def _proposal(action_type: str, payload: dict, summary: str) -> str:
+        await owner_crud.upsert_pending_action(
+            db,
+            conversation_id=ctx.conversation_id,
+            authorized_phone_id=ctx.authorized_phone_id,
+            action_type=action_type,
+            payload=payload,
+            summary=summary,
+            commit=True,
+        )
+        return f"Propuesta lista: {summary}. Responde 'si' para confirmar o 'no' para cancelar."
+
+    async def propose_create_task(title: str, description: Optional[str] = None) -> str:
+        """Propone crear una tarea administrativa."""
+        clean_title = (title or "").strip()
+        if not clean_title:
+            return "Necesito el titulo de la tarea."
+        return await _proposal(
+            ACTION_CREATE_TASK,
+            {"title": clean_title, "description": (description or "").strip() or None},
+            f"Crear tarea: {clean_title}",
+        )
+
+    async def propose_complete_task(task_id: int) -> str:
+        """Propone marcar una tarea como completada."""
+        return await _proposal(
+            ACTION_COMPLETE_TASK,
+            {"task_id": int(task_id)},
+            f"Marcar tarea #{int(task_id)} como completada",
+        )
+
+    async def propose_cancel_task(task_id: int) -> str:
+        """Propone cancelar una tarea."""
+        return await _proposal(
+            ACTION_CANCEL_TASK,
+            {"task_id": int(task_id)},
+            f"Cancelar tarea #{int(task_id)}",
+        )
+
+    async def propose_notification_sweep() -> str:
+        """Propone ejecutar el barrido de notificaciones de renovacion/vencimiento."""
+        return await _proposal(
+            ACTION_NOTIFICATION_SWEEP,
+            {},
+            "Ejecutar barrido de notificaciones automaticas",
+        )
+
+    async def propose_campaign_sweep() -> str:
+        """Propone ejecutar el barrido de campanas programadas."""
+        return await _proposal(
+            ACTION_CAMPAIGN_SWEEP,
+            {},
+            "Ejecutar barrido de campanas programadas",
+        )
+
+    async def confirm_action() -> str:
+        """Ejecuta la accion administrativa pendiente tras una confirmacion explicita."""
+        pending = await owner_crud.get_pending_action(db, ctx.conversation_id)
+        if pending is None:
+            return "No hay accion pendiente por confirmar."
+        pending_id = pending.id
+        action_type = pending.action_type
+        payload = dict(pending.payload or {})
+        try:
+            result = await _execute_pending(action_type, payload)
+        except Exception as exc:  # noqa: BLE001
+            await db.rollback()
+            await _audit(
+                ctx,
+                tool_name="confirm_action",
+                action_type=action_type,
+                payload=payload,
+                status="error",
+                error=str(exc),
+            )
+            return f"No pude ejecutar la accion: {exc}"
+        await owner_crud.mark_pending_action(
+            db, pending_id, OWNER_PENDING_STATUS_CONFIRMED, commit=True
+        )
+        await _audit(
+            ctx,
+            tool_name="confirm_action",
+            action_type=action_type,
+            payload=payload,
+            result=result,
+        )
+        return result
+
+    async def cancel_action() -> str:
+        """Cancela la accion administrativa pendiente."""
+        canceled = await owner_crud.cancel_pending_action(db, ctx.conversation_id, commit=True)
+        return "Accion cancelada." if canceled else "No habia accion pendiente."
+
+    async def _execute_pending(action_type: str, payload: dict) -> str:
+        if action_type == ACTION_CREATE_TASK:
+            task = await owner_crud.create_owner_task(
+                db,
+                title=payload.get("title") or "",
+                description=payload.get("description"),
+                created_by_phone_id=ctx.authorized_phone_id,
+                commit=True,
+            )
+            return f"Tarea #{task.id} creada: {task.title}"
+        if action_type == ACTION_COMPLETE_TASK:
+            task = await owner_crud.set_owner_task_status(
+                db, task_id=int(payload["task_id"]), status=OWNER_TASK_STATUS_DONE, commit=True
+            )
+            if task is None:
+                return f"No encontre la tarea #{payload['task_id']}."
+            return f"Tarea #{task.id} completada: {task.title}"
+        if action_type == ACTION_CANCEL_TASK:
+            task = await owner_crud.set_owner_task_status(
+                db,
+                task_id=int(payload["task_id"]),
+                status=OWNER_TASK_STATUS_CANCELED,
+                commit=True,
+            )
+            if task is None:
+                return f"No encontre la tarea #{payload['task_id']}."
+            return f"Tarea #{task.id} cancelada: {task.title}"
+        if action_type == ACTION_NOTIFICATION_SWEEP:
+            from app.services.notification_service import run_all_sweeps
+
+            stats = await run_all_sweeps()
+            return f"Barrido de notificaciones ejecutado: {stats}"
+        if action_type == ACTION_CAMPAIGN_SWEEP:
+            from app.services.campaign_service import run_campaign_sweep
+
+            stats = await run_campaign_sweep()
+            return f"Barrido de campanas ejecutado: {stats}"
+        raise ValueError(f"Tipo de accion desconocido: {action_type}")
+
+    factories = [
+        (get_business_report, "get_business_report", "KPIs generales del negocio para today/week/month/last_30_days/year."),
+        (get_payments_report, "get_payments_report", "Reporte financiero por periodo."),
+        (get_members_report, "get_members_report", "Socios activos, vencidos y proximos vencimientos."),
+        (get_classes_report, "get_classes_report", "Clases, reservas y ocupacion por periodo."),
+        (get_leads_report, "get_leads_report", "Leads y conversiones por periodo."),
+        (get_campaigns_report, "get_campaigns_report", "Estado resumido de campanas."),
+        (get_whatsapp_report, "get_whatsapp_report", "Conversaciones y mensajes WhatsApp pendientes."),
+        (list_tasks, "list_tasks", "Lista tareas administrativas."),
+        (propose_create_task, "propose_create_task", "Propone crear una tarea. Args: title, description opcional."),
+        (propose_complete_task, "propose_complete_task", "Propone completar una tarea por id."),
+        (propose_cancel_task, "propose_cancel_task", "Propone cancelar una tarea por id."),
+        (propose_notification_sweep, "propose_notification_sweep", "Propone ejecutar barrido de notificaciones."),
+        (propose_campaign_sweep, "propose_campaign_sweep", "Propone ejecutar barrido de campanas."),
+        (confirm_action, "confirm_action", "Ejecuta la accion pendiente tras confirmacion explicita."),
+        (cancel_action, "cancel_action", "Cancela la accion pendiente."),
+    ]
+
+    return [
+        StructuredTool.from_function(
+            coroutine=_wrap_tool(ctx, name, fn),
+            name=name,
+            description=desc,
+        )
+        for fn, name, desc in factories
+    ]

--- a/app/services/whatsapp_hooks.py
+++ b/app/services/whatsapp_hooks.py
@@ -36,6 +36,35 @@ async def on_inbound_message(
     if not text:
         return None
 
+    # Owner/admin agent takes precedence over every customer-facing behavior.
+    # An authorized owner phone must never fall through to the commercial chatbot
+    # or accidentally trigger customer STOP/BAJA handling.
+    try:
+        from app.crud import ownerAgentCrud
+
+        authorized = await ownerAgentCrud.resolve_authorized_phone(db, contact.wa_id)
+    except Exception as e:  # noqa: BLE001
+        logger.warning("owner-agent authorization lookup failed: %s", e)
+        authorized = None
+
+    if authorized is not None:
+        logger.debug(
+            "on_inbound_message: scheduling owner agent reply msg=%s contact=%s",
+            message.id,
+            contact.wa_id,
+        )
+        from app.services.owner_agent import reply_service as owner_reply_service
+
+        owner_reply_service.schedule_agent_reply(
+            conversation_id=conversation.id,
+            contact_id=contact.id,
+            contact_wa_id=contact.wa_id,
+            authorized_phone_id=authorized.id,
+            message_id=message.id,
+            text=text,
+        )
+        return None
+
     # STOP/BAJA/ALTA keywords consume the turn (consent + bot pause/resume + confirmation); the bot
     # must NOT also reply.
     from app.services import whatsapp_optout

--- a/app/services/whatsapp_outbound.py
+++ b/app/services/whatsapp_outbound.py
@@ -40,6 +40,7 @@ CLASS_MARKETING = "marketing"
 # --- send kinds (which subsystem) --------------------------------------------------
 KIND_MANUAL_HUMAN = "manual_human"
 KIND_CHATBOT_REPLY = "chatbot_reply"
+KIND_OWNER_AGENT_REPLY = "owner_agent_reply"
 KIND_PAYMENT_CONFIRM = "payment_confirm"
 KIND_NOTIFICATION = "notification"
 KIND_CAMPAIGN = "campaign"

--- a/docs/owner_agent_admin.md
+++ b/docs/owner_agent_admin.md
@@ -1,0 +1,377 @@
+# Agente Administrativo por WhatsApp
+
+## Resumen
+
+El Agente Administrativo es un agente separado del chatbot comercial de clientes.
+Su objetivo es que el dueno o administradores autorizados puedan consultar el
+negocio y ejecutar tareas operativas desde WhatsApp.
+
+El agente solo responde cuando el mensaje entrante viene de un telefono guardado
+en `owner_agent_authorized_phone` y marcado como activo. Los mensajes de clientes
+no autorizados siguen entrando al flujo normal del chatbot comercial.
+
+## Activacion
+
+La activacion tiene dos niveles:
+
+1. Kill-switch de servidor en `.env`:
+   - `OWNER_AGENT_SERVER_ENABLED=true`
+   - `ANTHROPIC_API_KEY=<secret>`
+   - Opcionales:
+     - `OWNER_AGENT_MODEL=claude-sonnet-4-6`
+     - `OWNER_AGENT_RECURSION_LIMIT=12`
+
+2. Configuracion operativa desde el frontend:
+   - Menu `Configuracion -> Agente Admin`
+   - Activar/desactivar el agente.
+   - Administrar telefonos autorizados.
+   - Elegir modelo.
+   - Configurar si las acciones requieren confirmacion.
+   - Editar instrucciones administrativas.
+
+Si `OWNER_AGENT_SERVER_ENABLED` esta apagado, el frontend puede guardar la
+configuracion pero el agente no respondera.
+
+## Telefonos autorizados
+
+El telefono inicial sembrado por migracion es:
+
+- `8719708890`, normalizado como `5218719708890`
+
+El backend normaliza formatos mexicanos comunes para que coincidan:
+
+- `8719708890`
+- `528719708890`
+- `5218719708890`
+
+La tabla `owner_agent_authorized_phone` guarda:
+
+- `label`: etiqueta visible, por ejemplo `Dueno`
+- `phone_number`: telefono escrito por el usuario
+- `normalized_wa_id`: formato canonico usado para matching
+- `enabled`: si puede usar el agente
+- `created_by`: cuenta que lo registro
+
+## Permisos
+
+Para editar esta configuracion desde el frontend se requiere la capability:
+
+- `manage_owner_agent`
+
+El rol `admin` la tiene implicitamente. Otros roles pueden recibirla desde:
+
+- `Configuracion -> Permisos`
+
+El backend vuelve a validar la capability en cada mutation; el JWT solo se usa
+para mostrar u ocultar opciones de UI.
+
+## Flujo de mensajes
+
+1. Meta WhatsApp Cloud API entrega el webhook en `/webhook/whatsapp`.
+2. `whatsapp_ingest_service` persiste contacto, conversacion y mensaje.
+3. `whatsapp_hooks.on_inbound_message` revisa si el `wa_id` esta autorizado.
+4. Si esta autorizado:
+   - agenda `owner_agent.reply_service.schedule_agent_reply`
+   - no ejecuta opt-out ni chatbot comercial
+5. Si no esta autorizado:
+   - mantiene el flujo existente del chatbot de clientes.
+6. El agente corre en background con su propia sesion de DB.
+7. La respuesta se envia por `whatsapp_outbound` con kind:
+   - `owner_agent_reply`
+
+## Seguridad operacional
+
+El agente admin usa estas barreras:
+
+- Allowlist de telefonos autorizados.
+- Kill-switch de servidor.
+- Toggle operativo en base de datos.
+- Confirmacion obligatoria para acciones que cambian estado.
+- Auditoria por herramienta/accion.
+- Separacion total del estado del chatbot comercial.
+
+Las tablas principales son:
+
+- `owner_agent_config`
+- `owner_agent_authorized_phone`
+- `owner_agent_pending_action`
+- `owner_agent_audit_log`
+- `owner_tasks`
+
+## Confirmacion de acciones
+
+Las acciones que modifican estado no se ejecutan directamente. El agente debe:
+
+1. Llamar a una tool `propose_*`.
+2. Guardar la accion en `owner_agent_pending_action`.
+3. Responder con un resumen y pedir confirmacion.
+4. Ejecutar solo si el usuario responde algo como `si`, `ok` o `dale`.
+5. Cancelar si responde `no`, `cancelar` o equivalente.
+
+Tools de confirmacion:
+
+- `confirm_action`
+- `cancel_action`
+
+## Tareas y consultas disponibles
+
+### Reporte general del negocio
+
+Tool: `get_business_report(period)`
+
+Devuelve KPIs del negocio:
+
+- Ingresos del periodo.
+- Reservas del periodo.
+- Socios activos.
+- Nuevos socios.
+- Ocupacion promedio.
+- Plan mas vendido del periodo, si existe.
+
+Periodos soportados:
+
+- `today`
+- `week`
+- `month`
+- `last_30_days`
+- `year`
+- tambien acepta variantes en espanol como `hoy`, `esta semana`, `este mes`.
+
+Ejemplos:
+
+- "Dame el reporte de hoy"
+- "Como va el negocio este mes?"
+- "Resumen de los ultimos 30 dias"
+
+### Reporte financiero
+
+Tool: `get_payments_report(period)`
+
+Devuelve:
+
+- Total cobrado.
+- Numero de pagos.
+- Monto completado.
+- Ticket promedio.
+- Pagos pendientes.
+- Pagos fallidos.
+- Pagos reembolsados.
+- Pagos huerfanos.
+- Posibles duplicados.
+- Desglose por metodo.
+
+Ejemplos:
+
+- "Cuanto vendimos hoy?"
+- "Reporte financiero de esta semana"
+- "Hay pagos huerfanos o duplicados?"
+
+### Reporte de socios
+
+Tool: `get_members_report(days_ahead)`
+
+Devuelve:
+
+- Suscripciones activas.
+- Suscripciones vencidas que siguen marcadas como activas.
+- Socios que vencen proximamente.
+
+`days_ahead` permite revisar proximos vencimientos, por default 14 dias.
+
+Ejemplos:
+
+- "Quien vence en los proximos 7 dias?"
+- "Resumen de socios"
+- "Cuantos socios activos hay?"
+
+### Reporte de clases
+
+Tool: `get_classes_report(period)`
+
+Devuelve:
+
+- Sesiones del periodo.
+- Reservas/check-ins.
+- Ocupacion promedio.
+- Ocupacion por tipo de clase.
+
+Ejemplos:
+
+- "Como estuvo la ocupacion hoy?"
+- "Reporte de clases de esta semana"
+- "Que clases tuvieron mas ocupacion?"
+
+### Reporte de leads
+
+Tool: `get_leads_report(period)`
+
+Devuelve:
+
+- Total de leads del periodo.
+- Leads convertidos.
+- Desglose por estado.
+
+Ejemplos:
+
+- "Como van los leads este mes?"
+- "Cuantos leads convertimos?"
+
+### Reporte de campanas
+
+Tool: `get_campaigns_report()`
+
+Devuelve:
+
+- Total de campanas.
+- Desglose por estado.
+
+Ejemplos:
+
+- "Estado de campanas"
+- "Cuantas campanas hay programadas?"
+
+### Reporte de WhatsApp
+
+Tool: `get_whatsapp_report()`
+
+Devuelve:
+
+- Conversaciones activas.
+- Mensajes entrantes no leidos.
+- Ultimos mensajes entrantes.
+
+Ejemplos:
+
+- "Hay mensajes pendientes?"
+- "Resumen de WhatsApp"
+
+## Acciones disponibles
+
+### Crear tarea
+
+Tool de propuesta: `propose_create_task(title, description)`
+
+Crea una tarea en `owner_tasks` despues de confirmacion.
+
+Ejemplos:
+
+- "Crea una tarea para revisar pagos huerfanos"
+- "Agrega tarea: llamar a socios vencidos"
+
+### Completar tarea
+
+Tool de propuesta: `propose_complete_task(task_id)`
+
+Marca una tarea como `done` despues de confirmacion.
+
+Ejemplos:
+
+- "Completa la tarea 12"
+- "Marca como terminada la tarea 5"
+
+### Cancelar tarea
+
+Tool de propuesta: `propose_cancel_task(task_id)`
+
+Marca una tarea como `canceled` despues de confirmacion.
+
+Ejemplos:
+
+- "Cancela la tarea 8"
+
+### Listar tareas
+
+Tool: `list_tasks(include_done)`
+
+Lista tareas abiertas por default. Si `include_done=true`, incluye completadas y
+canceladas.
+
+Ejemplos:
+
+- "Que tareas tengo pendientes?"
+- "Lista mis tareas"
+
+### Ejecutar barrido de notificaciones
+
+Tool de propuesta: `propose_notification_sweep()`
+
+Despues de confirmacion ejecuta:
+
+- `notification_service.run_all_sweeps()`
+
+Uso esperado:
+
+- recordatorios de renovacion
+- membresias vencidas
+
+Ejemplo:
+
+- "Ejecuta el barrido de notificaciones"
+
+### Ejecutar barrido de campanas
+
+Tool de propuesta: `propose_campaign_sweep()`
+
+Despues de confirmacion ejecuta:
+
+- `campaign_service.run_campaign_sweep()`
+
+Ejemplo:
+
+- "Ejecuta campanas programadas"
+
+## Auditoria
+
+Cada tool registra un evento en `owner_agent_audit_log` con:
+
+- conversacion
+- mensaje origen
+- telefono autorizado
+- tool o accion
+- payload
+- resumen del resultado
+- estado
+- error si fallo
+
+Esto permite revisar que pidio el administrador y que hizo el agente.
+
+## Limitaciones actuales
+
+- El agente no envia mensajes proactivos por si solo; responde a mensajes
+  entrantes dentro de la ventana de WhatsApp.
+- No administra clientes directamente en v1, salvo reportes y tareas internas.
+- Las acciones destructivas o de alto impacto deben agregarse como nuevas
+  `propose_*` tools con confirmacion y auditoria.
+- La configuracion es single-business. Si FitPilot se vuelve multi-tenant, estas
+  tablas deben recibir `tenant_id` o `business_id`.
+
+## Troubleshooting
+
+### No responde
+
+Revisar:
+
+- `OWNER_AGENT_SERVER_ENABLED=true`
+- `ANTHROPIC_API_KEY` configurado
+- agente activo en `Configuracion -> Agente Admin`
+- telefono marcado como activo
+- `normalized_wa_id` coincide con el `wa_id` entrante
+
+### Responde el chatbot comercial en lugar del agente admin
+
+El telefono no esta resolviendo contra `owner_agent_authorized_phone`. Revisar
+normalizacion y estado activo.
+
+### El frontend no muestra la seccion
+
+El usuario debe ser `admin` o tener la capability `manage_owner_agent`.
+
+### Las tools fallan con datos de reportes
+
+Verificar que la base de datos este disponible y que las migraciones esten
+aplicadas:
+
+```bash
+cd backend
+python -m alembic upgrade head
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ python-dateutil>=2.9.0
 # Optional: Better JSON serialization
 pydantic>=2.5.0
 
-# LangChain / LangGraph customer-facing WhatsApp chatbot agent (Anthropic Claude)
+# LangChain / LangGraph WhatsApp agents (customer chatbot + owner/admin agent)
 langchain-core>=0.3.0
 langchain-anthropic>=0.3.0     # pulls the official `anthropic` SDK; ChatAnthropic(model="claude-sonnet-4-6")
 langgraph>=0.2.50              # langgraph.prebuilt.create_react_agent

--- a/tests/test_owner_agent_config.py
+++ b/tests/test_owner_agent_config.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from app.crud import ownerAgentCrud
+from app.graphql.schema import schema
+from app.services import whatsapp_hooks
+
+
+def test_owner_phone_normalization_supports_mexican_whatsapp_formats():
+    assert ownerAgentCrud.normalize_owner_phone("8719708890") == "5218719708890"
+    assert ownerAgentCrud.normalize_owner_phone("528719708890") == "5218719708890"
+    assert ownerAgentCrud.normalize_owner_phone("5218719708890") == "5218719708890"
+
+    keys = ownerAgentCrud.phone_match_keys("8719708890")
+    assert {"8719708890", "528719708890", "5218719708890"}.issubset(keys)
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_hook_routes_authorized_owner_to_owner_agent(monkeypatch):
+    scheduled = {}
+
+    async def fake_resolve(_db, wa_id):
+        assert wa_id == "5218719708890"
+        return SimpleNamespace(id=99)
+
+    def fake_schedule_agent_reply(**kwargs):
+        scheduled.update(kwargs)
+
+    monkeypatch.setattr(ownerAgentCrud, "resolve_authorized_phone", fake_resolve)
+
+    from app.services.owner_agent import reply_service as owner_reply_service
+
+    monkeypatch.setattr(owner_reply_service, "schedule_agent_reply", fake_schedule_agent_reply)
+
+    message = SimpleNamespace(
+        id=10, direction="inbound", message_type="text", text_content="reporte de hoy"
+    )
+    contact = SimpleNamespace(id=20, wa_id="5218719708890")
+    conversation = SimpleNamespace(id=30, bot_enabled=True, bot_paused_until=None)
+
+    await whatsapp_hooks.on_inbound_message(object(), message, contact, conversation)
+
+    assert scheduled["conversation_id"] == 30
+    assert scheduled["contact_id"] == 20
+    assert scheduled["authorized_phone_id"] == 99
+    assert scheduled["text"] == "reporte de hoy"
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_hook_keeps_customer_chatbot_for_non_owner(monkeypatch):
+    customer_scheduled = {}
+
+    async def fake_resolve(_db, _wa_id):
+        return None
+
+    async def fake_keyword(*_args, **_kwargs):
+        return False
+
+    fake_reply_service = SimpleNamespace(
+        schedule_agent_reply=lambda **kwargs: customer_scheduled.update(kwargs)
+    )
+
+    monkeypatch.setattr(ownerAgentCrud, "resolve_authorized_phone", fake_resolve)
+    monkeypatch.setitem(sys.modules, "app.services.chatbot.reply_service", fake_reply_service)
+    import app.services.chatbot as chatbot_pkg
+
+    monkeypatch.setattr(chatbot_pkg, "reply_service", fake_reply_service, raising=False)
+    monkeypatch.setattr("app.services.whatsapp_optout.handle_keyword", fake_keyword)
+
+    message = SimpleNamespace(id=11, direction="inbound", message_type="text", text_content="hola")
+    contact = SimpleNamespace(id=21, wa_id="5215555555555")
+    conversation = SimpleNamespace(id=31, bot_enabled=True, bot_paused_until=None)
+
+    await whatsapp_hooks.on_inbound_message(object(), message, contact, conversation)
+
+    assert customer_scheduled["conversation_id"] == 31
+    assert customer_scheduled["contact_wa_id"] == "5215555555555"
+    assert customer_scheduled["text"] == "hola"
+
+
+@pytest.mark.asyncio
+async def test_owner_agent_config_mutation_requires_capability():
+    mutation = """
+        mutation {
+            saveOwnerAgentConfig(input: {enabled: true}) {
+                success
+                error
+            }
+        }
+    """
+    result = await schema.execute(
+        mutation,
+        context_value=SimpleNamespace(db=object(), user=SimpleNamespace(roles=[]), account_id=1),
+    )
+
+    assert not result.errors
+    payload = result.data["saveOwnerAgentConfig"]
+    assert payload["success"] is False
+    assert "permiso" in payload["error"].lower()


### PR DESCRIPTION
## What changed
- Adds the configurable WhatsApp owner/admin agent backend.
- Adds database tables, GraphQL config APIs, routing, tools, audit/pending actions, tests, and documentation.
- Keeps the admin agent separate from the existing customer chatbot and behind the server kill-switch.

## Validation
- python -m compileall app
- python -m pytest tests/test_owner_agent_config.py tests/test_whatsapp_member_matching.py::test_phone_match_keys_support_mexican_whatsapp_formats -q