### PR TITLE
feat(stepup): gym-side step-up (2FA) client for the shared verification service

### DIFF
--- a/app/core/verification_config.py
+++ b/app/core/verification_config.py
@@ -1,0 +1,37 @@
+"""Configuration for the shared FitPilot verification microservice.
+
+The gym backend is a *client* of the standalone `fitpilot-verification` service
+(Twilio Verify + Resend + proof issuance). Step-up verification is gated behind
+``STEP_UP_ENABLED`` so this can ship before the service is live without changing
+existing behavior.
+"""
+import os
+
+from app.core.env import load_environment
+
+load_environment()
+
+
+def _as_bool(value: str | None, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+class VerificationConfig:
+    # Master switch. When False, step-up checks are a no-op (no behavior change).
+    ENABLED: bool = _as_bool(os.getenv("STEP_UP_ENABLED"), default=False)
+    SERVICE_URL: str = (os.getenv("VERIFICATION_SERVICE_URL", "") or "").strip().rstrip("/")
+    SERVICE_TOKEN: str = (os.getenv("VERIFICATION_SERVICE_TOKEN", "") or "").strip()
+    # Identifies this consumer to the service; proofs are bound to this audience.
+    AUDIENCE: str = (os.getenv("VERIFICATION_AUDIENCE", "gym") or "gym").strip()
+    TIMEOUT_SECONDS: float = float(os.getenv("VERIFICATION_TIMEOUT_SECONDS", "10"))
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        return bool(cls.SERVICE_URL and cls.SERVICE_TOKEN)
+
+
+def step_up_enabled() -> bool:
+    """Whether step-up verification is active (enabled and configured)."""
+    return VerificationConfig.ENABLED and VerificationConfig.is_configured()

--- a/app/graphql/auth/permissions.py
+++ b/app/graphql/auth/permissions.py
@@ -47,3 +47,45 @@ async def require_capability(info: Info, capability: str) -> Optional[str]:
     if not await person_can(db, user, capability):
         return "No tienes permiso para realizar esta accion"
     return None
+
+
+async def require_step_up_proof(info: Info, proof: Optional[str]) -> Optional[str]:
+    """Validate+consume a step-up (2-step) proof for a sensitive action.
+
+    No-op when step-up is disabled (so callers behave as before until the shared
+    verification service is live). When enabled, the proof is validated and
+    single-use-consumed via the verification service, and bound to one of the
+    authenticated account's own contacts (phone/email).
+    """
+    from app.core.verification_config import step_up_enabled, VerificationConfig
+
+    if not step_up_enabled():
+        return None
+
+    user = getattr(info.context, "user", None)
+    account_id = getattr(info.context, "account_id", None)
+    if user is None or not account_id:
+        return "Acceso no autorizado"
+    if not proof:
+        return "Se requiere verificación de 2 pasos"
+
+    from app.services import verification_client as vc
+    from app.crud.usersCrud import get_user_by_account_id
+
+    result = await vc.consume_proof(proof, vc.PURPOSE_STEP_UP, VerificationConfig.AUDIENCE)
+    if not result.get("valid"):
+        return "Verificación de 2 pasos inválida o expirada"
+
+    destination = result.get("destination")
+    if destination:
+        account = await get_user_by_account_id(info.context.db, account_id)
+        person = account.person if account else None
+        contacts = {
+            c for c in (
+                getattr(person, "phone_number", None),
+                getattr(person, "email", None),
+            ) if c
+        }
+        if destination not in contacts:
+            return "La verificación no corresponde a tu cuenta"
+    return None

--- a/app/graphql/members/mutations.py
+++ b/app/graphql/members/mutations.py
@@ -11,7 +11,8 @@ from strawberry.types import Info
 
 from app.crud.membersCrud import create_member, update_member, delete_member_and_related
 from app.graphql.members.types import Member, MemberResponse, DeleteMemberResponse
-from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.auth.permissions import IsAuthenticated, require_step_up_proof
+from app.core.verification_config import step_up_enabled
 from app.crud.authCrud import get_account_by_id
 from app.security.hashing import verify_password
 from app.services.image_service import ImageService
@@ -196,49 +197,52 @@ class MemberMutation:
             )
 
     @strawberry.mutation(name="deleteMember", permission_classes=[IsAuthenticated])
