### PR TITLE
feat(pos): POS, caja/corte de caja y productos sobre el flujo de renovación

### DIFF
--- a/alembic/versions/a1b2c3d4e5f7_pos_caja.py
+++ b/alembic/versions/a1b2c3d4e5f7_pos_caja.py
@@ -1,0 +1,182 @@
+"""POS + caja: cash sessions, movements, sales, line items, tenders + capabilities.
+
+Creates the FitPilot-native POS tables in the ``app`` schema:
+
+* ``cash_sessions``   — shared cash register (caja); one open at a time.
+* ``cash_movements``  — manual cash in/out against a caja.
+* ``sales``           — POS ticket header.
+* ``sale_line_items`` — what was sold (membership lines carry subscription_id/payment_id).
+* ``sale_payments``   — tender ledger (drives the corte de caja).
+
+Also seeds + grants the POS capabilities to admin (display) and staff.
+Purely additive: no changes to existing tables, no data backfill.
+
+Revision ID: a1b2c3d4e5f7
+Revises: e7f8a9b0c1d2
+Create Date: 2026-06-22 18:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "a1b2c3d4e5f7"
+down_revision: Union[str, None] = "e7f8a9b0c1d2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+POS_CAPABILITIES = ("operate_pos", "manage_cash_session", "view_pos_reports", "manage_products")
+
+
+def upgrade() -> None:
+    # ---------------------------------------------------------- cash_sessions
+    op.create_table(
+        "cash_sessions",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("opened_by", sa.BigInteger(), nullable=False),
+        sa.Column("opened_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("opening_float", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("closed_by", sa.BigInteger(), nullable=True),
+        sa.Column("closed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("status", sa.String(length=10), nullable=False, server_default=sa.text("'open'")),
+        sa.Column("expected_cash", sa.Numeric(12, 2), nullable=True),
+        sa.Column("counted_cash", sa.Numeric(12, 2), nullable=True),
+        sa.Column("difference", sa.Numeric(12, 2), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.CheckConstraint("status IN ('open','closed')", name="ck_cash_session_status"),
+        sa.ForeignKeyConstraint(["opened_by"], [f"{SCHEMA}.accounts.id"]),
+        sa.ForeignKeyConstraint(["closed_by"], [f"{SCHEMA}.accounts.id"]),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_cash_session_single_open", "cash_sessions", ["status"],
+        unique=True, schema=SCHEMA, postgresql_where=sa.text("status = 'open'"),
+    )
+    op.create_index("idx_cash_session_opened_at", "cash_sessions", ["opened_at"], schema=SCHEMA)
+
+    # --------------------------------------------------------- cash_movements
+    op.create_table(
+        "cash_movements",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("cash_session_id", sa.BigInteger(), nullable=False),
+        sa.Column("direction", sa.String(length=3), nullable=False),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("reason", sa.String(length=200), nullable=True),
+        sa.Column("created_by", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.CheckConstraint("direction IN ('in','out')", name="ck_cash_movement_direction"),
+        sa.ForeignKeyConstraint(["cash_session_id"], [f"{SCHEMA}.cash_sessions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["created_by"], [f"{SCHEMA}.accounts.id"]),
+        schema=SCHEMA,
+    )
+    op.create_index("idx_cash_movement_session", "cash_movements", ["cash_session_id"], schema=SCHEMA)
+
+    # ------------------------------------------------------------------ sales
+    op.create_table(
+        "sales",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("person_id", sa.BigInteger(), nullable=True),
+        sa.Column("cash_session_id", sa.BigInteger(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default=sa.text("'completed'")),
+        sa.Column("subtotal", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("discount_total", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("tax_total", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("total", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("amount_paid", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("sold_by", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("completed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('open','completed','voided','refunded')", name="ck_sale_status"
+        ),
+        sa.ForeignKeyConstraint(["person_id"], [f"{SCHEMA}.people.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["cash_session_id"], [f"{SCHEMA}.cash_sessions.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["sold_by"], [f"{SCHEMA}.accounts.id"]),
+        schema=SCHEMA,
+    )
+    op.create_index("idx_sales_cash_session_status", "sales", ["cash_session_id", "status"], schema=SCHEMA)
+    op.create_index("idx_sales_sold_by_created", "sales", ["sold_by", "created_at"], schema=SCHEMA)
+
+    # -------------------------------------------------------- sale_line_items
+    op.create_table(
+        "sale_line_items",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("sale_id", sa.BigInteger(), nullable=False),
+        sa.Column("line_type", sa.String(length=20), nullable=False),
+        sa.Column("description", sa.String(length=200), nullable=False),
+        sa.Column("quantity", sa.Integer(), nullable=False, server_default=sa.text("1")),
+        sa.Column("unit_price", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("discount", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("line_total", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("plan_id", sa.BigInteger(), nullable=True),
+        sa.Column("product_id", sa.BigInteger(), nullable=True),  # FK added in Phase 2
+        sa.Column("subscription_id", sa.BigInteger(), nullable=True),
+        sa.Column("payment_id", sa.BigInteger(), nullable=True),
+        sa.Column("meta", sa.JSON(), nullable=True),
+        sa.CheckConstraint(
+            "line_type IN ('membership_new','membership_renewal','product','manual')",
+            name="ck_sale_line_type",
+        ),
+        sa.ForeignKeyConstraint(["sale_id"], [f"{SCHEMA}.sales.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["plan_id"], [f"{SCHEMA}.membership_plans.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["subscription_id"], [f"{SCHEMA}.membership_subscriptions.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["payment_id"], [f"{SCHEMA}.payments.id"], ondelete="SET NULL"),
+        schema=SCHEMA,
+    )
+    op.create_index("idx_sale_line_items_sale", "sale_line_items", ["sale_id"], schema=SCHEMA)
+
+    # ----------------------------------------------------------- sale_payments
+    op.create_table(
+        "sale_payments",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("sale_id", sa.BigInteger(), nullable=False),
+        sa.Column("payment_id", sa.BigInteger(), nullable=True),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("method", sa.String(length=40), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["sale_id"], [f"{SCHEMA}.sales.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["payment_id"], [f"{SCHEMA}.payments.id"], ondelete="SET NULL"),
+        schema=SCHEMA,
+    )
+    op.create_index("idx_sale_payment_sale", "sale_payments", ["sale_id"], schema=SCHEMA)
+    op.create_index("idx_sale_payment_method", "sale_payments", ["method"], schema=SCHEMA)
+
+    # ---------------------------------------------- capability seeds + grants
+    for capability in POS_CAPABILITIES:
+        op.execute(
+            f"""
+            INSERT INTO {SCHEMA}.role_capabilities (role_id, capability)
+            SELECT id, '{capability}' FROM {SCHEMA}.roles WHERE code IN ('admin','staff')
+            ON CONFLICT DO NOTHING
+            """
+        )
+
+
+def downgrade() -> None:
+    for capability in POS_CAPABILITIES:
+        op.execute(f"DELETE FROM {SCHEMA}.role_capabilities WHERE capability = '{capability}'")
+
+    op.drop_index("idx_sale_payment_method", table_name="sale_payments", schema=SCHEMA)
+    op.drop_index("idx_sale_payment_sale", table_name="sale_payments", schema=SCHEMA)
+    op.drop_table("sale_payments", schema=SCHEMA)
+
+    op.drop_index("idx_sale_line_items_sale", table_name="sale_line_items", schema=SCHEMA)
+    op.drop_table("sale_line_items", schema=SCHEMA)
+
+    op.drop_index("idx_sales_sold_by_created", table_name="sales", schema=SCHEMA)
+    op.drop_index("idx_sales_cash_session_status", table_name="sales", schema=SCHEMA)
+    op.drop_table("sales", schema=SCHEMA)
+
+    op.drop_index("idx_cash_movement_session", table_name="cash_movements", schema=SCHEMA)
+    op.drop_table("cash_movements", schema=SCHEMA)
+
+    op.drop_index("idx_cash_session_opened_at", table_name="cash_sessions", schema=SCHEMA)
+    op.drop_index("uq_cash_session_single_open", table_name="cash_sessions", schema=SCHEMA)
+    op.drop_table("cash_sessions", schema=SCHEMA)

--- a/alembic/versions/b2c3d4e5f6a8_pos_products.py
+++ b/alembic/versions/b2c3d4e5f6a8_pos_products.py
@@ -1,0 +1,77 @@
+"""POS products / inventory.
+
+* Creates ``products`` (catalog with optional stock).
+* Adds the FK ``sale_line_items.product_id -> products.id``.
+* Makes ``payments.person_id`` nullable so the POS can sell products to a
+  walk-in customer with no member record.
+
+Revision ID: b2c3d4e5f6a8
+Revises: a1b2c3d4e5f7
+Create Date: 2026-06-22 18:30:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "b2c3d4e5f6a8"
+down_revision: Union[str, None] = "a1b2c3d4e5f7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "products",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("sku", sa.String(length=40), nullable=True),
+        sa.Column("price", sa.Numeric(12, 2), nullable=False, server_default=sa.text("0")),
+        sa.Column("track_stock", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("stock_qty", sa.Integer(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        schema=SCHEMA,
+    )
+    op.create_index(
+        "uq_products_sku", "products", ["sku"], unique=True, schema=SCHEMA,
+        postgresql_where=sa.text("sku IS NOT NULL"),
+    )
+    op.create_index("idx_products_active", "products", ["is_active"], schema=SCHEMA)
+
+    op.create_foreign_key(
+        "fk_sale_line_items_product",
+        "sale_line_items",
+        "products",
+        ["product_id"],
+        ["id"],
+        source_schema=SCHEMA,
+        referent_schema=SCHEMA,
+        ondelete="SET NULL",
+    )
+
+    op.alter_column(
+        "payments", "person_id",
+        existing_type=sa.BigInteger(),
+        nullable=True,
+        schema=SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "payments", "person_id",
+        existing_type=sa.BigInteger(),
+        nullable=False,
+        schema=SCHEMA,
+    )
+    op.drop_constraint("fk_sale_line_items_product", "sale_line_items", schema=SCHEMA, type_="foreignkey")
+    op.drop_index("idx_products_active", table_name="products", schema=SCHEMA)
+    op.drop_index("uq_products_sku", table_name="products", schema=SCHEMA)
+    op.drop_table("products", schema=SCHEMA)

--- a/app/core/payment_methods.py
+++ b/app/core/payment_methods.py
@@ -1,0 +1,48 @@
+"""Canonical payment methods shared by the POS write paths.
+
+Historical ``payments.method`` rows are free-form strings (a mix of ``cash``,
+``efectivo``, ``card``, ``transfer``, ``mercadopago``) and are intentionally NOT
+migrated. Canonicalization is enforced only on the new POS write paths so that
+nothing existing breaks.
+
+``CASH_METHODS`` is the set of methods that move physical cash in the drawer; it
+is what the *corte de caja* counts. It tolerates the legacy Spanish value
+``efectivo`` still present in old rows.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+CASH = "cash"
+CARD = "card"
+TRANSFER = "transfer"
+MERCADOPAGO = "mercadopago"
+OTHER = "other"
+# Sentinel used as a membership anchor payment's method when a single sale is
+# settled with more than one tender (the true breakdown lives in sale_payments).
+MIXED = "mixed"
+
+ALL_METHODS = [CASH, CARD, TRANSFER, MERCADOPAGO, OTHER]
+
+# Methods that count toward the cash drawer for the corte de caja.
+CASH_METHODS = {CASH, "efectivo"}
+
+LABELS = {
+    CASH: "Efectivo",
+    CARD: "Tarjeta",
+    TRANSFER: "Transferencia",
+    MERCADOPAGO: "MercadoPago",
+    OTHER: "Otro",
+    MIXED: "Mixto",
+}
+
+
+def is_cash(method: Optional[str]) -> bool:
+    """True when ``method`` moves physical cash (counts for the corte de caja)."""
+    return (method or "").strip().lower() in CASH_METHODS
+
+
+def label_for(method: Optional[str]) -> str:
+    """Human-friendly label, falling back to the raw value for unknown methods."""
+    key = (method or "").strip().lower()
+    return LABELS.get(key, method or "")

--- a/app/crud/memberships/enrollment.py
+++ b/app/crud/memberships/enrollment.py
@@ -116,9 +116,14 @@ async def renew_subscription_with_standing_booking(
     external_reference: Optional[str] = None,
     recorded_by: Optional[int] = None,
     auto_materialize: bool = True,
+    commit: bool = True,
 ) -> tuple[MembershipSubscription, Payment, MembershipPlan, Optional[int], dict]:
     """
     Renew a subscription and handle standing booking creation for fixed time slot plans.
+
+    When ``commit`` is False the caller owns the transaction (e.g. a POS sale that
+    wraps several operations into one atomic commit); ids are still available via
+    the earlier flushes.
 
     Returns:
         - MembershipSubscription: The renewed subscription
@@ -281,14 +286,15 @@ async def renew_subscription_with_standing_booking(
         )
         _assert_materialization_success(materialization_stats)
 
-    # Commit transaction
-    logger.info("Committing renewal transaction for subscription %s", subscription.id)
-    await db.commit()
+    # Commit transaction (unless the caller owns it, e.g. a POS sale)
+    if commit:
+        logger.info("Committing renewal transaction for subscription %s", subscription.id)
+        await db.commit()
 
-    # Refresh objects
-    await db.refresh(subscription)
-    await db.refresh(payment)
-    await db.refresh(plan)
+        # Refresh objects
+        await db.refresh(subscription)
+        await db.refresh(payment)
+        await db.refresh(plan)
 
     return subscription, payment, plan, standing_booking_id, materialization_stats
 
@@ -311,9 +317,13 @@ async def create_member_enrollment_with_standing_booking(
     external_reference: Optional[str] = None,
     recorded_by: Optional[int] = None,
     auto_materialize: bool = True,
+    commit: bool = True,
 ) -> tuple[People, MembershipSubscription, Payment, MembershipPlan, Optional[int], dict]:
     """
     Create member enrollment with automatic standing booking for fixed time slot plans.
+
+    When ``commit`` is False the caller owns the transaction (e.g. a POS sale that
+    wraps several operations into one atomic commit).
 
     Returns:
         - People: The created member
@@ -361,7 +371,8 @@ async def create_member_enrollment_with_standing_booking(
     elif plan.fixed_time_slot:
         raise ValueError("Debe seleccionar un horario para registrar este plan.")
 
-    # Final commit
-    await db.commit()
+    # Final commit (unless the caller owns the transaction, e.g. a POS sale)
+    if commit:
+        await db.commit()
 
     return person, subscription, payment, plan, standing_booking_id, materialization_stats

--- a/app/crud/permissions.py
+++ b/app/crud/permissions.py
@@ -18,7 +18,20 @@ from app.models import People, Role, RoleCapability
 MANAGE_MEMBERSHIP_PLANS = "manage_membership_plans"
 MANAGE_OWNER_AGENT = "manage_owner_agent"
 MANAGE_USERS = "manage_users"
-ALL_CAPABILITIES: List[str] = [MANAGE_MEMBERSHIP_PLANS, MANAGE_OWNER_AGENT, MANAGE_USERS]
+# POS / caja capabilities
+OPERATE_POS = "operate_pos"  # run the checkout (create sales)
+MANAGE_CASH_SESSION = "manage_cash_session"  # open/close caja, corte, cash movements
+VIEW_POS_REPORTS = "view_pos_reports"  # read sales + cash-session reports
+MANAGE_PRODUCTS = "manage_products"  # CRUD of the product catalog / inventory
+ALL_CAPABILITIES: List[str] = [
+    MANAGE_MEMBERSHIP_PLANS,
+    MANAGE_OWNER_AGENT,
+    MANAGE_USERS,
+    OPERATE_POS,
+    MANAGE_CASH_SESSION,
+    VIEW_POS_REPORTS,
+    MANAGE_PRODUCTS,
+]
 
 ADMIN_ROLE_CODE = "admin"
 

--- a/app/crud/pos/__init__.py
+++ b/app/crud/pos/__init__.py
@@ -1,0 +1,1 @@
+"""POS CRUD package: cash sessions (caja), sales tickets and reports."""

--- a/app/crud/pos/cash_sessions.py
+++ b/app/crud/pos/cash_sessions.py
@@ -1,0 +1,158 @@
+"""Cash register (caja) CRUD: open, movements, close + corte de caja math."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.payment_methods import CASH_METHODS
+from app.models.posModel import CashSession, CashMovement, Sale, SalePayment
+
+
+def _dec(value) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value))
+
+
+async def get_open_cash_session(db: AsyncSession) -> Optional[CashSession]:
+    """The single currently-open caja, or None."""
+    result = await db.execute(
+        select(CashSession)
+        .where(CashSession.status == "open")
+        .order_by(CashSession.opened_at.desc())
+    )
+    return result.scalars().first()
+
+
+async def get_cash_session_by_id(db: AsyncSession, cash_session_id: int) -> Optional[CashSession]:
+    return await db.get(CashSession, cash_session_id)
+
+
+async def open_cash_session(
+    db: AsyncSession,
+    *,
+    opened_by: int,
+    opening_float: Decimal | float = Decimal("0"),
+    notes: Optional[str] = None,
+    commit: bool = True,
+) -> CashSession:
+    """Open the shared caja. Fails if one is already open."""
+    existing = await get_open_cash_session(db)
+    if existing is not None:
+        raise ValueError("Ya hay una caja abierta. Ciérrala antes de abrir otra.")
+
+    session = CashSession(
+        opened_by=opened_by,
+        opening_float=_dec(opening_float),
+        notes=notes,
+        status="open",
+    )
+    db.add(session)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(session)
+    return session
+
+
+async def record_cash_movement(
+    db: AsyncSession,
+    *,
+    cash_session_id: int,
+    direction: str,
+    amount: Decimal | float,
+    reason: Optional[str] = None,
+    created_by: Optional[int] = None,
+    commit: bool = True,
+) -> CashMovement:
+    """Record a manual cash movement (retiro='out' / ingreso='in') against an open caja."""
+    if direction not in ("in", "out"):
+        raise ValueError("Dirección de movimiento inválida (usa 'in' u 'out').")
+    if _dec(amount) <= 0:
+        raise ValueError("El monto del movimiento debe ser mayor a cero.")
+
+    session = await db.get(CashSession, cash_session_id)
+    if session is None or session.status != "open":
+        raise ValueError("La caja no está abierta.")
+
+    movement = CashMovement(
+        cash_session_id=cash_session_id,
+        direction=direction,
+        amount=_dec(amount),
+        reason=reason,
+        created_by=created_by,
+    )
+    db.add(movement)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(movement)
+    return movement
+
+
+async def _sum_cash_sale_payments(db: AsyncSession, cash_session_id: int) -> Decimal:
+    """Sum of cash tenders booked to completed sales of this caja."""
+    cash_methods = [m.lower() for m in CASH_METHODS]
+    stmt = (
+        select(func.coalesce(func.sum(SalePayment.amount), 0))
+        .select_from(SalePayment)
+        .join(Sale, SalePayment.sale_id == Sale.id)
+        .where(Sale.cash_session_id == cash_session_id)
+        .where(Sale.status == "completed")
+        .where(func.lower(SalePayment.method).in_(cash_methods))
+    )
+    return _dec((await db.execute(stmt)).scalar_one() or 0)
+
+
+async def _sum_movements(db: AsyncSession, cash_session_id: int, direction: str) -> Decimal:
+    stmt = (
+        select(func.coalesce(func.sum(CashMovement.amount), 0))
+        .where(CashMovement.cash_session_id == cash_session_id)
+        .where(CashMovement.direction == direction)
+    )
+    return _dec((await db.execute(stmt)).scalar_one() or 0)
+
+
+async def compute_expected_cash(db: AsyncSession, session: CashSession) -> Decimal:
+    """fondo inicial + ventas en efectivo + ingresos − retiros."""
+    cash_sales = await _sum_cash_sale_payments(db, session.id)
+    movements_in = await _sum_movements(db, session.id, "in")
+    movements_out = await _sum_movements(db, session.id, "out")
+    return _dec(session.opening_float) + cash_sales + movements_in - movements_out
+
+
+async def close_cash_session(
+    db: AsyncSession,
+    *,
+    cash_session_id: int,
+    counted_cash: Decimal | float,
+    closed_by: Optional[int] = None,
+    notes: Optional[str] = None,
+    commit: bool = True,
+) -> CashSession:
+    """Close the caja: compute expected cash, store the counted amount + difference."""
+    session = await db.get(CashSession, cash_session_id)
+    if session is None:
+        raise ValueError("Caja no encontrada.")
+    if session.status != "open":
+        raise ValueError("La caja ya está cerrada.")
+
+    expected = await compute_expected_cash(db, session)
+    counted = _dec(counted_cash)
+
+    session.expected_cash = expected
+    session.counted_cash = counted
+    session.difference = counted - expected
+    session.closed_by = closed_by
+    session.closed_at = datetime.now(timezone.utc)
+    session.status = "closed"
+    if notes:
+        session.notes = notes
+
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(session)
+    return session

