### PR TITLE
[codex] add paginated members query

### DIFF
--- a/app/crud/membersCrud.py
+++ b/app/crud/membersCrud.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime, timezone, date
-from typing import Optional, List, Tuple
+from typing import Optional, List
 import time
 
 import logging
@@ -55,29 +55,6 @@ class MemberData:
     active_standing_booking: Optional[StandingBookingInfo]
     total_payments: float
     last_activity: Optional[datetime]
-
-
-def _member_sort_key(member: 'MemberData') -> Tuple[int, float, str]:
-    """Sort key placing active memberships first, then by end date descending."""
-    membership = member.active_membership
-    status = (membership.status or '').lower() if membership and membership.status else ''
-
-    if 'active' in status or 'activo' in status:
-        priority = 0
-    elif membership:
-        priority = 1
-    else:
-        priority = 2
-
-    end_timestamp = 0.0
-    if membership and membership.end_date:
-        try:
-            end_timestamp = membership.end_date.timestamp()
-        except Exception:  # noqa: BLE001
-            end_timestamp = 0.0
-
-    full_name = (member.full_name or '').lower()
-    return (priority, -end_timestamp, full_name)
 
 
 def _build_member_data(person: People) -> MemberData:
@@ -204,14 +181,8 @@ def _build_member_data(person: People) -> MemberData:
     )
 
 
-async def get_members_list(
-    db: AsyncSession,
-    limit: Optional[int] = None,
-    offset: int = 0,
-    search: Optional[str] = None
-) -> List[MemberData]:
-    """Get comprehensive list of members with optional filters."""
-
+def _membership_sort_expressions():
+    """SQL ordering helpers shared by member list queries."""
     current_time = datetime.now(timezone.utc)
 
     active_membership_rank = (
@@ -240,31 +211,20 @@ async def get_members_list(
         .scalar_subquery()
     )
 
-    # Base query for people with member role
+    return active_membership_rank, latest_membership_end
+
+
+def _apply_member_filters(query, search: Optional[str] = None):
     query = (
-        select(People)
+        query
         .join(PersonRole)
         .join(Role)
-        .options(
-            selectinload(People.roles).selectinload(PersonRole.role),
-            selectinload(People.subscriptions).selectinload(MembershipSubscription.plan),
-            selectinload(People.payments),
-            selectinload(People.reservations).selectinload(Reservation.session),
-            selectinload(People.standing_bookings).selectinload(StandingBooking.template).selectinload(ClassTemplate.class_type),
-            selectinload(People.standing_bookings).selectinload(StandingBooking.template).selectinload(ClassTemplate.venue),
-            selectinload(People.standing_bookings).selectinload(StandingBooking.template).selectinload(ClassTemplate.instructor)
-        )
         .where(Role.code == 'member')
         .where(People.deleted_at.is_(None))
         .where(
             select(MembershipSubscription.id)
             .where(MembershipSubscription.person_id == People.id)
             .exists()
-        )
-        .order_by(
-            func.coalesce(active_membership_rank, 0).desc(),
-            latest_membership_end.desc(),
-            People.full_name
         )
     )
 
@@ -278,6 +238,40 @@ async def get_members_list(
             )
         )
 
+    return query
+
+
+async def get_members_list(
+    db: AsyncSession,
+    limit: Optional[int] = None,
+    offset: int = 0,
+    search: Optional[str] = None
+) -> List[MemberData]:
+    """Get comprehensive list of members with optional filters."""
+    active_membership_rank, latest_membership_end = _membership_sort_expressions()
+
+    # Base query for people with member role
+    query = _apply_member_filters(
+        select(People)
+        .options(
+            selectinload(People.roles).selectinload(PersonRole.role),
+            selectinload(People.subscriptions).selectinload(MembershipSubscription.plan),
+            selectinload(People.payments),
+            selectinload(People.reservations).selectinload(Reservation.session),
+            selectinload(People.standing_bookings).selectinload(StandingBooking.template).selectinload(ClassTemplate.class_type),
+            selectinload(People.standing_bookings).selectinload(StandingBooking.template).selectinload(ClassTemplate.venue),
+            selectinload(People.standing_bookings).selectinload(StandingBooking.template).selectinload(ClassTemplate.instructor)
+        ),
+        search=search,
+    )
+
+    query = query.order_by(
+        func.coalesce(active_membership_rank, 0).desc(),
+        latest_membership_end.desc().nullslast(),
+        People.full_name.asc().nullslast(),
+        People.id.asc(),
+    )
+
     if offset:
         query = query.offset(offset)
 
