### PR TITLE
feat(users): Admin CRUD for staff login accounts with roles

### DIFF
--- a/alembic/versions/e7f8a9b0c1d2_manage_users_capability.py
+++ b/alembic/versions/e7f8a9b0c1d2_manage_users_capability.py
@@ -1,0 +1,53 @@
+"""manage_users capability + ensure standard roles exist.
+
+Adds the ``manage_users`` capability (granted to admin for display in the
+permissions matrix; admin is an implicit super-user in code) and, defensively,
+seeds the standard roles so the user-management role picker is never empty in
+environments where roles were not seeded manually.
+
+Revision ID: e7f8a9b0c1d2
+Revises: d6e7f8a9b0c1
+Create Date: 2026-06-22 16:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "e7f8a9b0c1d2"
+down_revision: Union[str, None] = "d6e7f8a9b0c1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    # Defensive: ensure the standard roles exist (no-op where already present).
+    op.execute(
+        f"""
+        INSERT INTO {SCHEMA}.roles (code, description) VALUES
+            ('admin', 'Administrador'),
+            ('staff', 'Recepción / personal'),
+            ('instructor', 'Instructor de clases'),
+            ('member', 'Socio')
+        ON CONFLICT (code) DO NOTHING
+        """
+    )
+
+    # Seed the admin grant for display (admin is implicit super-user in code).
+    op.execute(
+        f"""
+        INSERT INTO {SCHEMA}.role_capabilities (role_id, capability)
+        SELECT id, 'manage_users' FROM {SCHEMA}.roles WHERE code = 'admin'
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"DELETE FROM {SCHEMA}.role_capabilities WHERE capability = 'manage_users'"
+    )

--- a/app/crud/permissions.py
+++ b/app/crud/permissions.py
@@ -17,7 +17,8 @@ from app.models import People, Role, RoleCapability
 # --- Capability registry (used by the settings UI to render the matrix) ----
 MANAGE_MEMBERSHIP_PLANS = "manage_membership_plans"
 MANAGE_OWNER_AGENT = "manage_owner_agent"
-ALL_CAPABILITIES: List[str] = [MANAGE_MEMBERSHIP_PLANS, MANAGE_OWNER_AGENT]
+MANAGE_USERS = "manage_users"
+ALL_CAPABILITIES: List[str] = [MANAGE_MEMBERSHIP_PLANS, MANAGE_OWNER_AGENT, MANAGE_USERS]
 
 ADMIN_ROLE_CODE = "admin"
 