--- a/app/crud/pos/products.py
+++ b/app/crud/pos/products.py
@@ -1,0 +1,122 @@
+"""Product catalog + inventory CRUD."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import List, Optional
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.posModel import Product
+
+_UNSET = object()
+
+
+def _dec(value) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value or 0))
+
+
+async def get_products(
+    db: AsyncSession,
+    *,
+    include_inactive: bool = False,
+    search: Optional[str] = None,
+) -> List[Product]:
+    stmt = select(Product)
+    if not include_inactive:
+        stmt = stmt.where(Product.is_active.is_(True))
+    if search:
+        term = f"%{search}%"
+        stmt = stmt.where(or_(Product.name.ilike(term), Product.sku.ilike(term)))
+    stmt = stmt.order_by(Product.name.asc())
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def get_product_by_id(db: AsyncSession, product_id: int) -> Optional[Product]:
+    return await db.get(Product, product_id)
+
+
+async def create_product(
+    db: AsyncSession,
+    *,
+    name: str,
+    price: Decimal | float,
+    sku: Optional[str] = None,
+    track_stock: bool = False,
+    stock_qty: Optional[int] = None,
+    is_active: bool = True,
+    commit: bool = True,
+) -> Product:
+    product = Product(
+        name=name,
+        price=_dec(price),
+        sku=(sku or None),
+        track_stock=bool(track_stock),
+        stock_qty=stock_qty if track_stock else None,
+        is_active=is_active,
+    )
+    db.add(product)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(product)
+    return product
+
+
+async def update_product(
+    db: AsyncSession,
+    product_id: int,
+    *,
+    name=_UNSET,
+    price=_UNSET,
+    sku=_UNSET,
+    track_stock=_UNSET,
+    stock_qty=_UNSET,
+    is_active=_UNSET,
+    commit: bool = True,
+) -> Optional[Product]:
+    product = await db.get(Product, product_id)
+    if product is None:
+        return None
+    if name is not _UNSET:
+        product.name = name
+    if price is not _UNSET:
+        product.price = _dec(price)
+    if sku is not _UNSET:
+        product.sku = sku or None
+    if track_stock is not _UNSET:
+        product.track_stock = bool(track_stock)
+    if stock_qty is not _UNSET:
+        product.stock_qty = stock_qty
+    if is_active is not _UNSET:
+        product.is_active = bool(is_active)
+    product.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(product)
+    return product
+
+
+async def set_product_active(
+    db: AsyncSession, product_id: int, is_active: bool, *, commit: bool = True
+) -> Optional[Product]:
+    return await update_product(db, product_id, is_active=is_active, commit=commit)
+
+
+async def adjust_stock(
+    db: AsyncSession, product_id: int, delta: int, *, commit: bool = True
+) -> Optional[Product]:
+    """Apply a stock delta (negative to decrement on a sale)."""
+    product = await db.get(Product, product_id)
+    if product is None:
+        return None
+    if product.track_stock:
+        current = product.stock_qty or 0
+        product.stock_qty = current + delta
+    await db.flush()
+    if commit:
+        await db.commit()
+        await db.refresh(product)
+    return product

--- a/app/crud/pos/reports.py
+++ b/app/crud/pos/reports.py
@@ -1,0 +1,120 @@
+"""Cash-session (corte de caja) reporting.
+
+Reuses the aggregation style of ``memberships/payment_metrics.py`` but scoped to a
+single caja via ``sale_payments -> sales WHERE cash_session_id = ?``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from decimal import Decimal
+from typing import List, Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.payment_methods import CASH_METHODS
+from app.models.posModel import CashSession, CashMovement, Sale, SalePayment
+
+from .cash_sessions import compute_expected_cash
+
+
+@dataclass
+class MethodTotalData:
+    method: str
+    count: int
+    total: float
+
+
+@dataclass
+class CashSessionReportData:
+    session_id: int
+    status: str
+    opened_by: Optional[int]
+    opened_at: datetime
+    closed_at: Optional[datetime]
+    opening_float: float
+    sales_count: int
+    sales_total: float
+    cash_in: float          # manual ingresos
+    cash_out: float         # manual retiros
+    cash_sales_total: float  # cash tenders only
+    computed_expected_cash: float  # live expected (works for open caja)
+    expected_cash: Optional[float]  # stored at close
+    counted_cash: Optional[float]
+    difference: Optional[float]
+    by_method: List[MethodTotalData] = field(default_factory=list)
+
+
+async def get_cash_session_report(
+    db: AsyncSession, cash_session_id: int
+) -> Optional[CashSessionReportData]:
+    session = await db.get(CashSession, cash_session_id)
+    if session is None:
+        return None
+
+    # Tenders grouped by method (completed sales of this caja).
+    by_method_stmt = (
+        select(
+            SalePayment.method,
+            func.count(SalePayment.id).label("count"),
+            func.coalesce(func.sum(SalePayment.amount), 0).label("total"),
+        )
+        .select_from(SalePayment)
+        .join(Sale, SalePayment.sale_id == Sale.id)
+        .where(Sale.cash_session_id == cash_session_id)
+        .where(Sale.status == "completed")
+        .group_by(SalePayment.method)
+        .order_by(func.sum(SalePayment.amount).desc())
+    )
+    by_method = [
+        MethodTotalData(method=r.method, count=int(r.count), total=float(r.total))
+        for r in (await db.execute(by_method_stmt)).all()
+    ]
+    cash_methods = {m.lower() for m in CASH_METHODS}
+    cash_sales_total = sum(
+        (b.total for b in by_method if (b.method or "").lower() in cash_methods), 0.0
+    )
+
+    # Sales count / total (over distinct sales, not the tender join).
+    sales_stmt = (
+        select(
+            func.count(Sale.id).label("count"),
+            func.coalesce(func.sum(Sale.total), 0).label("total"),
+        )
+        .where(Sale.cash_session_id == cash_session_id)
+        .where(Sale.status == "completed")
+    )
+    sales_row = (await db.execute(sales_stmt)).one()
+
+    # Manual movements.
+    movements_stmt = (
+        select(
+            CashMovement.direction,
+            func.coalesce(func.sum(CashMovement.amount), 0).label("total"),
+        )
+        .where(CashMovement.cash_session_id == cash_session_id)
+        .group_by(CashMovement.direction)
+    )
+    movements = {r.direction: float(r.total) for r in (await db.execute(movements_stmt)).all()}
+
+    computed_expected = float(await compute_expected_cash(db, session))
+
+    return CashSessionReportData(
+        session_id=session.id,
+        status=session.status,
+        opened_by=session.opened_by,
+        opened_at=session.opened_at,
+        closed_at=session.closed_at,
+        opening_float=float(session.opening_float or 0),
+        sales_count=int(sales_row.count),
+        sales_total=float(sales_row.total),
+        cash_in=movements.get("in", 0.0),
+        cash_out=movements.get("out", 0.0),
+        cash_sales_total=float(cash_sales_total),
+        computed_expected_cash=computed_expected,
+        expected_cash=float(session.expected_cash) if session.expected_cash is not None else None,
+        counted_cash=float(session.counted_cash) if session.counted_cash is not None else None,
+        difference=float(session.difference) if session.difference is not None else None,
+        by_method=by_method,
+    )