-    async def delete_member(self, info: Info, member_id: int, admin_password: str) -> DeleteMemberResponse:
-        """Delete a member after validating administrator password."""
+    async def delete_member(
+        self,
+        info: Info,
+        member_id: int,
+        admin_password: Optional[str] = None,
+        step_up_proof: Optional[str] = None,
+    ) -> DeleteMemberResponse:
+        """Delete a member. Requires admin role + a second factor.
+
+        When step-up verification is enabled, a single-use ``step_up_proof`` is
+        required; otherwise the admin re-enters their password (legacy path).
+        """
         db: AsyncSession = info.context.db
 
         member_id = coerce_int(member_id)
         if member_id is None:
-            return DeleteMemberResponse(
-                success=False,
-                message="ID de socio invalido"
-            )
-
-        if not admin_password:
-            return DeleteMemberResponse(
-                success=False,
-                message="La contrasena de administrador es obligatoria"
-            )
+            return DeleteMemberResponse(success=False, message="ID de socio invalido")
 
         account_id = getattr(info.context, "account_id", None)
         if not account_id:
-            return DeleteMemberResponse(
-                success=False,
-                message="Acceso no autorizado"
-            )
+            return DeleteMemberResponse(success=False, message="Acceso no autorizado")
 
         account = await get_account_by_id(db=db, account_id=account_id)
         if not account or not account.person:
             return DeleteMemberResponse(
-                success=False,
-                message="Cuenta de administrador no encontrada"
+                success=False, message="Cuenta de administrador no encontrada"
             )
 
         roles = {role.role.code for role in account.person.roles if role.role}
         if "admin" not in roles:
-            return DeleteMemberResponse(
-                success=False,
-                message="Se requiere rol de administrador"
-            )
+            return DeleteMemberResponse(success=False, message="Se requiere rol de administrador")
 
-        if not verify_password(admin_password, account.password_hash):
-            return DeleteMemberResponse(
-                success=False,
-                message="Contrasena de administrador incorrecta"
-            )
+        # Second factor: step-up proof when enabled, else legacy admin password.
+        if step_up_enabled():
+            error = await require_step_up_proof(info, step_up_proof)
+            if error:
+                return DeleteMemberResponse(success=False, message=error)
+        else:
+            if not admin_password:
+                return DeleteMemberResponse(
+                    success=False, message="La contrasena de administrador es obligatoria"
+                )
+            if not verify_password(admin_password, account.password_hash):
+                return DeleteMemberResponse(
+                    success=False, message="Contrasena de administrador incorrecta"
+                )
 
         success, message = await delete_member_and_related(db=db, member_id=member_id)
         return DeleteMemberResponse(success=success, message=message)

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -38,6 +38,7 @@ from app.graphql.permissions.queries import PermissionsQuery
 from app.graphql.permissions.mutations import PermissionsMutation
 from app.graphql.owner_agent.queries import OwnerAgentQuery
 from app.graphql.owner_agent.mutations import OwnerAgentMutation
+from app.graphql.verification.mutations import StepUpMutation
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +67,7 @@ class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQu
         return "Hello from GraphQL!"
 
 @strawberry.type
-class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation, OwnerAgentMutation):
+class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation, OwnerAgentMutation, StepUpMutation):
     pass
 
 

--- a/app/graphql/users/mutations.py
+++ b/app/graphql/users/mutations.py
@@ -1,4 +1,5 @@
 import strawberry
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
@@ -14,7 +15,7 @@ from app.crud.usersCrud import (
     username_exists,
 )
 from app.crud.permissions import MANAGE_USERS
-from app.graphql.auth.permissions import IsAuthenticated, require_capability
+from app.graphql.auth.permissions import IsAuthenticated, require_capability, require_step_up_proof
 from app.graphql.users.types import (
     CreatePersonInput, CreatePersonResponse, Person,
     CreateUserInput, UpdateUserInput, UserMutationResponse, AppUser,
@@ -49,13 +50,17 @@ class UserMutation:
     # User (login account) management — requires the manage_users capability.
     # ------------------------------------------------------------------
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    async def create_user(self, info: Info, input: CreateUserInput) -> UserMutationResponse:
+    async def create_user(self, info: Info, input: CreateUserInput, step_up_proof: Optional[str] = None) -> UserMutationResponse:
         """Create a login account (person + credentials + roles)."""
         db: AsyncSession = info.context.db
 
         error = await require_capability(info, MANAGE_USERS)
         if error:
             return UserMutationResponse(success=False, user=None, message=error)
+
+        step_error = await require_step_up_proof(info, step_up_proof)
+        if step_error:
+            return UserMutationResponse(success=False, user=None, message=step_error)
 
         full_name = (input.full_name or "").strip()
         username = (input.username or "").strip()
@@ -98,13 +103,17 @@ class UserMutation:
             )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    async def update_user(self, info: Info, input: UpdateUserInput) -> UserMutationResponse:
+    async def update_user(self, info: Info, input: UpdateUserInput, step_up_proof: Optional[str] = None) -> UserMutationResponse:
         """Update a user's identity, username, active state and/or roles."""
         db: AsyncSession = info.context.db
 
         error = await require_capability(info, MANAGE_USERS)
         if error:
             return UserMutationResponse(success=False, user=None, message=error)
+
+        step_error = await require_step_up_proof(info, step_up_proof)
+        if step_error:
+            return UserMutationResponse(success=False, user=None, message=step_error)
 
         def _opt(value):
             return value if value is not None else _UNSET
@@ -143,13 +152,17 @@ class UserMutation:
             )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    async def set_user_active(self, info: Info, account_id: int, is_active: bool) -> UserMutationResponse:
+    async def set_user_active(self, info: Info, account_id: int, is_active: bool, step_up_proof: Optional[str] = None) -> UserMutationResponse:
         """Activate or deactivate (soft-delete) a login account."""
         db: AsyncSession = info.context.db
 
         error = await require_capability(info, MANAGE_USERS)
         if error:
             return UserMutationResponse(success=False, user=None, message=error)
+
+        step_error = await require_step_up_proof(info, step_up_proof)
+        if step_error:
+            return UserMutationResponse(success=False, user=None, message=step_error)
 
         try:
             account = await set_account_active(db=db, account_id=account_id, is_active=is_active)
@@ -169,13 +182,17 @@ class UserMutation:
             )
 
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    async def reset_user_password(self, info: Info, account_id: int, password: str) -> UserMutationResponse:
+    async def reset_user_password(self, info: Info, account_id: int, password: str, step_up_proof: Optional[str] = None) -> UserMutationResponse:
         """Set a new password for a user account."""
         db: AsyncSession = info.context.db
 
         error = await require_capability(info, MANAGE_USERS)
         if error:
             return UserMutationResponse(success=False, user=None, message=error)
+
+        step_error = await require_step_up_proof(info, step_up_proof)
+        if step_error:
+            return UserMutationResponse(success=False, user=None, message=step_error)
 
         if not (password or "").strip():
             return UserMutationResponse(success=False, user=None, message="La contraseña es obligatoria")
@@ -201,13 +218,17 @@ class UserMutation:
     # account_id/session_id come from the authenticated context — never the client.
     # ------------------------------------------------------------------
     @strawberry.mutation(permission_classes=[IsAuthenticated])
-    async def update_my_account(self, info: Info, input: UpdateMyAccountInput) -> UserMutationResponse:
+    async def update_my_account(self, info: Info, input: UpdateMyAccountInput, step_up_proof: Optional[str] = None) -> UserMutationResponse:
         """Let the authenticated user edit their own name/email/phone/password."""
         db: AsyncSession = info.context.db
 
         account_id = getattr(info.context, "account_id", None)
         if account_id is None:
             return UserMutationResponse(success=False, user=None, message="Acceso no autorizado")
+
+        step_error = await require_step_up_proof(info, step_up_proof)
+        if step_error:
+            return UserMutationResponse(success=False, user=None, message=step_error)
 
         _UNSET = object()
         full_name = _UNSET

