### PR TITLE
feat(account): self-service myAccount/updateMyAccount; drop insecure changePassword

### DIFF
--- a/app/crud/sessionCrud.py
+++ b/app/crud/sessionCrud.py
@@ -83,6 +83,27 @@ async def revoke_session(db: AsyncSession, session_id: str) -> None:
     # No flush, no commit - just queue the update
 
 
+async def revoke_other_sessions(db: AsyncSession, user_id: int, keep_session_id: str) -> int:
+    """Revoke every active session for a person except the current one.
+
+    Sessions are keyed by ``user_id`` (= ``People.id``, see auth login) and the
+    token identifier is the ``session`` column. Returns the number of sessions
+    revoked. Does NOT commit — the caller commits atomically with its own changes.
+    """
+    timestamp = datetime.now(timezone.utc)
+    result = await db.execute(
+        update(Session)
+        .where(
+            Session.user_id == user_id,
+            Session.session != keep_session_id,
+            Session.revoked_at.is_(None),
+            Session.deleted_at.is_(None),
+        )
+        .values(revoked_at=timestamp, updated_at=timestamp)
+    )
+    return result.rowcount or 0
+
+
 async def update_refresh_token(db: AsyncSession, session_id: str, refresh_token: str) -> None:
     """Stores a new refresh token for an existing session.
 

--- a/app/crud/usersCrud.py
+++ b/app/crud/usersCrud.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.conversions import coerce_int
+from app.crud.sessionCrud import revoke_other_sessions
 from app.models import People, Account, PersonRole, Role
 
 async def get_person_by_id(db: AsyncSession, person_id: int) -> Optional[People]:
@@ -49,21 +50,6 @@ async def list_people(db: AsyncSession, role_code: str = None):
 async def list_members(db: AsyncSession):
     """List all people with member role"""
     return await list_people(db, role_code='member')
-
-async def update_account_password(db: AsyncSession, username: str, password_hash: str) -> Optional[Account]:
-    """Update account password"""
-    stmt = (
-        update(Account)
-        .where(Account.username == username)
-        .where(Account.is_active == True)
-        .values(password_hash=password_hash)
-        .returning(Account.id, Account.username, Account.person_id)
-    )
-
-    result = await db.execute(stmt)
-    row = result.first()
-    await db.commit()
-    return row
 
 async def get_person_roles(db: AsyncSession, person_id: int):
     """Get all roles for a person"""
@@ -341,3 +327,51 @@ async def reset_account_password(
     account.updated_at = datetime.now(timezone.utc)
     await db.commit()
     return account
+
+
+async def update_own_account(
+    db: AsyncSession,
+    account_id: int,
+    *,
+    full_name=_UNSET,
+    email=_UNSET,
+    phone_number=_UNSET,
+    new_password_hash=_UNSET,
+    revoke_other_sessions_now: bool = False,
+    keep_session_id: Optional[str] = None,
+) -> Optional[Account]:
+    """Self-service update of the current user's own People/Account fields.
+
+    Applies provided fields (``_UNSET`` = leave unchanged), optionally sets a new
+    password hash, and optionally revokes the person's other sessions — all in a
+    single atomic commit. ``username``/roles/``is_active`` are intentionally NOT
+    updatable here (admin-only). Password verification is the caller's job.
+    """
+    account_id_value = coerce_int(account_id)
+    if account_id_value is None:
+        return None
+
+    account = await get_user_by_account_id(db, account_id_value)
+    if account is None:
+        return None
+
+    person = account.person
+
+    if person is not None:
+        if full_name is not _UNSET and full_name is not None:
+            person.full_name = full_name
+        if email is not _UNSET:
+            person.email = email
+        if phone_number is not _UNSET:
+            person.phone_number = phone_number
+        person.updated_at = datetime.now(timezone.utc)
+
+    if new_password_hash is not _UNSET:
+        account.password_hash = new_password_hash
+    account.updated_at = datetime.now(timezone.utc)
+
+    if revoke_other_sessions_now and person is not None:
+        await revoke_other_sessions(db, person.id, keep_session_id)
+
+    await db.commit()
+    return await get_user_by_account_id(db, account_id_value)

--- a/app/graphql/context.py
+++ b/app/graphql/context.py
@@ -31,6 +31,7 @@ class Context(BaseContext):
     response: Response | None
     user: object = None
     account_id: int = None
+    session_id: str = None
 
 
 async def _get_active_session(db: AsyncSession, session_id_value):
@@ -62,11 +63,11 @@ async def _mint_access_from_refresh(
     payload_refresh = verify_refresh_token(refresh_token)
     if payload_refresh is None:
         logger.warning("Invalid refresh token provided; skipping context auth")
-        return None, None
+        return None, None, None
 
     session_id_value = payload_refresh.get("session_id")
     if await _get_active_session(db, session_id_value) is None:
-        return None, None
+        return None, None, None
     session_id = str(session_id_value)
 
     person_id = payload_refresh.get("person_id")
@@ -113,7 +114,7 @@ async def _mint_access_from_refresh(
         )
         response.headers["x-access-token"] = new_access_token
 
-    return user, account_id
+    return user, account_id, session_id
 
 
 async def build_context(
@@ -126,6 +127,7 @@ async def build_context(
 
     user = None
     account_id = None
+    session_id_ctx = None
 
     # Priorizar cookies HTTP-Only, luego headers para compatibilidad
     access_token = request.cookies.get("access_token")
@@ -151,7 +153,7 @@ async def build_context(
             session_id = payload.get("session_id")
 
             if await _get_active_session(db, session_id) is None:
-                return Context(db=db, request=request, response=response, user=None, account_id=None)
+                return Context(db=db, request=request, response=response, user=None, account_id=None, session_id=None)
 
             # Execute queries sequentially to avoid AsyncPG concurrent operation errors
             if person_id:
@@ -160,13 +162,14 @@ async def build_context(
                 account = await get_account_by_username(db, username)
                 if account:
                     account_id = account.id
+            session_id_ctx = session_id
         else:
             # Access token invalid/expired -> attempt refresh
             if refresh_token:
-                user, account_id = await _mint_access_from_refresh(db, request, response, refresh_token)
+                user, account_id, session_id_ctx = await _mint_access_from_refresh(db, request, response, refresh_token)
     elif refresh_token:
         # No access token present but refresh_cookie exists -> proactively mint new access token
-        user, account_id = await _mint_access_from_refresh(db, request, response, refresh_token)
+        user, account_id, session_id_ctx = await _mint_access_from_refresh(db, request, response, refresh_token)
 
-    return Context(db=db, request=request, response=response, user=user, account_id=account_id)
+    return Context(db=db, request=request, response=response, user=user, account_id=account_id, session_id=session_id_ctx)
 

--- a/app/graphql/users/mutations.py
+++ b/app/graphql/users/mutations.py
@@ -1,25 +1,27 @@
 import strawberry
-from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
-from app.security.hashing import hash_password
+from app.security.hashing import hash_password, verify_password
 from app.crud.usersCrud import (
-    update_account_password,
     create_person,
     create_user_with_account,
     update_user as crud_update_user,
     set_account_active,
     reset_account_password,
+    update_own_account,
+    get_user_by_account_id,
     username_exists,
 )
 from app.crud.permissions import MANAGE_USERS
 from app.graphql.auth.permissions import IsAuthenticated, require_capability
 from app.graphql.users.types import (
-    ChangePasswordInput, ChangePasswordResponse,
     CreatePersonInput, CreatePersonResponse, Person,
     CreateUserInput, UpdateUserInput, UserMutationResponse, AppUser,
+    UpdateMyAccountInput,
 )
+
+MIN_PASSWORD_LENGTH = 8
 
 
 # Sentinel so partial updates don't wipe fields that were not provided.
@@ -28,24 +30,6 @@ _UNSET = object()
 
 @strawberry.type
 class UserMutation:
-    @strawberry.mutation
-    async def change_password(self, data: ChangePasswordInput, info: strawberry.Info) -> ChangePasswordResponse:
-        password = data.password
-        username = data.username
-
-        hashed_password = hash_password(password=password)
-
-        result = await update_account_password(
-            db=info.context.db,
-            username=username,
-            password_hash=hashed_password
-        )
-
-        if not result:
-            raise HTTPException(status_code=404, detail="Account not found")
-
-        return ChangePasswordResponse(message="Password updated successfully")
-
     @strawberry.mutation
     async def create_person(self, data: CreatePersonInput, info: strawberry.Info) -> CreatePersonResponse:
         """Create a new person in the system"""
@@ -210,4 +194,101 @@ class UserMutation:
             await db.rollback()
             return UserMutationResponse(
                 success=False, user=None, message=f"Error al restablecer la contraseña: {str(e)}"
+            )
+
+    # ------------------------------------------------------------------
+    # Self-service: the current user updates their OWN account.
+    # account_id/session_id come from the authenticated context — never the client.
+    # ------------------------------------------------------------------
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def update_my_account(self, info: Info, input: UpdateMyAccountInput) -> UserMutationResponse:
+        """Let the authenticated user edit their own name/email/phone/password."""
+        db: AsyncSession = info.context.db
+
+        account_id = getattr(info.context, "account_id", None)
+        if account_id is None:
+            return UserMutationResponse(success=False, user=None, message="Acceso no autorizado")
+
+        _UNSET = object()
+        full_name = _UNSET
+        email = _UNSET
+        phone_number = _UNSET
+        new_password_hash = _UNSET
+        revoke_others = False
+
+        # full_name: required-if-sent, trimmed, max 200.
+        if input.full_name is not None:
+            value = input.full_name.strip()
+            if not value:
+                return UserMutationResponse(success=False, user=None, message="El nombre no puede estar vacío")
+            if len(value) > 200:
+                return UserMutationResponse(success=False, user=None, message="El nombre es demasiado largo (máx. 200)")
+            full_name = value
+
+        # email: "" clears; non-empty must contain "@"; max 200.
+        if input.email is not None:
+            value = input.email.strip()
+            if value == "":
+                email = None
+            elif "@" not in value or len(value) > 200:
+                return UserMutationResponse(success=False, user=None, message="Correo inválido")
+            else:
+                email = value
+
+        # phone_number: "" clears; max 32.
+        if input.phone_number is not None:
+            value = input.phone_number.strip()
+            if value == "":
+                phone_number = None
+            elif len(value) > 32:
+                return UserMutationResponse(success=False, user=None, message="Teléfono demasiado largo (máx. 32)")
+            else:
+                phone_number = value
+
+        # password change: requires current password verification + min length.
+        if input.new_password is not None:
+            new_password = input.new_password
+            if not (input.current_password or ""):
+                return UserMutationResponse(success=False, user=None, message="Debes indicar tu contraseña actual")
+            if len(new_password) < MIN_PASSWORD_LENGTH:
+                return UserMutationResponse(
+                    success=False, user=None,
+                    message=f"La nueva contraseña debe tener al menos {MIN_PASSWORD_LENGTH} caracteres",
+                )
+
+            current_account = await get_user_by_account_id(db, account_id)
+            if current_account is None:
+                return UserMutationResponse(success=False, user=None, message="Cuenta no encontrada")
+            if not verify_password(input.current_password, current_account.password_hash):
+                return UserMutationResponse(success=False, user=None, message="La contraseña actual es incorrecta")
+
+            new_password_hash = hash_password(password=new_password)
+            revoke_others = True
+
+        if full_name is _UNSET and email is _UNSET and phone_number is _UNSET and new_password_hash is _UNSET:
+            return UserMutationResponse(success=False, user=None, message="No hay cambios para aplicar")
+
+        try:
+            account = await update_own_account(
+                db=db,
+                account_id=account_id,
+                full_name=full_name,
+                email=email,
+                phone_number=phone_number,
+                new_password_hash=new_password_hash,
+                revoke_other_sessions_now=revoke_others,
+                keep_session_id=getattr(info.context, "session_id", None),
+            )
+            if account is None:
+                return UserMutationResponse(success=False, user=None, message="Cuenta no encontrada")
+
+            return UserMutationResponse(
+                success=True,
+                user=AppUser.from_account(account),
+                message="Datos actualizados exitosamente",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return UserMutationResponse(
+                success=False, user=None, message=f"Error al actualizar la cuenta: {str(e)}"
             )

--- a/app/graphql/users/queries.py
+++ b/app/graphql/users/queries.py
@@ -4,7 +4,9 @@ import strawberry
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
-from app.crud.usersCrud import list_people, get_person_by_id, list_users, list_roles
+from app.crud.usersCrud import (
+    list_people, get_person_by_id, list_users, list_roles, get_user_by_account_id
+)
 from app.crud.permissions import MANAGE_USERS
 from app.db.postgresql import get_db
 from app.graphql.auth.permissions import IsAuthenticated, require_capability
@@ -41,6 +43,18 @@ class UserQuery:
 
         roles = await list_roles(db=db)
         return [RoleType.from_model(role) for role in roles]
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def my_account(self, info: Info) -> Optional[AppUser]:
+        """The authenticated user's own account (self-service)."""
+        db = info.context.db
+
+        account_id = getattr(info.context, "account_id", None)
+        if account_id is None:
+            return None
+
+        account = await get_user_by_account_id(db=db, account_id=account_id)
+        return AppUser.from_account(account) if account else None
 
     @strawberry.field(permission_classes=[IsAuthenticated])
     async def person(self, info: Info, person_id: int) -> Optional[Person]:

--- a/app/graphql/users/types.py
+++ b/app/graphql/users/types.py
@@ -120,17 +120,6 @@ class UpdatePersonInput:
     wa_id: Optional[str] = None
 
 
-@strawberry.input
-class ChangePasswordInput:
-    username: str
-    password: str
-
-
-@strawberry.type
-class ChangePasswordResponse:
-    message: str
-
-
 @strawberry.type
 class CreatePersonResponse:
     person: Person
@@ -164,3 +153,13 @@ class UserMutationResponse:
     success: bool
     user: Optional[AppUser]
     message: str
+
+
+# --- Self-service (current user updates their own account) ----------------
+@strawberry.input
+class UpdateMyAccountInput:
+    full_name: Optional[str] = None
+    email: Optional[str] = None
+    phone_number: Optional[str] = None
+    current_password: Optional[str] = None
+    new_password: Optional[str] = None

--- a/tests/test_auth_context_sessions.py
+++ b/tests/test_auth_context_sessions.py
@@ -60,6 +60,7 @@ async def test_build_context_accepts_active_access_token(monkeypatch):
 
     assert context.user is user
     assert context.account_id == 99
+    assert context.session_id == "session-1"
 
 
 @pytest.mark.asyncio
@@ -181,6 +182,7 @@ async def test_build_context_refreshes_active_refresh_token(monkeypatch):
 
     assert context.user is user
     assert context.account_id == 99