--- a/app/crud/usersCrud.py
+++ b/app/crud/usersCrud.py
@@ -1,5 +1,6 @@
-from typing import Optional
-from sqlalchemy import select, update, and_
+from datetime import datetime, timezone
+from typing import List, Optional
+from sqlalchemy import select, update, delete, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -88,3 +89,218 @@ async def create_person(db: AsyncSession, full_name: str, email: str = None, pho
     await db.commit()
     await db.refresh(person)
     return person
+
+
+# ---------------------------------------------------------------------------
+# User (login account) management — used by the Admin "Usuarios" CRUD.
+# A "user" = People (identity) + Account (login) + roles (PersonRole).
+# ---------------------------------------------------------------------------
+
+# Sentinel so callers can distinguish "not provided" from "explicitly None".
+_UNSET = object()
+
+
+async def list_roles(db: AsyncSession) -> List[Role]:
+    """All roles ordered by code (to populate role pickers)."""
+    result = await db.execute(select(Role).order_by(Role.code))
+    return result.scalars().all()
+
+
+async def list_users(db: AsyncSession, include_inactive: bool = True) -> List[Account]:
+    """List login accounts (staff users) with their person + roles loaded."""
+    query = (
+        select(Account)
+        .options(
+            selectinload(Account.person)
+            .selectinload(People.roles)
+            .selectinload(PersonRole.role)
+        )
+        .join(People, Account.person_id == People.id)
+        .where(People.deleted_at.is_(None))
+        .order_by(Account.username)
+    )
+    if not include_inactive:
+        query = query.where(Account.is_active.is_(True))
+
+    result = await db.execute(query)
+    return result.scalars().all()
+
+
+async def get_user_by_account_id(db: AsyncSession, account_id: int) -> Optional[Account]:
+    """Get a single account (any active state) with its person + roles loaded."""
+    account_id = coerce_int(account_id)
+    if account_id is None:
+        return None
+
+    result = await db.execute(
+        select(Account)
+        .options(
+            selectinload(Account.person)
+            .selectinload(People.roles)
+            .selectinload(PersonRole.role)
+        )
+        .where(Account.id == account_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def username_exists(
+    db: AsyncSession, username: str, exclude_account_id: Optional[int] = None
+) -> bool:
+    """Whether an account with this username already exists (optionally ignoring one id)."""
+    query = select(Account.id).where(Account.username == username)
+    exclude_id = coerce_int(exclude_account_id)
+    if exclude_id is not None:
+        query = query.where(Account.id != exclude_id)
+    result = await db.execute(query)
+    return result.first() is not None
+
+
+async def _set_person_roles(db: AsyncSession, person_id: int, role_ids: List) -> None:
+    """Make a person's role assignments match ``role_ids`` (validating they exist).
+
+    Diffs against the current assignments so unchanged roles are left untouched —
+    this avoids a delete+reinsert of the same (person_id, role_id) PK in one flush.
+    """
+    normalized: List[int] = []
+    for rid in role_ids or []:
+        rid_value = coerce_int(rid)
+        if rid_value is not None:
+            normalized.append(rid_value)
+    target = set(normalized)
+
+    if target:
+        found = set(
+            (await db.execute(select(Role.id).where(Role.id.in_(target)))).scalars().all()
+        )
+        missing = target - found
+        if missing:
+            raise ValueError(f"Roles inexistentes: {sorted(missing)}")
+
+    current = (
+        await db.execute(select(PersonRole.role_id).where(PersonRole.person_id == person_id))
+    ).scalars().all()
+    current_ids = set(current)
+
+    to_remove = current_ids - target
+    to_add = target - current_ids
+
+    if to_remove:
+        await db.execute(
+            delete(PersonRole).where(
+                PersonRole.person_id == person_id,
+                PersonRole.role_id.in_(to_remove),
+            )
+        )
+    for rid in to_add:
+        db.add(PersonRole(person_id=person_id, role_id=rid))
+
+
+async def create_user_with_account(
+    db: AsyncSession,
+    full_name: str,
+    username: str,
+    password_hash: str,
+    email: Optional[str] = None,
+    phone_number: Optional[str] = None,
+    role_ids: Optional[List] = None,
+    is_active: bool = True,
+) -> Optional[Account]:
+    """Create a People + Account (login) and assign roles. Returns the loaded Account."""
+    person = People(full_name=full_name, email=email, phone_number=phone_number)
+    db.add(person)
+    await db.flush()  # obtain person.id without committing
+
+    account = Account(
+        person_id=person.id,
+        username=username,
+        password_hash=password_hash,
+        is_active=is_active,
+    )
+    db.add(account)
+    await db.flush()  # obtain account.id
+
+    await _set_person_roles(db, person.id, role_ids or [])
+
+    await db.commit()
+    return await get_user_by_account_id(db, account.id)
+
+
+async def update_user(
+    db: AsyncSession,
+    account_id: int,
+    full_name=_UNSET,
+    email=_UNSET,
+    phone_number=_UNSET,
+    username=_UNSET,
+    is_active=_UNSET,
+    role_ids=_UNSET,
+) -> Optional[Account]:
+    """Partial update of a user's person, account and (optionally) roles."""
+    account_id_value = coerce_int(account_id)
+    if account_id_value is None:
+        return None
+
+    account = await get_user_by_account_id(db, account_id_value)
+    if account is None:
+        return None
+
+    person = account.person
+
+    if full_name is not _UNSET and full_name is not None:
+        person.full_name = full_name
+    if email is not _UNSET:
+        person.email = email
+    if phone_number is not _UNSET:
+        person.phone_number = phone_number
+    if username is not _UNSET and username is not None:
+        account.username = username
+    if is_active is not _UNSET and is_active is not None:
+        account.is_active = bool(is_active)
+
+    person.updated_at = datetime.now(timezone.utc)
+    account.updated_at = datetime.now(timezone.utc)
+
+    if role_ids is not _UNSET and role_ids is not None:
+        await _set_person_roles(db, person.id, role_ids)
+
+    await db.commit()
+    return await get_user_by_account_id(db, account_id_value)
+
+
+async def set_account_active(
+    db: AsyncSession, account_id: int, is_active: bool
+) -> Optional[Account]:
+    """Activate/deactivate a login account (soft-delete of access)."""
+    account_id_value = coerce_int(account_id)
+    if account_id_value is None:
+        return None
+
+    result = await db.execute(select(Account).where(Account.id == account_id_value))
+    account = result.scalar_one_or_none()
+    if account is None:
+        return None
+
+    account.is_active = bool(is_active)
+    account.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    return await get_user_by_account_id(db, account_id_value)
+
+
+async def reset_account_password(
+    db: AsyncSession, account_id: int, password_hash: str
+) -> Optional[Account]:
+    """Set a new password hash for an account by id."""
+    account_id_value = coerce_int(account_id)
+    if account_id_value is None:
+        return None
+
+    result = await db.execute(select(Account).where(Account.id == account_id_value))
+    account = result.scalar_one_or_none()
+    if account is None:
+        return None
+
+    account.password_hash = password_hash
+    account.updated_at = datetime.now(timezone.utc)
+    await db.commit()
+    return account

--- a/app/graphql/users/mutations.py
+++ b/app/graphql/users/mutations.py
@@ -1,12 +1,29 @@
 import strawberry
 from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
 
 from app.security.hashing import hash_password
-from app.crud.usersCrud import update_account_password, create_person
+from app.crud.usersCrud import (
+    update_account_password,
+    create_person,
+    create_user_with_account,
+    update_user as crud_update_user,
+    set_account_active,
+    reset_account_password,
+    username_exists,
+)
+from app.crud.permissions import MANAGE_USERS
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
 from app.graphql.users.types import (
     ChangePasswordInput, ChangePasswordResponse,
-    CreatePersonInput, CreatePersonResponse, Person
+    CreatePersonInput, CreatePersonResponse, Person,
+    CreateUserInput, UpdateUserInput, UserMutationResponse, AppUser,
 )
+
+
+# Sentinel so partial updates don't wipe fields that were not provided.
+_UNSET = object()
 
 
 @strawberry.type
@@ -43,3 +60,154 @@ class UserMutation:
             person=Person.from_model(person),
             message="Person created successfully"
         )
+
+    # ------------------------------------------------------------------
+    # User (login account) management — requires the manage_users capability.
+    # ------------------------------------------------------------------
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def create_user(self, info: Info, input: CreateUserInput) -> UserMutationResponse:
+        """Create a login account (person + credentials + roles)."""
+        db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_USERS)
+        if error:
+            return UserMutationResponse(success=False, user=None, message=error)
+
+        full_name = (input.full_name or "").strip()
+        username = (input.username or "").strip()
+        password = input.password or ""
+
+        if not full_name:
+            return UserMutationResponse(success=False, user=None, message="El nombre es obligatorio")
+        if not username:
+            return UserMutationResponse(success=False, user=None, message="El usuario es obligatorio")
+        if not password:
+            return UserMutationResponse(success=False, user=None, message="La contraseña es obligatoria")
+        if not input.role_ids:
+            return UserMutationResponse(success=False, user=None, message="Debes asignar al menos un rol")
+
+        try:
+            if await username_exists(db, username):
+                return UserMutationResponse(
+                    success=False, user=None, message="El nombre de usuario ya existe"
+                )
+
+            account = await create_user_with_account(
+                db=db,
+                full_name=full_name,
+                username=username,
+                password_hash=hash_password(password=password),
+                email=(input.email or None),
+                phone_number=(input.phone_number or None),
+                role_ids=list(input.role_ids),
+            )
+
+            return UserMutationResponse(
+                success=True,
+                user=AppUser.from_account(account) if account else None,
+                message="Usuario creado exitosamente",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return UserMutationResponse(
+                success=False, user=None, message=f"Error al crear usuario: {str(e)}"
+            )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def update_user(self, info: Info, input: UpdateUserInput) -> UserMutationResponse:
+        """Update a user's identity, username, active state and/or roles."""
+        db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_USERS)
+        if error:
+            return UserMutationResponse(success=False, user=None, message=error)
+
+        def _opt(value):
+            return value if value is not None else _UNSET
+
+        try:
+            new_username = (input.username or "").strip() if input.username is not None else None
+            if new_username:
+                if await username_exists(db, new_username, exclude_account_id=input.account_id):
+                    return UserMutationResponse(
+                        success=False, user=None, message="El nombre de usuario ya existe"
+                    )
+
+            account = await crud_update_user(
+                db=db,
+                account_id=input.account_id,
+                full_name=_opt(input.full_name),
+                email=input.email if input.email is not None else _UNSET,
+                phone_number=input.phone_number if input.phone_number is not None else _UNSET,
+                username=_opt(new_username),
+                is_active=_opt(input.is_active),
+                role_ids=_opt(input.role_ids),
+            )
+
+            if account is None:
+                return UserMutationResponse(success=False, user=None, message="Usuario no encontrado")
+
+            return UserMutationResponse(
+                success=True,
+                user=AppUser.from_account(account),
+                message="Usuario actualizado exitosamente",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return UserMutationResponse(
+                success=False, user=None, message=f"Error al actualizar usuario: {str(e)}"
+            )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def set_user_active(self, info: Info, account_id: int, is_active: bool) -> UserMutationResponse:
+        """Activate or deactivate (soft-delete) a login account."""
+        db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_USERS)
+        if error:
+            return UserMutationResponse(success=False, user=None, message=error)
+
+        try:
+            account = await set_account_active(db=db, account_id=account_id, is_active=is_active)
+            if account is None:
+                return UserMutationResponse(success=False, user=None, message="Usuario no encontrado")
+
+            action = "reactivado" if is_active else "desactivado"
+            return UserMutationResponse(
+                success=True,
+                user=AppUser.from_account(account),
+                message=f"Usuario {action} exitosamente",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return UserMutationResponse(
+                success=False, user=None, message=f"Error al cambiar el estado del usuario: {str(e)}"
+            )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def reset_user_password(self, info: Info, account_id: int, password: str) -> UserMutationResponse:
+        """Set a new password for a user account."""
+        db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_USERS)
+        if error:
+            return UserMutationResponse(success=False, user=None, message=error)
+
+        if not (password or "").strip():
+            return UserMutationResponse(success=False, user=None, message="La contraseña es obligatoria")
+
+        try:
+            account = await reset_account_password(
+                db=db, account_id=account_id, password_hash=hash_password(password=password)
+            )
+            if account is None:
+                return UserMutationResponse(success=False, user=None, message="Usuario no encontrado")
+
+            return UserMutationResponse(
+                success=True, user=None, message="Contraseña actualizada exitosamente"
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return UserMutationResponse(
+                success=False, user=None, message=f"Error al restablecer la contraseña: {str(e)}"
+            )

--- a/app/graphql/users/queries.py
+++ b/app/graphql/users/queries.py
@@ -4,10 +4,11 @@ import strawberry
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
-from app.crud.usersCrud import list_people, get_person_by_id
+from app.crud.usersCrud import list_people, get_person_by_id, list_users, list_roles
+from app.crud.permissions import MANAGE_USERS
 from app.db.postgresql import get_db
-from app.graphql.auth.permissions import IsAuthenticated
-from app.graphql.users.types import Person
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
+from app.graphql.users.types import Person, AppUser, RoleType
 from app.core.conversions import coerce_int
 
 
@@ -20,6 +21,26 @@ class UserQuery:
 
         people = await list_people(db=db, role_code=role_code)
         return [Person.from_model(person) for person in people]
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def app_users(self, info: Info, include_inactive: bool = True) -> list[AppUser]:
+        """List login accounts (staff users). Requires the manage_users capability."""
+        db = info.context.db
+
+        error = await require_capability(info, MANAGE_USERS)
+        if error:
+            return []
+
+        accounts = await list_users(db=db, include_inactive=include_inactive)
+        return [AppUser.from_account(account) for account in accounts]
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def roles(self, info: Info) -> list[RoleType]:
+        """Available roles in the system (to assign to users)."""
+        db = info.context.db
+
+        roles = await list_roles(db=db)
+        return [RoleType.from_model(role) for role in roles]
 
     @strawberry.field(permission_classes=[IsAuthenticated])
     async def person(self, info: Info, person_id: int) -> Optional[Person]:

--- a/app/graphql/users/types.py
+++ b/app/graphql/users/types.py
@@ -1,15 +1,18 @@
 import strawberry
 from datetime import datetime
 from typing import Optional, List
-from app.models import People, Role, PersonRole, Account
+from app.models import People, Role, PersonRole, Account as AccountModel
 
 
 @strawberry.type
 class RoleType:
     id: int
-    name: str
     code: str
     description: Optional[str] = None
+
+    @classmethod
+    def from_model(cls, role: Role) -> "RoleType":
+        return cls(id=role.id, code=role.code, description=role.description)
 
 
 @strawberry.type
@@ -58,16 +61,45 @@ class Person:
             updated_at=person.updated_at,
             roles=[
                 PersonRole(
-                    role=RoleType(
-                        id=pr.role.id,
-                        name=pr.role.name,
-                        code=pr.role.code,
-                        description=pr.role.description
-                    ),
-                    assigned_at=pr.created_at
+                    role=RoleType.from_model(pr.role),
+                    assigned_at=pr.created_at,
                 )
                 for pr in person.roles
+                if pr.role
             ] if person.roles else []
+        )
+
+
+@strawberry.type
+class AppUser:
+    """A login user: account credentials + identity + assigned roles."""
+
+    account_id: int
+    person_id: int
+    username: str
+    is_active: bool
+    full_name: Optional[str]
+    email: Optional[str]
+    phone_number: Optional[str]
+    created_at: datetime
+    roles: List[RoleType]
+
+    @classmethod
+    def from_account(cls, account: AccountModel) -> "AppUser":
+        person = getattr(account, "person", None)
+        roles: List[RoleType] = []
+        if person is not None and getattr(person, "roles", None):
+            roles = [RoleType.from_model(pr.role) for pr in person.roles if pr.role]
+        return cls(
+            account_id=account.id,
+            person_id=account.person_id,
+            username=account.username,
+            is_active=account.is_active,
+            full_name=person.full_name if person else None,
+            email=person.email if person else None,
+            phone_number=person.phone_number if person else None,
+            created_at=account.created_at,
+            roles=roles,
         )
 
 
@@ -102,4 +134,33 @@ class ChangePasswordResponse:
 @strawberry.type
 class CreatePersonResponse:
     person: Person
+    message: str
+
+
+# --- User (login account) management -------------------------------------
+@strawberry.input
+class CreateUserInput:
+    full_name: str
+    username: str
+    password: str
+    email: Optional[str] = None
+    phone_number: Optional[str] = None
+    role_ids: List[int] = strawberry.field(default_factory=list)
+
+
+@strawberry.input
+class UpdateUserInput:
+    account_id: int
+    full_name: Optional[str] = None
+    username: Optional[str] = None
+    email: Optional[str] = None
+    phone_number: Optional[str] = None
+    is_active: Optional[bool] = None
+    role_ids: Optional[List[int]] = None
+
+
+@strawberry.type
+class UserMutationResponse:
+    success: bool
+    user: Optional[AppUser]
     message: str

--- a/tests/test_users_crud.py
+++ b/tests/test_users_crud.py
@@ -1,0 +1,127 @@
+"""Backend tests for the user (login account) CRUD layer.
+
+Covers:
+  - create_user_with_account (person + account + roles) and username_exists
+  - update_user role diffing (add keeping existing, then narrow) + scalar fields
+  - update_user validation of unknown role ids
+  - set_account_active toggling and reset_account_password
+
+Each test runs inside a SAVEPOINT-wrapped session (see conftest.py) so nothing
+persists to defaultdb. Roles use unique codes to avoid colliding with real rows.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.crud.usersCrud import (
+    create_user_with_account,
+    update_user,
+    set_account_active,
+    reset_account_password,
+    username_exists,
+)
+from app.models import Account, Role
+
+
+async def _make_role(db, code_prefix: str) -> Role:
+    role = Role(code=f"{code_prefix}_{uuid.uuid4().hex[:8]}", description=f"Test {code_prefix}")
+    db.add(role)
+    await db.flush()
+    return role
+
+
+def _uname() -> str:
+    return f"testuser_{uuid.uuid4().hex[:10]}"
+
+
+async def test_create_user_with_account(db):
+    role = await _make_role(db, "rolea")
+    username = _uname()
+
+    account = await create_user_with_account(
+        db=db,
+        full_name="Alice Tester",
+        username=username,
+        password_hash="hash-1",
+        email="alice@example.com",
+        phone_number="555",
+        role_ids=[role.id],
+    )
+
+    assert account is not None
+    assert account.username == username
+    assert account.is_active is True
+    assert account.person is not None
+    assert account.person.full_name == "Alice Tester"
+    assert {pr.role_id for pr in account.person.roles} == {role.id}
+
+    assert await username_exists(db, username) is True
+    assert await username_exists(db, username, exclude_account_id=account.id) is False
+
+
+async def test_update_user_replaces_roles(db):
+    role_a = await _make_role(db, "rolea")
+    role_b = await _make_role(db, "roleb")
+
+    account = await create_user_with_account(
+        db=db, full_name="Bob", username=_uname(), password_hash="h",
+        role_ids=[role_a.id],
+    )
+
+    # Add role_b while keeping role_a (diff path: must not collide on the kept PK).
+    updated = await update_user(db=db, account_id=account.id, role_ids=[role_a.id, role_b.id])
+    assert {pr.role_id for pr in updated.person.roles} == {role_a.id, role_b.id}
+
+    # Narrow down to only role_b.
+    updated = await update_user(db=db, account_id=account.id, role_ids=[role_b.id])
+    assert {pr.role_id for pr in updated.person.roles} == {role_b.id}
+
+    # Update scalar field without touching roles (username=None => leave unchanged).
+    updated = await update_user(
+        db=db, account_id=account.id, full_name="Bob Updated", username=None
+    )
+    assert updated.person.full_name == "Bob Updated"
+    assert {pr.role_id for pr in updated.person.roles} == {role_b.id}
+
+
+async def test_update_user_invalid_role_raises(db):
+    role_a = await _make_role(db, "rolea")
+    account = await create_user_with_account(
+        db=db, full_name="Carol", username=_uname(), password_hash="h",
+        role_ids=[role_a.id],
+    )
+    with pytest.raises(ValueError):
+        await update_user(db=db, account_id=account.id, role_ids=[role_a.id, 999_999_999])
+
+
+async def test_set_account_active_toggle(db):
+    role_a = await _make_role(db, "rolea")
+    account = await create_user_with_account(
+        db=db, full_name="Dan", username=_uname(), password_hash="h",
+        role_ids=[role_a.id],
+    )
+
+    deactivated = await set_account_active(db=db, account_id=account.id, is_active=False)
+    assert deactivated.is_active is False
+
+    reactivated = await set_account_active(db=db, account_id=account.id, is_active=True)
+    assert reactivated.is_active is True
+
+
+async def test_reset_account_password(db):
+    role_a = await _make_role(db, "rolea")
+    account = await create_user_with_account(
+        db=db, full_name="Eve", username=_uname(), password_hash="old-hash",
+        role_ids=[role_a.id],
+    )
+
+    result = await reset_account_password(db=db, account_id=account.id, password_hash="new-hash")
+    assert result is not None
+
+    fresh = (
+        await db.execute(select(Account).where(Account.id == account.id))
+    ).scalar_one()
+    assert fresh.password_hash == "new-hash"


### PR DESCRIPTION
## Contexto
Hasta ahora las cuentas de acceso (login) del staff se creaban a mano en la base de datos. Este PR agrega un CRUD para que un usuario **Admin** (o cualquiera con la nueva capacidad `manage_users`) pueda **crear / editar / activar-desactivar** cuentas de acceso y **asignarles uno o varios roles**.

Un "usuario" del sistema = `People` (identidad) + `Account` (login) + `PersonRole` (roles, M:N). Construido sobre el sistema de capacidades existente (`manage_membership_plans`, `manage_owner_agent`); admin es super-usuario implícito.

## Cambios
- **permissions.py**: nueva capacidad `manage_users` en `ALL_CAPABILITIES`.
- **usersCrud.py**: `create_user_with_account`, `update_user` (los roles se **diffean** para no borrar+reinsertar la misma PK en un flush), `set_account_active`, `reset_account_password`, `username_exists`, `list_users`, `list_roles`, `get_user_by_account_id`.
- **graphql/users**: tipo `AppUser`, inputs `CreateUserInput`/`UpdateUserInput`, `UserMutationResponse`; mutations `createUser`/`updateUser`/`setUserActive`/`resetUserPassword` (gated con `require_capability`) y queries `appUsers` + `roles`.
- **Fix bug latente**: `RoleType.name` se leía de `pr.role.name`, pero `Role` no tiene columna `name` → eliminado, con `RoleType.from_model`.
- **Migración `e7f8a9b0c1d2`** (down_revision `d6e7f8a9b0c1`): siembra roles estándar (`admin/staff/instructor/member`, `ON CONFLICT DO NOTHING`) y el grant de display `manage_users` para admin.
- **Tests** del CRUD de usuarios (`tests/test_users_crud.py`).

## Validación
- `py_compile` de todos los archivos ✅
- El esquema Strawberry construye y expone los nuevos campos/tipos ✅
- Cadena Alembic con un solo head, sin colisión ✅
- ⚠️ No ejecutado contra una BD: falta correr `alembic upgrade head` y `pytest tests/test_users_crud.py` en dev.

## Deploy / notas
- Aplicar migración `e7f8a9b0c1d2` en el deploy.
- Confirmar que la tabla `roles` de prod tenga los roles deseados (no existía migración previa que los sembrara; esta lo hace de forma idempotente).
- PR de frontend asociado (sección "Usuarios" en Configuración) por separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)