@@ -287,10 +281,17 @@ async def get_members_list(
     result = await db.execute(query)
     people = result.scalars().all()
 
-    members_data = [_build_member_data(person) for person in people]
+    return [_build_member_data(person) for person in people]
 
-    members_data.sort(key=_member_sort_key)
-    return members_data
+
+async def count_members(
+    db: AsyncSession,
+    search: Optional[str] = None,
+) -> int:
+    """Count members matching the same filters as get_members_list."""
+    query = _apply_member_filters(select(func.count(func.distinct(People.id))), search=search)
+    result = await db.execute(query)
+    return int(result.scalar_one() or 0)
 
 
 async def get_member_by_id(db: AsyncSession, member_id: int) -> Optional[MemberData]:

--- a/app/graphql/members/queries.py
+++ b/app/graphql/members/queries.py
@@ -4,14 +4,40 @@ import strawberry
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
-from app.crud.membersCrud import get_members_list, get_member_by_id
-from app.graphql.members.types import Member
+from app.crud.membersCrud import count_members, get_members_list, get_member_by_id
+from app.graphql.members.types import Member, PaginatedMembers
 from app.graphql.auth.permissions import IsAuthenticated
 from app.core.conversions import coerce_int
 
 
 @strawberry.type
 class MembersQuery:
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def members_page(
+        self,
+        info: Info,
+        limit: int = 100,
+        offset: int = 0,
+        search: Optional[str] = None
+    ) -> PaginatedMembers:
+        """Get a paginated list of members with an exact total."""
+        db: AsyncSession = info.context.db
+        safe_limit = max(1, min(int(limit or 100), 500))
+        safe_offset = max(0, int(offset or 0))
+
+        members_data = await get_members_list(
+            db=db,
+            limit=safe_limit,
+            offset=safe_offset,
+            search=search
+        )
+        total = await count_members(db=db, search=search)
+
+        return PaginatedMembers(
+            items=[Member.from_data(member_data) for member_data in members_data],
+            total=total,
+        )
+
     @strawberry.field(permission_classes=[IsAuthenticated])
     async def members(
         self,

--- a/app/graphql/members/types.py
+++ b/app/graphql/members/types.py
@@ -127,6 +127,12 @@ class Member:
         )
 
 
+@strawberry.type
+class PaginatedMembers:
+    items: List[Member]
+    total: int
+
+
 @strawberry.input
 class CreateMemberInput:
     full_name: str

--- a/tests/test_members_pagination.py
+++ b/tests/test_members_pagination.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+import uuid
+
+from sqlalchemy import select
+
+from app.graphql.schema import schema
+from app.models import MembershipPlan, MembershipSubscription, People, PersonRole, Role
+
+
+async def _member_role(db) -> Role:
+    role = (await db.execute(select(Role).where(Role.code == "member"))).scalar_one_or_none()
+    if role is not None:
+        return role
+
+    role = Role(code="member", description="Socio")
+    db.add(role)
+    await db.flush()
+    return role
+
+
+async def _plan(db, token: str) -> MembershipPlan:
+    plan = MembershipPlan(
+        name=f"{token} Plan",
+        description="Pagination test plan",
+        price=Decimal("100.00"),
+        duration_value=1,
+        duration_unit="month",
+        class_limit=None,
+        plan_type="flexible",
+        fixed_time_slot=False,
+        is_active=True,
+    )
+    db.add(plan)
+    await db.flush()
+    return plan
+
+
+async def _make_member(
+    db,
+    *,
+    role: Role,
+    plan: MembershipPlan,
+    token: str,
+    index: int,
+    name: str | None = None,
+    end_days: int = 30,
+    now: datetime | None = None,
+    end_at: datetime | None = None,
+) -> People:
+    now = now or datetime.now(timezone.utc)
+    subscription_end = end_at or now + timedelta(days=end_days)
+    person = People(
+        full_name=name or f"{token} Member {index:03d}",
+        email=f"{token.lower()}-{index}@example.com",
+        phone_number=f"555000{index:04d}",
+    )
+    db.add(person)
+    await db.flush()
+
+    db.add(PersonRole(person_id=person.id, role_id=role.id, created_at=now))
+    db.add(
+        MembershipSubscription(
+            person_id=person.id,
+            plan_id=plan.id,
+            start_at=now - timedelta(days=1),
+            end_at=subscription_end,
+            status="active",
+        )
+    )
+    await db.flush()
+    return person
+
+
+async def _members_page(db, *, limit: int, offset: int, search: str):
+    result = await schema.execute(
+        """
+        query MembersPage($limit: Int!, $offset: Int!, $search: String) {
+            membersPage(limit: $limit, offset: $offset, search: $search) {
+                total
+                items {
+                    id
+                    fullName
+                    activeMembership {
+                        status
+                        remainingDays
+                    }
+                }
+            }
+        }
+        """,
+        variable_values={"limit": limit, "offset": offset, "search": search},
+        context_value=SimpleNamespace(db=db, user=object()),
+    )
+    assert result.errors is None
+    return result.data["membersPage"]
+
+
+async def test_members_page_returns_items_total_limit_offset_and_search(db):
+    token = f"PageSearch{uuid.uuid4().hex[:8]}"
+    role = await _member_role(db)
+    plan = await _plan(db, token)
+
+    await _make_member(db, role=role, plan=plan, token=token, index=1, end_days=30)
+    middle = await _make_member(db, role=role, plan=plan, token=token, index=2, end_days=20)
+    await _make_member(db, role=role, plan=plan, token=token, index=3, end_days=10)
+
+    page = await _members_page(db, limit=1, offset=1, search=token)
+
+    assert page["total"] == 3
+    assert len(page["items"]) == 1
+    assert page["items"][0]["id"] == middle.id
+    assert page["items"][0]["fullName"] == middle.full_name
+
+
+async def test_members_page_order_is_stable_after_first_100_rows(db):
+    token = f"PageTie{uuid.uuid4().hex[:8]}"
+    role = await _member_role(db)
+    plan = await _plan(db, token)
+    fixed_now = datetime.now(timezone.utc)
+    fixed_end = fixed_now + timedelta(days=30)
+
+    created = [
+        await _make_member(
+            db,
+            role=role,
+            plan=plan,
+            token=token,
+            index=index,
+            name=f"{token} Same Name",
+            now=fixed_now,
+            end_at=fixed_end,
+        )
+        for index in range(105)
+    ]
+
+    first_page = await _members_page(db, limit=100, offset=0, search=token)
+    second_page = await _members_page(db, limit=100, offset=100, search=token)
+
+    expected_ids = [person.id for person in sorted(created, key=lambda person: person.id)]
+    actual_ids = [item["id"] for item in first_page["items"] + second_page["items"]]
+
+    assert first_page["total"] == 105
+    assert second_page["total"] == 105
+    assert len(first_page["items"]) == 100
+    assert len(second_page["items"]) == 5
+    assert actual_ids == expected_ids


### PR DESCRIPTION
## Summary
- Add `membersPage` GraphQL query returning `items` plus exact `total`.
- Share member filters between list and count queries.
- Move stable ordering into SQL so offset pagination is deterministic.
- Add backend pagination tests for total, search, offset, and stable ordering beyond 100 rows.

## Validation
- `git diff --check`
- `python -m compileall app\crud\membersCrud.py app\graphql\members tests\test_members_pagination.py`

## Note
- Local pytest for the backend resolver could not run because PostgreSQL rejected the connection in this environment (`ConnectionRefusedError [WinError 1225]`).