--- a/app/graphql/verification/mutations.py
+++ b/app/graphql/verification/mutations.py
@@ -1,0 +1,111 @@
+import strawberry
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.core.verification_config import VerificationConfig, step_up_enabled
+from app.crud.usersCrud import get_user_by_account_id
+from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.verification.types import StepUpRequestResponse, StepUpVerifyResponse
+from app.services import verification_client as vc
+
+CHANNEL_SMS = "sms"
+CHANNEL_EMAIL = "email"
+
+
+def _mask(destination: str, channel: str) -> str:
+    """Mask a phone/email for display (no full PII back to the client)."""
+    if not destination:
+        return ""
+    if channel == CHANNEL_EMAIL and "@" in destination:
+        name, _, domain = destination.partition("@")
+        head = name[:2]
+        return f"{head}{'*' * max(1, len(name) - 2)}@{domain}"
+    # phone: keep last 4
+    tail = destination[-4:]
+    return f"{'*' * max(1, len(destination) - 4)}{tail}"
+
+
+@strawberry.type
+class StepUpMutation:
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def request_step_up_verification(self, info: Info, channel: str) -> StepUpRequestResponse:
+        """Send a step-up code to the authenticated user's own phone/email."""
+        if not step_up_enabled():
+            return StepUpRequestResponse(
+                success=False, verification_id=None, channel=None,
+                masked_destination=None, next_cooldown_seconds=None,
+                message="La verificación de 2 pasos no está disponible",
+            )
+
+        db: AsyncSession = info.context.db
+        account_id = getattr(info.context, "account_id", None)
+        if not account_id:
+            return StepUpRequestResponse(
+                success=False, verification_id=None, channel=None,
+                masked_destination=None, next_cooldown_seconds=None,
+                message="Acceso no autorizado",
+            )
+
+        channel = (channel or "").strip().lower()
+        if channel not in (CHANNEL_SMS, CHANNEL_EMAIL):
+            return StepUpRequestResponse(
+                success=False, verification_id=None, channel=None,
+                masked_destination=None, next_cooldown_seconds=None,
+                message="Canal inválido (usa 'sms' o 'email')",
+            )
+
+        account = await get_user_by_account_id(db, account_id)
+        person = account.person if account else None
+        destination = None
+        if person is not None:
+            destination = person.phone_number if channel == CHANNEL_SMS else person.email
+        if not destination:
+            label = "teléfono" if channel == CHANNEL_SMS else "correo"
+            return StepUpRequestResponse(
+                success=False, verification_id=None, channel=channel,
+                masked_destination=None, next_cooldown_seconds=None,
+                message=f"Tu cuenta no tiene {label} registrado",
+            )
+
+        try:
+            res = await vc.request_verification(
+                channel, destination, vc.PURPOSE_STEP_UP,
+                client_session_id=getattr(info.context, "session_id", None),
+            )
+        except vc.VerificationServiceError as exc:
+            return StepUpRequestResponse(
+                success=False, verification_id=None, channel=channel,
+                masked_destination=None, next_cooldown_seconds=None,
+                message=f"No se pudo enviar el código: {exc}",
+            )
+
+        return StepUpRequestResponse(
+            success=True,
+            verification_id=str(res.get("verificationId") or res.get("verification_id") or ""),
+            channel=channel,
+            masked_destination=res.get("maskedDestination") or _mask(destination, channel),
+            next_cooldown_seconds=res.get("nextCooldownSeconds"),
+            message="Código enviado",
+        )
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def verify_step_up(self, info: Info, verification_id: str, code: str) -> StepUpVerifyResponse:
+        """Check the code; on success return a single-use proof for a sensitive action."""
+        if not step_up_enabled():
+            return StepUpVerifyResponse(success=False, proof=None, message="La verificación de 2 pasos no está disponible")
+
+        if not (verification_id or "").strip() or not (code or "").strip():
+            return StepUpVerifyResponse(success=False, proof=None, message="Código o verificación inválidos")
+
+        try:
+            res = await vc.check_verification(verification_id, code)
+        except vc.VerificationServiceError as exc:
+            return StepUpVerifyResponse(success=False, proof=None, message=f"No se pudo verificar: {exc}")
+
+        proof = res.get("proof")
+        if not proof:
+            return StepUpVerifyResponse(success=False, proof=None, message="Código incorrecto o expirado")
+
+        return StepUpVerifyResponse(success=True, proof=proof, message="Verificación exitosa")

--- a/app/graphql/verification/types.py
+++ b/app/graphql/verification/types.py
@@ -1,0 +1,19 @@
+import strawberry
+from typing import Optional
+
+
+@strawberry.type
+class StepUpRequestResponse:
+    success: bool
+    verification_id: Optional[str]
+    channel: Optional[str]
+    masked_destination: Optional[str]
+    next_cooldown_seconds: Optional[int]
+    message: str
+
+
+@strawberry.type
+class StepUpVerifyResponse:
+    success: bool
+    proof: Optional[str]
+    message: str