--- a/app/crud/pos/sales.py
+++ b/app/crud/pos/sales.py
@@ -1,0 +1,370 @@
+"""Sales (POS tickets) CRUD.
+
+``create_sale`` is the heart of the POS. It *wraps* the existing enrollment /
+renewal CRUD so a membership line produces a subscription + payment exactly like
+today, then records the line items and the tender ledger and commits once.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import List, Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.core.payment_methods import MIXED, is_cash
+from app.crud.memberships.enrollment import (
+    create_member_enrollment_with_standing_booking,
+    renew_subscription_with_standing_booking,
+)
+from app.crud.memberships.payments import create_payment
+from app.models.posModel import Sale, SaleLineItem, SalePayment
+
+from .cash_sessions import get_open_cash_session
+
+
+def _dec(value) -> Decimal:
+    return value if isinstance(value, Decimal) else Decimal(str(value or 0))
+
+
+@dataclass
+class SaleLineInput:
+    """One line of a sale.
+
+    line_type:
+      * ``membership_new``      -> enrolls a brand-new member (needs full_name, plan_id)
+      * ``membership_renewal``  -> renews an existing member (needs member_id, plan_id)
+      * ``product``             -> a catalog product (Phase 2; needs product_id)
+      * ``manual``              -> a free-form charge (needs description + unit_price)
+    """
+
+    line_type: str
+    description: str = ""
+    quantity: int = 1
+    unit_price: Optional[Decimal | float] = None  # membership: overrides plan price when set
+    discount: Decimal | float = 0
+    # membership fields
+    plan_id: Optional[int] = None
+    member_id: Optional[int] = None          # renewal
+    full_name: Optional[str] = None          # new enrollment
+    email: Optional[str] = None
+    phone_number: Optional[str] = None
+    start_at: Optional[datetime] = None
+    template_id: Optional[int] = None
+    seat_id: Optional[int] = None
+    # product field (Phase 2)
+    product_id: Optional[int] = None
+
+
+@dataclass
+class SalePaymentInput:
+    """A single tender (how part of the ticket was paid)."""
+
+    method: str
+    amount: Decimal | float
+    provider: Optional[str] = None
+    provider_payment_id: Optional[str] = None
+    external_reference: Optional[str] = None
+
+
+def _sale_query_with_relations():
+    return select(Sale).options(
+        selectinload(Sale.person),
+        selectinload(Sale.line_items),
+        selectinload(Sale.sale_payments),
+        selectinload(Sale.cash_session),
+    )
+
+
+async def get_sale(db: AsyncSession, sale_id: int) -> Optional[Sale]:
+    result = await db.execute(_sale_query_with_relations().where(Sale.id == sale_id))
+    return result.scalars().first()
+
+
+async def get_sales(
+    db: AsyncSession,
+    *,
+    limit: int = 100,
+    offset: int = 0,
+    cash_session_id: Optional[int] = None,
+    status: Optional[str] = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+) -> List[Sale]:
+    query = _sale_query_with_relations()
+    if cash_session_id is not None:
+        query = query.where(Sale.cash_session_id == cash_session_id)
+    if status:
+        query = query.where(Sale.status == status)
+    if start_date is not None:
+        query = query.where(Sale.created_at >= start_date)
+    if end_date is not None:
+        query = query.where(Sale.created_at <= end_date)
+    query = query.order_by(Sale.created_at.desc()).offset(offset).limit(limit)
+    result = await db.execute(query)
+    return list(result.scalars().all())
+
+
+async def create_sale(
+    db: AsyncSession,
+    *,
+    line_items: List[SaleLineInput],
+    tenders: List[SalePaymentInput],
+    person_id: Optional[int] = None,
+    sold_by: Optional[int] = None,
+    note: Optional[str] = None,
+    require_open_cash_for_cash: bool = True,
+    commit: bool = True,
+) -> Sale:
+    """Create a POS sale atomically, reusing enrollment/renewal for membership lines."""
+    if not line_items:
+        raise ValueError("La venta no tiene conceptos.")
+    nonzero_tenders = [t for t in tenders if _dec(t.amount) > 0]
+    if not nonzero_tenders:
+        raise ValueError("La venta no tiene pagos.")
+
+    open_session = await get_open_cash_session(db)
+    has_cash_tender = any(is_cash(t.method) for t in nonzero_tenders)
+    if require_open_cash_for_cash and has_cash_tender and open_session is None:
+        raise ValueError("Abre la caja antes de cobrar en efectivo.")
+
+    # A single tender keeps its own method; split tenders mark the membership
+    # anchor payment as 'mixed' (the real breakdown lives in sale_payments).
+    primary_method = nonzero_tenders[0].method if len(nonzero_tenders) == 1 else MIXED
+
+    sale = Sale(
+        person_id=person_id,
+        cash_session_id=open_session.id if open_session else None,
+        status="open",
+        sold_by=sold_by,
+        note=note,
+    )
+    db.add(sale)
+    await db.flush()
+
+    subtotal = Decimal("0")
+    anchor_payment_id: Optional[int] = None
+
+    for li in line_items:
+        if li.line_type in ("membership_new", "membership_renewal"):
+            item, line_total, payment_id = await _process_membership_line(
+                db, sale, li, primary_method, sold_by
+            )
+        elif li.line_type == "manual":
+            item, line_total, payment_id = await _process_manual_line(
+                db, sale, li, primary_method, sold_by
+            )
+        elif li.line_type == "product":
+            item, line_total, payment_id = await _process_product_line(
+                db, sale, li, primary_method, sold_by
+            )
+        else:
+            raise ValueError(f"Tipo de línea desconocido: {li.line_type}")
+
+        db.add(item)
+        subtotal += line_total
+        if anchor_payment_id is None:
+            anchor_payment_id = payment_id
+
+    total = subtotal  # Phase 1: no sale-level discount/tax
+    paid = sum((_dec(t.amount) for t in nonzero_tenders), Decimal("0"))
+    if paid + Decimal("0.01") < total:
+        raise ValueError(f"El pago (${paid:.2f}) es menor al total (${total:.2f}).")
+
+    # Change is given out of cash, so the cash booked to the tender ledger must be
+    # the NET kept in the drawer (tendered - change). Otherwise the corte de caja
+    # over-counts expected cash by the change handed back. sale.amount_paid keeps
+    # the gross tendered (for the receipt's change line).
+    remaining_change = max(paid - total, Decimal("0"))
+    for t in nonzero_tenders:
+        amount = _dec(t.amount)
+        if remaining_change > 0 and is_cash(t.method):
+            reduction = min(remaining_change, amount)
+            amount -= reduction
+            remaining_change -= reduction
+        if amount <= 0:
+            continue
+        db.add(
+            SalePayment(
+                sale_id=sale.id,
+                payment_id=anchor_payment_id,
+                amount=amount,
+                method=t.method,
+            )
+        )
+
+    sale.subtotal = subtotal
+    sale.total = total
+    sale.amount_paid = paid
+    sale.status = "completed"
+    sale.completed_at = datetime.now(timezone.utc)
+
+    await db.flush()
+    if commit:
+        await db.commit()
+
+    refreshed = await get_sale(db, sale.id)
+    return refreshed if refreshed is not None else sale
+
+
+async def _process_membership_line(db, sale, li: SaleLineInput, primary_method, sold_by):
+    if not li.plan_id:
+        raise ValueError("La línea de membresía requiere un plan.")
+
+    if li.line_type == "membership_new":
+        if not li.full_name:
+            raise ValueError("El alta de membresía requiere el nombre del socio.")
+        person, subscription, payment, plan, sb_id, stats = (
+            await create_member_enrollment_with_standing_booking(
+                db=db,
+                full_name=li.full_name,
+                email=li.email,
+                phone_number=li.phone_number,
+                plan_id=li.plan_id,
+                start_at=li.start_at,
+                payment_method=primary_method,
+                payment_amount=li.unit_price,
+                payment_status="COMPLETED",
+                recorded_by=sold_by,
+                template_id=li.template_id,
+                seat_id=li.seat_id,
+                auto_materialize=True,
+                commit=False,
+            )
+        )
+        if sale.person_id is None:
+            sale.person_id = person.id
+        description = li.description or f"Alta de membresía: {plan.name}"
+    else:  # membership_renewal
+        if not li.member_id:
+            raise ValueError("La renovación requiere un socio.")
+        subscription, payment, plan, sb_id, stats = (
+            await renew_subscription_with_standing_booking(
+                db=db,
+                member_id=li.member_id,
+                plan_id=li.plan_id,
+                template_id=li.template_id,
+                seat_id=li.seat_id,
+                start_at=li.start_at,
+                payment_method=primary_method,
+                payment_amount=li.unit_price,
+                payment_status="COMPLETED",
+                recorded_by=sold_by,
+                commit=False,
+            )
+        )
+        if sale.person_id is None:
+            sale.person_id = li.member_id
+        description = li.description or f"Renovación de membresía: {plan.name}"
+
+    line_total = _dec(payment.amount)
+    meta = {
+        "template_id": li.template_id,
+        "seat_id": li.seat_id,
+        "standing_booking_id": sb_id,
+        "plan_name": plan.name,
+    }
+    item = SaleLineItem(
+        sale_id=sale.id,
+        line_type=li.line_type,
+        description=description,
+        quantity=1,
+        unit_price=line_total,
+        discount=Decimal("0"),
+        line_total=line_total,
+        plan_id=li.plan_id,
+        subscription_id=subscription.id,
+        payment_id=payment.id,
+        meta=meta,
+    )
+    return item, line_total, payment.id
+
+
+async def _process_manual_line(db, sale, li: SaleLineInput, primary_method, sold_by):
+    if sale.person_id is None:
+        raise ValueError("Un cargo manual requiere un socio.")
+    line_total = _dec(li.unit_price) * (li.quantity or 1) - _dec(li.discount)
+    if line_total <= 0:
+        raise ValueError("El cargo manual debe tener un importe mayor a cero.")
+    payment = await create_payment(
+        db=db,
+        person_id=sale.person_id,
+        amount=line_total,
+        method=primary_method,
+        status="COMPLETED",
+        comment=li.description or "Cargo POS",
+        recorded_by=sold_by,
+        commit=False,
+    )
+    item = SaleLineItem(
+        sale_id=sale.id,
+        line_type="manual",
+        description=li.description or "Cargo manual",
+        quantity=li.quantity or 1,
+        unit_price=_dec(li.unit_price),
+        discount=_dec(li.discount),
+        line_total=line_total,
+        payment_id=payment.id,
+    )
+    return item, line_total, payment.id
+
+
+async def _process_product_line(db, sale, li: SaleLineInput, primary_method, sold_by):
+    from app.crud.pos.products import adjust_stock, get_product_by_id
+
+    if not li.product_id:
+        raise ValueError("La línea de producto requiere un producto.")
+    product = await get_product_by_id(db, li.product_id)
+    if product is None or not product.is_active:
+        raise ValueError("Producto no disponible.")
+
+    qty = li.quantity or 1
+    unit_price = _dec(li.unit_price) if li.unit_price is not None else _dec(product.price)
+    line_total = unit_price * qty - _dec(li.discount)
+    if line_total <= 0:
+        raise ValueError("El importe del producto debe ser mayor a cero.")
+
+    if product.track_stock:
+        if product.stock_qty is None or product.stock_qty < qty:
+            raise ValueError(f"Stock insuficiente de {product.name}.")
+        await adjust_stock(db, product.id, -qty, commit=False)
+
+    payment = await create_payment(
+        db=db,
+        person_id=sale.person_id,  # may be None (walk-in)
+        amount=line_total,
+        method=primary_method,
+        status="COMPLETED",
+        comment=f"Producto: {product.name}",
+        recorded_by=sold_by,
+        commit=False,
+    )
+    item = SaleLineItem(
+        sale_id=sale.id,
+        line_type="product",
+        description=li.description or product.name,
+        quantity=qty,
+        unit_price=unit_price,
+        discount=_dec(li.discount),
+        line_total=line_total,
+        product_id=product.id,
+        payment_id=payment.id,
+    )
+    return item, line_total, payment.id
+
+
+async def void_sale(db: AsyncSession, sale_id: int, *, commit: bool = True) -> Optional[Sale]:
+    """Mark a sale as voided. Does not auto-reverse memberships (manual for v1)."""
+    sale = await db.get(Sale, sale_id)
+    if sale is None:
+        return None
+    if sale.status == "voided":
+        return sale
+    sale.status = "voided"
+    await db.flush()
+    if commit:
+        await db.commit()
+    return await get_sale(db, sale_id)

--- a/app/crud/posCrud.py
+++ b/app/crud/posCrud.py
@@ -1,0 +1,54 @@
+"""Aggregated POS CRUD facade (mirrors app.crud.membershipsCrud)."""
+from app.crud.pos.cash_sessions import (
+    close_cash_session,
+    compute_expected_cash,
+    get_cash_session_by_id,
+    get_open_cash_session,
+    open_cash_session,
+    record_cash_movement,
+)
+from app.crud.pos.reports import (
+    CashSessionReportData,
+    MethodTotalData,
+    get_cash_session_report,
+)
+from app.crud.pos.products import (
+    adjust_stock,
+    create_product,
+    get_product_by_id,
+    get_products,
+    set_product_active,
+    update_product,
+)
+from app.crud.pos.sales import (
+    SaleLineInput,
+    SalePaymentInput,
+    create_sale,
+    get_sale,
+    get_sales,
+    void_sale,
+)
+
+__all__ = [
+    "get_products",
+    "get_product_by_id",
+    "create_product",
+    "update_product",
+    "set_product_active",
+    "adjust_stock",
+    "open_cash_session",
+    "close_cash_session",
+    "record_cash_movement",
+    "get_open_cash_session",
+    "get_cash_session_by_id",
+    "compute_expected_cash",
+    "get_cash_session_report",
+    "CashSessionReportData",
+    "MethodTotalData",
+    "create_sale",
+    "get_sale",
+    "get_sales",
+    "void_sale",
+    "SaleLineInput",
+    "SalePaymentInput",
+]

--- a/app/graphql/auth/permissions.py
+++ b/app/graphql/auth/permissions.py
@@ -47,3 +47,23 @@ async def require_capability(info: Info, capability: str) -> Optional[str]:
     if not await person_can(db, user, capability):
         return "No tienes permiso para realizar esta accion"
     return None
+
+
+async def require_any_capability(info: Info, capabilities) -> Optional[str]:
+    """Return None if the requester holds ANY of ``capabilities``, else an error message.
+
+    Authoritative DB-backed check (admin is an implicit super-user). Used where a
+    screen is reachable by more than one role, e.g. the Caja tab (manage_cash_session)
+    also needs to read its live corte (view_pos_reports).
+    """
+    user = getattr(info.context, "user", None)
+    if user is None:
+        return "Acceso no autorizado"
+
+    from app.crud.permissions import person_can
+
+    db = info.context.db
+    for capability in capabilities:
+        if await person_can(db, user, capability):
+            return None
+    return "No tienes permiso para realizar esta accion"

--- a/app/graphql/pos/__init__.py
+++ b/app/graphql/pos/__init__.py
@@ -1,0 +1,1 @@
+"""GraphQL API for the POS: cash sessions (caja), sales and reports."""

--- a/app/graphql/pos/mutations.py
+++ b/app/graphql/pos/mutations.py
@@ -1,0 +1,266 @@
+import logging
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud.permissions import MANAGE_CASH_SESSION, MANAGE_PRODUCTS, OPERATE_POS
+from app.crud.posCrud import (
+    SaleLineInput,
+    SalePaymentInput,
+    close_cash_session,
+    create_product,
+    create_sale,
+    open_cash_session,
+    record_cash_movement,
+    set_product_active,
+    update_product,
+    void_sale,
+)
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
+from app.graphql.pos.types import (
+    CashMovementInput,
+    CashMovementResponse,
+    CashMovementType,
+    CashSessionResponse,
+    CashSessionType,
+    CloseCashSessionInput,
+    CreateProductInput,
+    CreateSaleInput,
+    OpenCashSessionInput,
+    ProductMutationResponse,
+    ProductType,
+    SaleResponse,
+    SaleType,
+    UpdateProductInput,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@strawberry.type
+class PosMutation:
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def open_cash_session(self, info: Info, input: OpenCashSessionInput) -> CashSessionResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, MANAGE_CASH_SESSION)
+        if error:
+            return CashSessionResponse(success=False, session=None, message=error)
+        try:
+            account_id = getattr(info.context, "account_id", None)
+            session = await open_cash_session(
+                db,
+                opened_by=account_id,
+                opening_float=input.opening_float,
+                notes=input.notes,
+            )
+            return CashSessionResponse(
+                success=True,
+                session=CashSessionType.from_model(session),
+                message="Caja abierta exitosamente.",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return CashSessionResponse(success=False, session=None, message=str(e))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def close_cash_session(self, info: Info, input: CloseCashSessionInput) -> CashSessionResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, MANAGE_CASH_SESSION)
+        if error:
+            return CashSessionResponse(success=False, session=None, message=error)
+        try:
+            account_id = getattr(info.context, "account_id", None)
+            session = await close_cash_session(
+                db,
+                cash_session_id=input.cash_session_id,
+                counted_cash=input.counted_cash,
+                closed_by=account_id,
+                notes=input.notes,
+            )
+            return CashSessionResponse(
+                success=True,
+                session=CashSessionType.from_model(session),
+                message="Corte de caja realizado exitosamente.",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return CashSessionResponse(success=False, session=None, message=str(e))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def record_cash_movement(self, info: Info, input: CashMovementInput) -> CashMovementResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, MANAGE_CASH_SESSION)
+        if error:
+            return CashMovementResponse(success=False, movement=None, message=error)
+        try:
+            account_id = getattr(info.context, "account_id", None)
+            movement = await record_cash_movement(
+                db,
+                cash_session_id=input.cash_session_id,
+                direction=input.direction,
+                amount=input.amount,
+                reason=input.reason,
+                created_by=account_id,
+            )
+            return CashMovementResponse(
+                success=True,
+                movement=CashMovementType.from_model(movement),
+                message="Movimiento registrado exitosamente.",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return CashMovementResponse(success=False, movement=None, message=str(e))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def create_sale(self, info: Info, input: CreateSaleInput) -> SaleResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, OPERATE_POS)
+        if error:
+            return SaleResponse(success=False, sale=None, message=error)
+        try:
+            account_id = getattr(info.context, "account_id", None)
+            line_items = [
+                SaleLineInput(
+                    line_type=li.line_type,
+                    description=li.description or "",
+                    quantity=li.quantity or 1,
+                    unit_price=li.unit_price,
+                    discount=li.discount or 0,
+                    plan_id=li.plan_id,
+                    member_id=li.member_id,
+                    full_name=li.full_name,
+                    email=li.email,
+                    phone_number=li.phone_number,
+                    start_at=li.start_at,
+                    template_id=li.template_id,
+                    seat_id=li.seat_id,
+                    product_id=li.product_id,
+                )
+                for li in input.line_items
+            ]
+            tenders = [
+                SalePaymentInput(
+                    method=p.method,
+                    amount=p.amount,
+                    provider=p.provider,
+                    provider_payment_id=p.provider_payment_id,
+                    external_reference=p.external_reference,
+                )
+                for p in input.payments
+            ]
+            sale = await create_sale(
+                db,
+                line_items=line_items,
+                tenders=tenders,
+                person_id=input.person_id,
+                sold_by=account_id,
+                note=input.note,
+            )
+            return SaleResponse(
+                success=True,
+                sale=SaleType.from_model(sale),
+                message="Venta registrada exitosamente.",
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.error("Error creating sale: %s", e, exc_info=True)
+            await db.rollback()
+            return SaleResponse(success=False, sale=None, message=str(e))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def create_product(self, info: Info, input: CreateProductInput) -> ProductMutationResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, MANAGE_PRODUCTS)
+        if error:
+            return ProductMutationResponse(success=False, product=None, message=error)
+        try:
+            product = await create_product(
+                db,
+                name=input.name,
+                price=input.price,
+                sku=input.sku,
+                track_stock=input.track_stock,
+                stock_qty=input.stock_qty,
+                is_active=input.is_active,
+            )
+            return ProductMutationResponse(
+                success=True,
+                product=ProductType.from_model(product),
+                message="Producto creado exitosamente.",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return ProductMutationResponse(success=False, product=None, message=str(e))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def update_product(self, info: Info, input: UpdateProductInput) -> ProductMutationResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, MANAGE_PRODUCTS)
+        if error:
+            return ProductMutationResponse(success=False, product=None, message=error)
+
+        _UNSET = object()
+
+        def _opt(value):
+            return value if value is not None else _UNSET
+
+        try:
+            product = await update_product(
+                db,
+                input.product_id,
+                name=_opt(input.name),
+                price=_opt(input.price),
+                sku=_opt(input.sku),
+                track_stock=_opt(input.track_stock),
+                stock_qty=_opt(input.stock_qty),
+                is_active=_opt(input.is_active),
+            )
+            if product is None:
+                return ProductMutationResponse(success=False, product=None, message="Producto no encontrado.")
+            return ProductMutationResponse(
+                success=True,
+                product=ProductType.from_model(product),
+                message="Producto actualizado exitosamente.",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return ProductMutationResponse(success=False, product=None, message=str(e))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def set_product_active(self, info: Info, product_id: int, is_active: bool) -> ProductMutationResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, MANAGE_PRODUCTS)
+        if error:
+            return ProductMutationResponse(success=False, product=None, message=error)
+        try:
+            product = await set_product_active(db, product_id, is_active)
+            if product is None:
+                return ProductMutationResponse(success=False, product=None, message="Producto no encontrado.")
+            action = "reactivado" if is_active else "desactivado"
+            return ProductMutationResponse(
+                success=True,
+                product=ProductType.from_model(product),
+                message=f"Producto {action} exitosamente.",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return ProductMutationResponse(success=False, product=None, message=str(e))
+
+    @strawberry.mutation(permission_classes=[IsAuthenticated])
+    async def void_sale(self, info: Info, sale_id: int) -> SaleResponse:
+        db: AsyncSession = info.context.db
+        error = await require_capability(info, OPERATE_POS)
+        if error:
+            return SaleResponse(success=False, sale=None, message=error)
+        try:
+            sale = await void_sale(db, sale_id)
+            if sale is None:
+                return SaleResponse(success=False, sale=None, message="Venta no encontrada.")
+            return SaleResponse(
+                success=True,
+                sale=SaleType.from_model(sale),
+                message="Venta anulada.",
+            )
+        except Exception as e:  # noqa: BLE001
+            await db.rollback()
+            return SaleResponse(success=False, sale=None, message=str(e))

--- a/app/graphql/pos/queries.py
+++ b/app/graphql/pos/queries.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from typing import List, Optional
+
+import strawberry
+from sqlalchemy.ext.asyncio import AsyncSession
+from strawberry.types import Info
+
+from app.crud.permissions import (
+    MANAGE_CASH_SESSION,
+    MANAGE_PRODUCTS,
+    OPERATE_POS,
+    VIEW_POS_REPORTS,
+)
+from app.crud.posCrud import (
+    get_cash_session_report,
+    get_open_cash_session,
+    get_products,
+    get_sale,
+    get_sales,
+)
+from app.graphql.auth.permissions import IsAuthenticated, require_any_capability
+
+# Anyone who runs the checkout, manages the caja or reads reports may see the
+# open caja / its live corte; the writes (open/close/movement) stay gated on
+# manage_cash_session in the mutations.
+_CAJA_VIEW_CAPS = [MANAGE_CASH_SESSION, OPERATE_POS, VIEW_POS_REPORTS]
+from app.graphql.pos.types import (
+    CashSessionReportType,
+    CashSessionType,
+    ProductType,
+    SaleType,
+)
+
+
+@strawberry.type
+class PosQuery:
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def open_cash_session(self, info: Info) -> Optional[CashSessionType]:
+        """The currently-open caja, or null."""
+        db: AsyncSession = info.context.db
+        if await require_any_capability(info, _CAJA_VIEW_CAPS):
+            return None
+        session = await get_open_cash_session(db)
+        return CashSessionType.from_model(session) if session else None
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def cash_session_report(self, info: Info, cash_session_id: int) -> Optional[CashSessionReportType]:
+        """Corte de caja report for a session (works live for an open caja)."""
+        db: AsyncSession = info.context.db
+        if await require_any_capability(info, _CAJA_VIEW_CAPS):
+            return None
+        data = await get_cash_session_report(db, cash_session_id)
+        return CashSessionReportType.from_data(data) if data else None
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def sales(
+        self,
+        info: Info,
+        limit: int = 100,
+        offset: int = 0,
+        cash_session_id: Optional[int] = None,
+        status: Optional[str] = None,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+    ) -> List[SaleType]:
+        db: AsyncSession = info.context.db
+        if await require_any_capability(info, [OPERATE_POS, VIEW_POS_REPORTS]):
+            return []
+        rows = await get_sales(
+            db,
+            limit=limit,
+            offset=offset,
+            cash_session_id=cash_session_id,
+            status=status,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        return [SaleType.from_model(s) for s in rows]
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def sale(self, info: Info, sale_id: int) -> Optional[SaleType]:
+        db: AsyncSession = info.context.db
+        if await require_any_capability(info, [OPERATE_POS, VIEW_POS_REPORTS]):
+            return None
+        s = await get_sale(db, sale_id)
+        return SaleType.from_model(s) if s else None
+
+    @strawberry.field(permission_classes=[IsAuthenticated])
+    async def products(
+        self, info: Info, include_inactive: bool = False, search: Optional[str] = None
+    ) -> List[ProductType]:
+        """Product catalog. Readable by POS operators and by catalog managers."""
+        db: AsyncSession = info.context.db
+        if await require_any_capability(info, [OPERATE_POS, MANAGE_PRODUCTS]):
+            return []
+        rows = await get_products(db, include_inactive=include_inactive, search=search)
+        return [ProductType.from_model(p) for p in rows]

--- a/app/graphql/pos/types.py
+++ b/app/graphql/pos/types.py
@@ -1,0 +1,344 @@
+from datetime import datetime
+from typing import List, Optional
+
+import strawberry
+
+from app.models.posModel import (
+    CashMovement as CashMovementModel,
+    CashSession as CashSessionModel,
+    Product as ProductModel,
+    Sale as SaleModel,
+    SaleLineItem as SaleLineItemModel,
+    SalePayment as SalePaymentModel,
+)
+
+
+@strawberry.type
+class ProductType:
+    id: int
+    name: str
+    sku: Optional[str]
+    price: float
+    track_stock: bool
+    stock_qty: Optional[int]
+    is_active: bool
+
+    @classmethod
+    def from_model(cls, p: ProductModel) -> "ProductType":
+        return cls(
+            id=p.id,
+            name=p.name,
+            sku=p.sku,
+            price=float(p.price or 0),
+            track_stock=bool(p.track_stock),
+            stock_qty=p.stock_qty,
+            is_active=bool(p.is_active),
+        )
+
+
+@strawberry.input
+class CreateProductInput:
+    name: str
+    price: float
+    sku: Optional[str] = None
+    track_stock: bool = False
+    stock_qty: Optional[int] = None
+    is_active: bool = True
+
+
+@strawberry.input
+class UpdateProductInput:
+    product_id: int
+    name: Optional[str] = None
+    price: Optional[float] = None
+    sku: Optional[str] = None
+    track_stock: Optional[bool] = None
+    stock_qty: Optional[int] = None
+    is_active: Optional[bool] = None
+
+
+@strawberry.type
+class ProductMutationResponse:
+    success: bool
+    product: Optional["ProductType"]
+    message: str
+
+
+@strawberry.type
+class CashSessionType:
+    id: int
+    opened_by: Optional[int]
+    opened_at: datetime
+    opening_float: float
+    closed_by: Optional[int]
+    closed_at: Optional[datetime]
+    status: str
+    expected_cash: Optional[float]
+    counted_cash: Optional[float]
+    difference: Optional[float]
+    notes: Optional[str]
+
+    @classmethod
+    def from_model(cls, s: CashSessionModel) -> "CashSessionType":
+        return cls(
+            id=s.id,
+            opened_by=s.opened_by,
+            opened_at=s.opened_at,
+            opening_float=float(s.opening_float or 0),
+            closed_by=s.closed_by,
+            closed_at=s.closed_at,
+            status=s.status,
+            expected_cash=float(s.expected_cash) if s.expected_cash is not None else None,
+            counted_cash=float(s.counted_cash) if s.counted_cash is not None else None,
+            difference=float(s.difference) if s.difference is not None else None,
+            notes=s.notes,
+        )
+
+
+@strawberry.type
+class CashMovementType:
+    id: int
+    cash_session_id: int
+    direction: str
+    amount: float
+    reason: Optional[str]
+    created_at: datetime
+
+    @classmethod
+    def from_model(cls, m: CashMovementModel) -> "CashMovementType":
+        return cls(
+            id=m.id,
+            cash_session_id=m.cash_session_id,
+            direction=m.direction,
+            amount=float(m.amount or 0),
+            reason=m.reason,
+            created_at=m.created_at,
+        )
+
+
+@strawberry.type
+class SaleLineItemType:
+    id: int
+    line_type: str
+    description: str
+    quantity: int
+    unit_price: float
+    discount: float
+    line_total: float
+    plan_id: Optional[int]
+    product_id: Optional[int]
+    subscription_id: Optional[int]
+    payment_id: Optional[int]
+
+    @classmethod
+    def from_model(cls, li: SaleLineItemModel) -> "SaleLineItemType":
+        return cls(
+            id=li.id,
+            line_type=li.line_type,
+            description=li.description,
+            quantity=li.quantity,
+            unit_price=float(li.unit_price or 0),
+            discount=float(li.discount or 0),
+            line_total=float(li.line_total or 0),
+            plan_id=li.plan_id,
+            product_id=li.product_id,
+            subscription_id=li.subscription_id,
+            payment_id=li.payment_id,
+        )
+
+
+@strawberry.type
+class SalePaymentType:
+    id: int
+    amount: float
+    method: str
+    payment_id: Optional[int]
+    created_at: datetime
+
+    @classmethod
+    def from_model(cls, sp: SalePaymentModel) -> "SalePaymentType":
+        return cls(
+            id=sp.id,
+            amount=float(sp.amount or 0),
+            method=sp.method,
+            payment_id=sp.payment_id,
+            created_at=sp.created_at,
+        )
+
+
+@strawberry.type
+class SaleType:
+    id: int
+    person_id: Optional[int]
+    person_name: Optional[str]
+    cash_session_id: Optional[int]
+    status: str
+    subtotal: float
+    discount_total: float
+    tax_total: float
+    total: float
+    amount_paid: float
+    change_due: float
+    note: Optional[str]
+    sold_by: Optional[int]
+    created_at: datetime
+    completed_at: Optional[datetime]
+    line_items: List[SaleLineItemType]
+    payments: List[SalePaymentType]
+
+    @classmethod
+    def from_model(cls, sale: SaleModel) -> "SaleType":
+        person_name = None
+        if "person" in sale.__dict__ and sale.person is not None:
+            person_name = sale.person.full_name
+        total = float(sale.total or 0)
+        paid = float(sale.amount_paid or 0)
+        return cls(
+            id=sale.id,
+            person_id=sale.person_id,
+            person_name=person_name,
+            cash_session_id=sale.cash_session_id,
+            status=sale.status,
+            subtotal=float(sale.subtotal or 0),
+            discount_total=float(sale.discount_total or 0),
+            tax_total=float(sale.tax_total or 0),
+            total=total,
+            amount_paid=paid,
+            change_due=max(paid - total, 0.0),
+            note=sale.note,
+            sold_by=sale.sold_by,
+            created_at=sale.created_at,
+            completed_at=sale.completed_at,
+            line_items=[SaleLineItemType.from_model(li) for li in (sale.line_items or [])],
+            payments=[SalePaymentType.from_model(sp) for sp in (sale.sale_payments or [])],
+        )
+
+
+@strawberry.type
+class MethodTotalType:
+    method: str
+    count: int
+    total: float
+
+
+@strawberry.type
+class CashSessionReportType:
+    session_id: int
+    status: str
+    opened_by: Optional[int]
+    opened_at: datetime
+    closed_at: Optional[datetime]
+    opening_float: float
+    sales_count: int
+    sales_total: float
+    cash_in: float
+    cash_out: float
+    cash_sales_total: float
+    computed_expected_cash: float
+    expected_cash: Optional[float]
+    counted_cash: Optional[float]
+    difference: Optional[float]
+    by_method: List[MethodTotalType]
+
+    @classmethod
+    def from_data(cls, d) -> "CashSessionReportType":
+        return cls(
+            session_id=d.session_id,
+            status=d.status,
+            opened_by=d.opened_by,
+            opened_at=d.opened_at,
+            closed_at=d.closed_at,
+            opening_float=d.opening_float,
+            sales_count=d.sales_count,
+            sales_total=d.sales_total,
+            cash_in=d.cash_in,
+            cash_out=d.cash_out,
+            cash_sales_total=d.cash_sales_total,
+            computed_expected_cash=d.computed_expected_cash,
+            expected_cash=d.expected_cash,
+            counted_cash=d.counted_cash,
+            difference=d.difference,
+            by_method=[
+                MethodTotalType(method=b.method, count=b.count, total=b.total)
+                for b in d.by_method
+            ],
+        )
+
+
+# ---------------------------------------------------------------- inputs ----
+@strawberry.input
+class SaleLineInputType:
+    line_type: str  # membership_new | membership_renewal | product | manual
+    description: Optional[str] = None
+    quantity: int = 1
+    unit_price: Optional[float] = None
+    discount: Optional[float] = 0
+    plan_id: Optional[int] = None
+    member_id: Optional[int] = None
+    full_name: Optional[str] = None
+    email: Optional[str] = None
+    phone_number: Optional[str] = None
+    start_at: Optional[datetime] = None
+    template_id: Optional[int] = None
+    seat_id: Optional[int] = None
+    product_id: Optional[int] = None
+
+
+@strawberry.input
+class SalePaymentInputType:
+    method: str
+    amount: float
+    provider: Optional[str] = None
+    provider_payment_id: Optional[str] = None
+    external_reference: Optional[str] = None
+
+
+@strawberry.input
+class CreateSaleInput:
+    line_items: List[SaleLineInputType]
+    payments: List[SalePaymentInputType]
+    person_id: Optional[int] = None
+    note: Optional[str] = None
+
+
+@strawberry.input
+class OpenCashSessionInput:
+    opening_float: float = 0
+    notes: Optional[str] = None
+
+
+@strawberry.input
+class CloseCashSessionInput:
+    cash_session_id: int
+    counted_cash: float
+    notes: Optional[str] = None
+
+
+@strawberry.input
+class CashMovementInput:
+    cash_session_id: int
+    direction: str  # 'in' | 'out'
+    amount: float
+    reason: Optional[str] = None
+
+
+# ------------------------------------------------------------- responses ----
+@strawberry.type
+class SaleResponse:
+    success: bool
+    sale: Optional[SaleType]
+    message: str
+
+
+@strawberry.type
+class CashSessionResponse:
+    success: bool
+    session: Optional[CashSessionType]
+    message: str
+
+
+@strawberry.type
+class CashMovementResponse:
+    success: bool
+    movement: Optional[CashMovementType]
+    message: str

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -38,6 +38,8 @@ from app.graphql.permissions.queries import PermissionsQuery
 from app.graphql.permissions.mutations import PermissionsMutation
 from app.graphql.owner_agent.queries import OwnerAgentQuery
 from app.graphql.owner_agent.mutations import OwnerAgentMutation
+from app.graphql.pos.queries import PosQuery
+from app.graphql.pos.mutations import PosMutation
 
 logger = logging.getLogger(__name__)
 
@@ -60,13 +62,13 @@ except ImportError as e:
         pass
 
 @strawberry.type
-class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery, PermissionsQuery, OwnerAgentQuery):
+class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery, PermissionsQuery, OwnerAgentQuery, PosQuery):
     @strawberry.field
     def hello(self) -> str:
         return "Hello from GraphQL!"
 
 @strawberry.type
-class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation, OwnerAgentMutation):
+class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation, OwnerAgentMutation, PosMutation):
     pass
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -19,6 +19,9 @@ from app.models.whatsappModel import (
 from app.models.notificationModel import NotificationSetting, NotificationLog
 from app.models.chatbotModel import ChatbotConfig, ChatbotPendingAction
 from app.models.campaignsModel import Campaign, CampaignVariant, CampaignRecipient
+from app.models.posModel import (
+    Product, CashSession, CashMovement, Sale, SaleLineItem, SalePayment
+)
 from app.models.ownerAgentModel import (
     OwnerAgentConfig,
     OwnerAgentAuthorizedPhone,
@@ -40,6 +43,7 @@ __all__ = [
     "NotificationSetting", "NotificationLog",
     "ChatbotConfig", "ChatbotPendingAction",
     "Campaign", "CampaignVariant", "CampaignRecipient",
+    "Product", "CashSession", "CashMovement", "Sale", "SaleLineItem", "SalePayment",
     "OwnerAgentConfig", "OwnerAgentAuthorizedPhone", "OwnerAgentPendingAction",
     "OwnerAgentAuditLog", "OwnerTask",
 ]

--- a/app/models/membershipsModel.py
+++ b/app/models/membershipsModel.py
@@ -90,7 +90,8 @@ class Payment(Base):
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     subscription_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("membership_subscriptions.id"))
-    person_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("people.id"), nullable=False)
+    # Nullable since the POS can sell products to a walk-in customer (no member).
+    person_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("people.id"))
     amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
     paid_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     method: Mapped[str] = mapped_column(String(40), nullable=False)

--- a/app/models/posModel.py
+++ b/app/models/posModel.py
@@ -1,0 +1,207 @@
+"""Point-of-sale models for FitPilot.
+
+Layers a POS on top of the existing ``payments`` table without changing it:
+
+* ``cash_sessions``  — the shared cash register (caja): opened with a float,
+  closed with a counted amount for the *corte de caja*. A partial unique index
+  enforces at most one open caja at a time.
+* ``cash_movements`` — manual cash in/out (retiros / ingresos) against a caja.
+* ``sales``          — a POS ticket header (N line items, M tenders).
+* ``sale_line_items``— what was sold; membership lines carry the subscription_id
+  and payment_id produced by the reused enrollment/renewal CRUD.
+* ``sale_payments``  — the tender ledger (how the ticket was paid); drives the
+  corte de caja. ``payment_id`` is an optional back-reference, not unique, so a
+  single sale can be settled with several tenders.
+"""
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Optional, List, TYPE_CHECKING
+
+from sqlalchemy import (
+    ForeignKey, Integer, BigInteger, Numeric, String, Text, Boolean,
+    CheckConstraint, Index, JSON,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy import TIMESTAMP
+
+from app.db.postgresql import Base
+
+if TYPE_CHECKING:
+    from app.models.userModel import People
+
+
+class Product(Base):
+    """A POS catalog product (water, supplements, day-pass, etc.) with optional stock."""
+
+    __tablename__ = "products"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    sku: Mapped[Optional[str]] = mapped_column(String(40))
+    price: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    track_stock: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    stock_qty: Mapped[Optional[int]] = mapped_column(Integer)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+
+    __table_args__ = (
+        Index("uq_products_sku", "sku", unique=True, postgresql_where="sku IS NOT NULL"),
+        Index("idx_products_active", "is_active"),
+    )
+
+
+class CashSession(Base):
+    """A cash register (caja) session: opened with a float, closed with a count."""
+
+    __tablename__ = "cash_sessions"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    opened_by: Mapped[int] = mapped_column(BigInteger, ForeignKey("accounts.id"), nullable=False)
+    opened_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    opening_float: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    closed_by: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("accounts.id"))
+    closed_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+    status: Mapped[str] = mapped_column(String(10), nullable=False, default="open")
+    expected_cash: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 2))
+    counted_cash: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 2))
+    difference: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 2))
+    notes: Mapped[Optional[str]] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    movements: Mapped[List["CashMovement"]] = relationship(
+        back_populates="cash_session", cascade="all, delete-orphan"
+    )
+    sales: Mapped[List["Sale"]] = relationship(back_populates="cash_session")
+
+    __table_args__ = (
+        CheckConstraint("status IN ('open','closed')", name="ck_cash_session_status"),
+        # At most one open caja across the whole gym (shared register model).
+        Index(
+            "uq_cash_session_single_open",
+            "status",
+            unique=True,
+            postgresql_where="status = 'open'",
+        ),
+        Index("idx_cash_session_opened_at", "opened_at"),
+    )
+
+
+class CashMovement(Base):
+    """Manual cash movement (retiro / ingreso) against an open caja."""
+
+    __tablename__ = "cash_movements"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    cash_session_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("cash_sessions.id", ondelete="CASCADE"), nullable=False
+    )
+    direction: Mapped[str] = mapped_column(String(3), nullable=False)  # 'in' | 'out'
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    reason: Mapped[Optional[str]] = mapped_column(String(200))
+    created_by: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("accounts.id"))
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    cash_session: Mapped["CashSession"] = relationship(back_populates="movements")
+
+    __table_args__ = (
+        CheckConstraint("direction IN ('in','out')", name="ck_cash_movement_direction"),
+        Index("idx_cash_movement_session", "cash_session_id"),
+    )
+
+
+class Sale(Base):
+    """A POS ticket: one header, N line items, M tenders."""
+
+    __tablename__ = "sales"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    person_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("people.id"))
+    cash_session_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("cash_sessions.id"))
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="completed")
+    subtotal: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    discount_total: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    tax_total: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    total: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    amount_paid: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    note: Mapped[Optional[str]] = mapped_column(Text)
+    sold_by: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("accounts.id"))
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    completed_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True))
+
+    person: Mapped[Optional["People"]] = relationship()
+    cash_session: Mapped[Optional["CashSession"]] = relationship(back_populates="sales")
+    line_items: Mapped[List["SaleLineItem"]] = relationship(
+        back_populates="sale", cascade="all, delete-orphan"
+    )
+    sale_payments: Mapped[List["SalePayment"]] = relationship(
+        back_populates="sale", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('open','completed','voided','refunded')", name="ck_sale_status"
+        ),
+        Index("idx_sales_cash_session_status", "cash_session_id", "status"),
+        Index("idx_sales_sold_by_created", "sold_by", "created_at"),
+    )
+
+
+class SaleLineItem(Base):
+    """A single line of a POS ticket (membership, product or manual charge)."""
+
+    __tablename__ = "sale_line_items"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    sale_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("sales.id", ondelete="CASCADE"), nullable=False
+    )
+    # 'membership_new' | 'membership_renewal' | 'product' | 'manual'
+    line_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    description: Mapped[str] = mapped_column(String(200), nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    unit_price: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    discount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    line_total: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False, default=Decimal("0"))
+    plan_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("membership_plans.id"))
+    # product_id gains a FK to products in the Phase 2 migration.
+    product_id: Mapped[Optional[int]] = mapped_column(BigInteger)
+    subscription_id: Mapped[Optional[int]] = mapped_column(
+        BigInteger, ForeignKey("membership_subscriptions.id")
+    )
+    payment_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("payments.id"))
+    meta: Mapped[Optional[dict]] = mapped_column(JSON)
+
+    sale: Mapped["Sale"] = relationship(back_populates="line_items")
+
+    __table_args__ = (
+        CheckConstraint(
+            "line_type IN ('membership_new','membership_renewal','product','manual')",
+            name="ck_sale_line_type",
+        ),
+        Index("idx_sale_line_items_sale", "sale_id"),
+    )
+
+
+class SalePayment(Base):
+    """Tender ledger row: how (part of) a ticket was paid. Drives the corte de caja."""
+
+    __tablename__ = "sale_payments"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    sale_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("sales.id", ondelete="CASCADE"), nullable=False
+    )
+    # Optional back-reference to a payments row (not unique: split tenders may
+    # share the same membership anchor payment).
+    payment_id: Mapped[Optional[int]] = mapped_column(BigInteger, ForeignKey("payments.id"))
+    amount: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
+    method: Mapped[str] = mapped_column(String(40), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    sale: Mapped["Sale"] = relationship(back_populates="sale_payments")
+
+    __table_args__ = (
+        Index("idx_sale_payment_sale", "sale_id"),
+        Index("idx_sale_payment_method", "method"),
+    )


### PR DESCRIPTION
## POS + Caja + Productos (backend)

Agrega un punto de venta **sobre** el flujo de suscripción/renovación existente, sin modificarlo (wrap, don't duplicate).

### Qué incluye
- **Ventas**: `sales`, `sale_line_items`, `sale_payments` (libro de cobros → pago dividido).
- **Caja**: `cash_sessions` (una abierta a la vez), `cash_movements`; **corte de caja** = fondo + efectivo + ingresos − retiros (el cambio en efectivo se asienta neto al cajón para que el corte cuadre).
- **Seam de reúso**: `create_sale` llama a `create_member_enrollment_with_standing_booking` / `renew_subscription_with_standing_booking` con un nuevo flag `commit=False` → suscripción + pago + standing bookings se comportan igual que hoy y todo el ticket commitea una sola vez. `commit=True` por defecto deja intactos los callers existentes.
- **Productos/inventario**; `payments.person_id` ahora nullable (venta de mostrador).
- **Capacidades**: `operate_pos`, `manage_cash_session`, `view_pos_reports`, `manage_products`; las lecturas usan `require_any_capability` para que cada pantalla funcione para su rol.
- **Migraciones**: `a1b2c3d4e5f7` (caja/ventas + seed de capacidades) → `b2c3d4e5f6a8` (productos + person_id nullable).

### Deploy
- `alembic upgrade head`.

### Verificación
- El schema de Strawberry construye; todos los módulos compilan.
- Revisión adversaria multi-agente previa al merge: 6 hallazgos corregidos en esta rama (gates de capacidad, exactitud del corte ante cambio en efectivo, carrera al recargar el reporte tras un movimiento).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
