### PR TITLE
feat(members): exponer seat_id actual en activeStandingBooking

### DIFF
--- a/app/crud/membersCrud.py
+++ b/app/crud/membersCrud.py
@@ -28,6 +28,7 @@ class StandingBookingInfo:
     start_time_local: str
     venue_name: Optional[str]
     instructor_name: Optional[str]
+    seat_id: Optional[int] = None
 
 
 @dataclass
@@ -97,7 +98,8 @@ def _build_member_data(person: People) -> MemberData:
                 weekday=getattr(template, 'weekday', 0),
                 start_time_local=str(getattr(template, 'start_time_local', '')),
                 venue_name=getattr(venue, 'name', None) if venue else None,
-                instructor_name=getattr(instructor, 'full_name', None) if instructor else None
+                instructor_name=getattr(instructor, 'full_name', None) if instructor else None,
+                seat_id=getattr(display_sb, 'seat_id', None),
             )
 
     if person.subscriptions:

--- a/app/graphql/members/types.py
+++ b/app/graphql/members/types.py
@@ -15,6 +15,7 @@ class ActiveStandingBooking:
     start_time_local: str
     venue_name: Optional[str]
     instructor_name: Optional[str]
+    seat_id: Optional[int] = None
 
     @classmethod
     def from_info(cls, info: Optional[StandingBookingInfo]) -> Optional["ActiveStandingBooking"]:
@@ -28,7 +29,8 @@ class ActiveStandingBooking:
             weekday=info.weekday,
             start_time_local=info.start_time_local,
             venue_name=info.venue_name,
-            instructor_name=info.instructor_name
+            instructor_name=info.instructor_name,
+            seat_id=info.seat_id,
         )
 
 


### PR DESCRIPTION
## Exponer el asiento actual del socio (backend)

Habilita que el POS pre-seleccione el **asiento actual** del socio al renovar (acompaña al PR de frontend con `PosRenewalLineDialog`).

- `StandingBookingInfo` (en `crud/membersCrud.py`) ahora lleva `seat_id`, tomado de la fila `StandingBooking` (`display_sb.seat_id`, columna ya cargada).
- El tipo GraphQL `ActiveStandingBooking` (`graphql/members/types.py`) expone `seatId`.

**Aditivo**: sin migración, sin cambios de resolver, retrocompatible (campo opcional). El pipeline del POS ya transportaba `template_id`/`seat_id` de extremo a extremo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