--- a/app/services/verification_client.py
+++ b/app/services/verification_client.py
@@ -1,0 +1,101 @@
+"""HTTP client for the shared FitPilot verification microservice.
+
+Contract (internal, bearer-authenticated):
+- POST /v1/verifications                  -> start a verification (send code)
+- POST /v1/verifications/{id}/check       -> check code, return single-use proof
+- POST /v1/proofs/consume                 -> validate + consume a proof
+
+All calls go over the internal network (VERIFICATION_SERVICE_URL); no public DNS.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from app.core.verification_config import VerificationConfig
+from app.core.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+PURPOSE_STEP_UP = "step_up"
+
+
+class VerificationServiceError(Exception):
+    """Raised when the verification service call fails."""
+
+
+def _headers() -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {VerificationConfig.SERVICE_TOKEN}",
+        "Content-Type": "application/json",
+    }
+
+
+async def request_verification(
+    channel: str,
+    destination: str,
+    purpose: str,
+    *,
+    client_session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Start a verification; the service sends the code (Twilio Verify / Resend)."""
+    payload: Dict[str, Any] = {
+        "channel": channel,
+        "destination": destination,
+        "purpose": purpose,
+        "audience": VerificationConfig.AUDIENCE,
+    }
+    if client_session_id:
+        payload["clientSessionId"] = client_session_id
+
+    try:
+        async with httpx.AsyncClient(timeout=VerificationConfig.TIMEOUT_SECONDS) as client:
+            resp = await client.post(
+                f"{VerificationConfig.SERVICE_URL}/v1/verifications",
+                json=payload,
+                headers=_headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:  # noqa: BLE001
+        logger.error("verification request failed: %s", exc)
+        raise VerificationServiceError(str(exc)) from exc
+
+
+async def check_verification(verification_id: str, code: str) -> Dict[str, Any]:
+    """Check a code; on success the service returns a single-use ``proof``."""
+    try:
+        async with httpx.AsyncClient(timeout=VerificationConfig.TIMEOUT_SECONDS) as client:
+            resp = await client.post(
+                f"{VerificationConfig.SERVICE_URL}/v1/verifications/{verification_id}/check",
+                json={"code": code},
+                headers=_headers(),
+            )
+            resp.raise_for_status()
+            return resp.json()
+    except httpx.HTTPError as exc:  # noqa: BLE001
+        logger.error("verification check failed: %s", exc)
+        raise VerificationServiceError(str(exc)) from exc
+
+
+async def consume_proof(proof: str, purpose: str, audience: str) -> Dict[str, Any]:
+    """Validate and single-use-consume a proof. Fails closed on any error.
+
+    Returns ``{"valid": bool, "destination": Optional[str]}``.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=VerificationConfig.TIMEOUT_SECONDS) as client:
+            resp = await client.post(
+                f"{VerificationConfig.SERVICE_URL}/v1/proofs/consume",
+                json={"proof": proof, "expectedPurpose": purpose, "expectedAudience": audience},
+                headers=_headers(),
+            )
+            if resp.status_code >= 400:
+                logger.warning("proof consume rejected: HTTP %s", resp.status_code)
+                return {"valid": False, "destination": None}
+            data = resp.json()
+            return {"valid": bool(data.get("valid")), "destination": data.get("destination")}
+    except httpx.HTTPError as exc:  # noqa: BLE001
+        logger.error("proof consume failed: %s", exc)
+        return {"valid": False, "destination": None}

--- a/tests/test_step_up.py
+++ b/tests/test_step_up.py
@@ -1,0 +1,73 @@
+"""Tests for the step-up (2-step) proof gate `require_step_up_proof`.
+
+DB-free: the verification service client and the enable flag are monkeypatched,
+so these run without Postgres or the verification microservice.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.graphql.auth import permissions
+import app.core.verification_config as vcfg
+import app.services.verification_client as vc
+
+
+def _info(*, user: bool = True, account_id: int = 1, db=None):
+    ctx = SimpleNamespace(
+        user=(object() if user else None),
+        account_id=account_id,
+        db=db,
+    )
+    return SimpleNamespace(context=ctx)
+
+
+@pytest.mark.asyncio
+async def test_disabled_is_noop(monkeypatch):
+    monkeypatch.setattr(vcfg, "step_up_enabled", lambda: False)
+    assert await permissions.require_step_up_proof(_info(), None) is None
+    assert await permissions.require_step_up_proof(_info(), "whatever") is None
+
+
+@pytest.mark.asyncio
+async def test_enabled_requires_proof(monkeypatch):
+    monkeypatch.setattr(vcfg, "step_up_enabled", lambda: True)
+    err = await permissions.require_step_up_proof(_info(), None)
+    assert err and "2 pasos" in err
+
+
+@pytest.mark.asyncio
+async def test_enabled_rejects_invalid_proof(monkeypatch):
+    monkeypatch.setattr(vcfg, "step_up_enabled", lambda: True)
+
+    async def fake_consume(proof, purpose, audience):
+        return {"valid": False, "destination": None}
+
+    monkeypatch.setattr(vc, "consume_proof", fake_consume)
+    err = await permissions.require_step_up_proof(_info(), "bad-proof")
+    assert err is not None
+
+
+@pytest.mark.asyncio
+async def test_enabled_accepts_valid_proof(monkeypatch):
+    monkeypatch.setattr(vcfg, "step_up_enabled", lambda: True)
+
+    captured = {}
+
+    async def fake_consume(proof, purpose, audience):
+        captured["args"] = (proof, purpose, audience)
+        return {"valid": True, "destination": None}
+
+    monkeypatch.setattr(vc, "consume_proof", fake_consume)
+    assert await permissions.require_step_up_proof(_info(), "good-proof") is None
+    # consumed with the step_up purpose + gym audience
+    assert captured["args"][0] == "good-proof"
+    assert captured["args"][1] == vc.PURPOSE_STEP_UP
+
+
+@pytest.mark.asyncio
+async def test_enabled_requires_auth_context(monkeypatch):
+    monkeypatch.setattr(vcfg, "step_up_enabled", lambda: True)
+    err = await permissions.require_step_up_proof(_info(user=False, account_id=None), "p")
+    assert err == "Acceso no autorizado"


### PR DESCRIPTION
## Contexto
Primera entrega (lado gym) de la **unificación vía microservicio de verificación compartido** (`fitpilot-verification`, que reutiliza Twilio Verify + Resend de nutrition). Añade un **segundo paso (step-up)** antes de acciones sensibles, consumido como **cliente** del servicio compartido.

**Off por defecto** (`STEP_UP_ENABLED=false`): sin cambios de comportamiento hasta que el servicio esté desplegado y se active el flag — por eso es seguro mergear ya.

## Cambios (backend gym)
- `core/verification_config.py`: flag `STEP_UP_ENABLED` + `VERIFICATION_SERVICE_URL/TOKEN/AUDIENCE`.
- `services/verification_client.py` (httpx): `request` / `check` / `consume_proof` contra el contrato del servicio (`/v1/verifications`, `/v1/verifications/{id}/check`, `/v1/proofs/consume`).
- `graphql/verification`: mutations `requestStepUpVerification(channel)` y `verifyStepUp(verificationId, code)` (usan el teléfono/email de la cuenta autenticada).
- `require_step_up_proof` (en `auth/permissions.py`): valida y **consume single-use** el proof, atado a un contacto propio de la cuenta; **no-op** mientras el flag está apagado.
- Cableado `stepUpProof` en `deleteMember` (mantiene el `admin_password` como fallback cuando el flag está off) y en `createUser/updateUser/setUserActive/resetUserPassword/updateMyAccount`.
- Tests del gate (sin BD).

## Validación
- `py_compile` + el esquema Strawberry construye con los nuevos campos ✅
- `pytest tests/test_step_up.py` → **5 passed** ✅
- Con el flag off, las rutas existentes se comportan igual que antes (deleteMember sigue pidiendo admin_password).

## Pendiente (siguientes entregas del plan)
- **Workstream 1**: levantar el servicio `fitpilot-verification` (extraído de nutrition) en Coolify, en la red `fitpilot-shared`, con los proveedores; emitir `VERIFICATION_SERVICE_TOKEN` y setear `VERIFICATION_SERVICE_URL` en el gym; flip `STEP_UP_ENABLED=true`.
- **Frontend**: `StepUpDialog` (reemplaza `AdminPasswordDialog`) + `verification_service`.
- **Workstream 3**: migrar nutrition a consumir el servicio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)