+    assert context.session_id == "session-1"
     assert touched == ["session-1"]
     assert response.headers["x-access-token"] == "new-access"
     assert response.cookies[0]["key"] == "access_token"

--- a/tests/test_users_account_update.py
+++ b/tests/test_users_account_update.py
@@ -1,0 +1,264 @@
+"""Backend tests for self-service account update (myAccount / updateMyAccount).
+
+Covers:
+  - update_own_account CRUD: field updates, clearing email/phone, password hash
+  - revoke_other_sessions CRUD: revokes the person's other sessions, keeps current
+  - myAccount query and updateMyAccount mutation via schema execution, including
+    password change (current-password verification + revoking other sessions)
+
+Each test runs inside a SAVEPOINT-wrapped session (see conftest.py) so nothing
+persists to defaultdb. Roles use unique non-customer codes.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+
+from app.crud.usersCrud import (
+    create_user_with_account,
+    update_own_account,
+    get_user_by_account_id,
+)
+from app.crud.sessionCrud import revoke_other_sessions
+from app.graphql.context import Context
+from app.graphql.schema import schema
+from app.security.hashing import hash_password, verify_password
+from app.models import Role, Session
+
+
+async def _make_role(db) -> Role:
+    role = Role(code=f"team_{uuid.uuid4().hex[:8]}", description="Equipo")
+    db.add(role)
+    await db.flush()
+    return role
+
+
+def _uname() -> str:
+    return f"selfsvc_{uuid.uuid4().hex[:10]}"
+
+
+def _make_session(db, *, user_id: int, session: str, revoked: bool = False) -> Session:
+    s = Session(
+        refresh_token="rt",
+        session=session,
+        user_id=user_id,
+        revoked_at=datetime.now(timezone.utc) if revoked else None,
+    )
+    db.add(s)
+    return s
+
+
+def _ctx(db, *, user, account_id, session_id=None) -> Context:
+    return Context(
+        db=db,
+        request=SimpleNamespace(),
+        response=None,
+        user=user,
+        account_id=account_id,
+        session_id=session_id,
+    )
+
+
+_UPDATE_MUTATION = """
+mutation Upd($i: UpdateMyAccountInput!) {
+  updateMyAccount(input: $i) {
+    success
+    message
+    user { accountId fullName email phoneNumber }
+  }
+}
+"""
+
+
+# --------------------------------------------------------------------------- #
+# CRUD: update_own_account                                                     #
+# --------------------------------------------------------------------------- #
+
+async def test_update_own_account_updates_and_clears_fields(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="Keep Me", username=_uname(), password_hash="h",
+        email="x@y.com", phone_number="555", role_ids=[role.id],
+    )
+
+    # Clear email + phone (explicit None) while leaving full_name untouched (_UNSET).
+    updated = await update_own_account(db, acct.id, email=None, phone_number=None)
+    assert updated.person.email is None
+    assert updated.person.phone_number is None
+    assert updated.person.full_name == "Keep Me"
+
+    # Update full_name only.
+    updated = await update_own_account(db, acct.id, full_name="New Name")
+    assert updated.person.full_name == "New Name"
+
+
+async def test_update_own_account_sets_password_hash(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="P", username=_uname(), password_hash="old", role_ids=[role.id],
+    )
+    updated = await update_own_account(db, acct.id, new_password_hash="newhash")
+    assert updated.password_hash == "newhash"
+
+
+# --------------------------------------------------------------------------- #
+# CRUD: revoke_other_sessions                                                  #
+# --------------------------------------------------------------------------- #
+
+async def test_revoke_other_sessions(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="S", username=_uname(), password_hash="h", role_ids=[role.id],
+    )
+    pid = acct.person_id
+    other_pid = pid + 10_000_000  # a different person
+
+    _make_session(db, user_id=pid, session="s-current")
+    _make_session(db, user_id=pid, session="s-other1")
+    _make_session(db, user_id=pid, session="s-other2")
+    _make_session(db, user_id=pid, session="s-already", revoked=True)
+    _make_session(db, user_id=other_pid, session="s-other-user")
+    await db.flush()
+
+    count = await revoke_other_sessions(db, pid, "s-current")
+    assert count == 2  # only the two active, non-current sessions
+
+    rows = {
+        r.session: r
+        for r in (
+            await db.execute(select(Session).where(Session.user_id == pid))
+        ).scalars().all()
+    }
+    assert rows["s-current"].revoked_at is None
+    assert rows["s-other1"].revoked_at is not None
+    assert rows["s-other2"].revoked_at is not None
+    assert rows["s-already"].revoked_at is not None  # stays revoked
+
+    other = (
+        await db.execute(select(Session).where(Session.session == "s-other-user"))
+    ).scalar_one()
+    assert other.revoked_at is None  # different person untouched
+
+
+# --------------------------------------------------------------------------- #
+# GraphQL: myAccount                                                           #
+# --------------------------------------------------------------------------- #
+
+async def test_my_account_returns_current(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="Me", username=_uname(), password_hash=hash_password("pw"),
+        email="me@x.com", role_ids=[role.id],
+    )
+    ctx = _ctx(db, user=acct.person, account_id=acct.id)
+    result = await schema.execute(
+        "query { myAccount { accountId username fullName email } }", context_value=ctx
+    )
+    assert result.errors is None
+    data = result.data["myAccount"]
+    assert data["accountId"] == acct.id
+    assert data["username"] == acct.username
+    assert data["fullName"] == "Me"
+
+
+async def test_my_account_none_without_account_id(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="Me", username=_uname(), password_hash=hash_password("pw"),
+        role_ids=[role.id],
+    )
+    ctx = _ctx(db, user=acct.person, account_id=None)
+    result = await schema.execute("query { myAccount { accountId } }", context_value=ctx)
+    assert result.errors is None
+    assert result.data["myAccount"] is None
+
+
+# --------------------------------------------------------------------------- #
+# GraphQL: updateMyAccount                                                     #
+# --------------------------------------------------------------------------- #
+
+async def test_update_my_account_updates_fields(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="Old", username=_uname(), password_hash=hash_password("pw"),
+        role_ids=[role.id],
+    )
+    ctx = _ctx(db, user=acct.person, account_id=acct.id, session_id="s1")
+    result = await schema.execute(
+        _UPDATE_MUTATION,
+        variable_values={"i": {"fullName": "New", "email": "new@x.com", "phoneNumber": "123"}},
+        context_value=ctx,
+    )
+    assert result.errors is None
+    payload = result.data["updateMyAccount"]
+    assert payload["success"] is True
+    assert payload["user"]["fullName"] == "New"
+    assert payload["user"]["email"] == "new@x.com"
+    assert payload["user"]["phoneNumber"] == "123"
+
+
+async def test_update_my_account_no_changes_fails(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="X", username=_uname(), password_hash=hash_password("pw"),
+        role_ids=[role.id],
+    )
+    ctx = _ctx(db, user=acct.person, account_id=acct.id, session_id="s1")
+    result = await schema.execute(
+        _UPDATE_MUTATION, variable_values={"i": {}}, context_value=ctx
+    )
+    assert result.errors is None
+    assert result.data["updateMyAccount"]["success"] is False
+
+
+async def test_update_my_account_wrong_current_password_fails(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="X", username=_uname(),
+        password_hash=hash_password("correct-horse"), role_ids=[role.id],
+    )
+    ctx = _ctx(db, user=acct.person, account_id=acct.id, session_id="s1")
+    result = await schema.execute(
+        _UPDATE_MUTATION,
+        variable_values={"i": {"currentPassword": "wrong", "newPassword": "newpass1234"}},
+        context_value=ctx,
+    )
+    assert result.errors is None
+    assert result.data["updateMyAccount"]["success"] is False
+
+
+async def test_update_my_account_password_change_revokes_other_sessions(db):
+    role = await _make_role(db)
+    acct = await create_user_with_account(
+        db=db, full_name="X", username=_uname(),
+        password_hash=hash_password("orig-pass-1"), role_ids=[role.id],
+    )
+    pid = acct.person_id
+    _make_session(db, user_id=pid, session="s-current")
+    _make_session(db, user_id=pid, session="s-other")
+    await db.flush()
+
+    ctx = _ctx(db, user=acct.person, account_id=acct.id, session_id="s-current")
+    result = await schema.execute(
+        _UPDATE_MUTATION,
+        variable_values={"i": {"currentPassword": "orig-pass-1", "newPassword": "brand-new-pass"}},
+        context_value=ctx,
+    )
+    assert result.errors is None
+    assert result.data["updateMyAccount"]["success"] is True
+
+    fresh = await get_user_by_account_id(db, acct.id)
+    assert verify_password("brand-new-pass", fresh.password_hash)
+
+    rows = {
+        r.session: r
+        for r in (
+            await db.execute(select(Session).where(Session.user_id == pid))
+        ).scalars().all()
+    }
+    assert rows["s-current"].revoked_at is None
+    assert rows["s-other"].revoked_at is not None


### PR DESCRIPTION
## Contexto
API autenticada para que el **usuario actual** edite sus **propios** datos (nombre, correo, teléfono, contraseña) sin pasar por el CRUD admin de *Usuarios*. Backend-only (sin UI en esta iteración). `account_id`/`session_id` se toman del contexto autenticado, **nunca** del cliente.

Implementa el plan revisado `PLAN_USER_DATA.md` con las correcciones de seguridad detectadas en la revisión.

## Cambios
- **Query `myAccount: AppUser`** — la cuenta del usuario autenticado.
- **Mutation `updateMyAccount(UpdateMyAccountInput)`** — nombre/correo/teléfono + contraseña:
  - cambio de contraseña exige verificar la **contraseña actual** (`verify_password`) y mínimo 8 caracteres; `""` limpia correo/teléfono; rechaza requests sin cambios.
  - al cambiar contraseña, **revoca las demás sesiones** del usuario (conserva la actual).
  - sigue el patrón payload (`success`/`message`), sin lanzar excepciones; `rollback` en error.
- **`usersCrud.update_own_account`** — actualización atómica de `People`/`Account` (+ contraseña opcional + revocación opcional) en un solo `commit`.
- **`sessionCrud.revoke_other_sessions(user_id=person_id, keep_session_id)`** — revoca en bloque las sesiones activas salvo la actual (sin commit; el caller hace commit).
- **Contexto**: se añade `session_id` y se threadea por **ambos** caminos (access-token y refresh — `_mint_access_from_refresh` ahora lo devuelve), evitando el bug de revocar la sesión actual tras un refresh.
- **Eliminada la mutation legacy insegura `changePassword`** (+ tipos `ChangePasswordInput`/`Response` y la CRUD huérfana `update_account_password`): estaba **sin autenticación** y sin referencias en todo el repo.

## Correcciones de la revisión aplicadas
1. Sesiones llaveadas por `person_id` (`Session.user_id`), identificador por columna `Session.session`.
2. `session_id` threadeado en access-token **y** refresh (evita revocar la sesión actual tras refresh).
3. Nuevo helper de revocación masiva (`revoke_other_sessions`); antes solo existía revocar una sola sesión.
4. Guarda reforzada: además de `IsAuthenticated`, se exige `account_id` presente.

## Validación
- `py_compile` + el esquema Strawberry construye con `myAccount`/`updateMyAccount`/`UpdateMyAccountInput` y **sin** `changePassword` ✅
- `pytest tests/test_auth_context_sessions.py` ✅ (4 passed) — incluye el threading de `session_id` en ambos caminos.
- ⚠️ Tests con BD (`tests/test_users_account_update.py`) no ejecutados aquí; correr `pytest tests/test_users_account_update.py` en dev.

## Fuera de alcance (anotado)
- `create_person` también está sin gating de auth (como estaba `changePassword`); se deja para un PR aparte.
- Sin pantalla frontend en esta iteración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)