### PR TITLE
fix(reservas): reasignar bici disponible antes de reembolsar (chatbot/MercadoPago)

### DIFF
--- a/app/crud/memberships/standing_bookings.py
+++ b/app/crud/memberships/standing_bookings.py
@@ -9,7 +9,10 @@ from app.models import MembershipPlan, MembershipSubscription
 from app.models.classModel import ClassTemplate
 
 from app.crud.standing_bookings.materialization import _init_materialization_stats
-from app.crud.standing_bookings.utils import _get_templates_in_same_group as _get_templates_in_same_group_core
+from app.crud.standing_bookings.utils import (
+    _get_templates_in_same_group as _get_templates_in_same_group_core,
+    _resolve_group_seat,
+)
 from .utils import _align_date_to_weekday, _calculate_window_end_for_plan
 
 
@@ -47,21 +50,27 @@ async def _create_standing_bookings_for_group(
     subscription: MembershipSubscription,
     template_id: int,
     seat_id: Optional[int] = None,
-) -> Tuple[List[int], List[int], Dict[int, date]]:
-    """Create standing bookings for ALL templates in the same TimeslotGroup."""
+) -> Tuple[List[int], List[int], Dict[int, date], Optional[str]]:
+    """Create standing bookings for ALL templates in the same TimeslotGroup.
+
+    Before creating them, resolve the seat group-wide: if the preferred seat is taken on any
+    session of any group template across the membership window, auto-reassign to another free
+    bike so a paid booking succeeds instead of failing (and refunding). Returns the assigned
+    seat's label (for the customer-facing confirmation) as the 4th element.
+    """
     import logging
 
     logger = logging.getLogger(__name__)
 
     if not STANDING_BOOKINGS_AVAILABLE:
         logger.warning("Standing bookings not available, skipping group creation")
-        return [], [], {}
+        return [], [], {}, None
 
     templates = await _get_templates_in_same_group(db, template_id)
 
     if not templates:
         logger.warning("No templates found for group with template_id %s", template_id)
-        return [], [], {}
+        return [], [], {}, None
 
     logger.info(
         "Creating %s standing bookings for group (templates: %s)",
@@ -71,6 +80,25 @@ async def _create_standing_bookings_for_group(
 
     membership_start = subscription.start_at.date()
     membership_end = subscription.end_at.date()
+
+    # Resolve the seat across the WHOLE group/window so an occupied bike is swapped for a free
+    # one (instead of every per-template create raising "Seat already reserved" -> refund).
+    resolved_seat_id, assigned_seat_label = await _resolve_group_seat(
+        db,
+        templates,
+        membership_start,
+        membership_end,
+        subscription.person_id,
+        seat_id,
+    )
+    if seat_id is not None and resolved_seat_id != seat_id:
+        logger.info(
+            "Preferred seat %s taken across group; reassigned to %s (%s)",
+            seat_id,
+            resolved_seat_id,
+            assigned_seat_label,
+        )
+    seat_id = resolved_seat_id
 
     standing_booking_ids: List[int] = []
     template_ids_used: List[int] = []
@@ -124,7 +152,7 @@ async def _create_standing_bookings_for_group(
         len(standing_booking_ids),
         template_ids_used,
     )
-    return standing_booking_ids, template_ids_used, template_start_dates
+    return standing_booking_ids, template_ids_used, template_start_dates, assigned_seat_label
 
 
 async def _generate_sessions_for_templates(
@@ -327,11 +355,13 @@ async def _handle_fixed_timeslot_effects(
     generation_stats: dict = {"sessions_created": 0}
 
     # Create standing bookings for the whole TimeslotGroup
-    standing_booking_ids, template_ids_used, template_start_dates = await _create_standing_bookings_for_group(
-        db=db,
-        subscription=subscription,
-        template_id=template_id,
-        seat_id=seat_id,
+    standing_booking_ids, template_ids_used, template_start_dates, assigned_seat_label = (
+        await _create_standing_bookings_for_group(
+            db=db,
+            subscription=subscription,
+            template_id=template_id,
+            seat_id=seat_id,
+        )
     )
     primary_id = standing_booking_ids[0] if standing_booking_ids else None
 
@@ -376,6 +406,7 @@ async def _handle_fixed_timeslot_effects(
     # Attach aggregation info
     materialization_stats["generation_stats"] = generation_stats
     materialization_stats["standing_booking_ids"] = standing_booking_ids
+    materialization_stats["assigned_seat_label"] = assigned_seat_label
     materialization_stats["aligned_start_dates"] = template_start_dates_iso
     materialization_stats["window"] = {
         "start": window_start.isoformat(),

--- a/app/crud/standing_bookings/utils.py
+++ b/app/crud/standing_bookings/utils.py
@@ -186,3 +186,71 @@ async def _resolve_seat_for_session(
             return seat_item.id, "Preferred seat taken, auto-selected another"
 
     return None, "No seats available for target session"
+
+
+async def _resolve_group_seat(
+    db: AsyncSession,
+    templates: List[ClassTemplate],
+    window_start: date,
+    window_end: date,
+    person_id: int,
+    preferred_seat_id: Optional[int],
+) -> tuple[Optional[int], Optional[str]]:
+    """Pick a seat free across ALL templates of a timeslot group for the whole window.
+
+    A fixed-slot package reserves the SAME seat for every template in the group (e.g. Mon-Fri at
+    8pm) across the entire membership period, so the seat must be free for every session of every
+    group template in ``[window_start, window_end]`` -- mirroring the per-template check in
+    ``create_standing_booking`` (bookings.py).
+
+    Returns ``(seat_id, label)``:
+    - keeps ``preferred_seat_id`` when it is free across the whole group/window (so a renewal
+      preserves the member's existing bike);
+    - otherwise returns the first free seat by label (auto-reassign to another available bike);
+    - returns ``(preferred_seat_id, None)`` when NO seat is free, so the caller's existing
+      failure/refund path still applies (genuinely full class);
+    - returns ``(None, None)`` when the venue has no seats (capacity-based class).
+    """
+    if not templates:
+        return preferred_seat_id, None
+
+    venue_id = templates[0].venue_id
+
+    seats_stmt = (
+        select(Seat)
+        .where(and_(Seat.venue_id == venue_id, Seat.is_active == True))
+        .order_by(Seat.label)
+    )
+    seats = (await db.execute(seats_stmt)).scalars().all()
+    if not seats:
+        return None, None
+
+    template_ids = [t.id for t in templates]
+    taken_stmt = (
+        select(Reservation.seat_id)
+        .join(ClassSession, Reservation.session_id == ClassSession.id)
+        .where(
+            and_(
+                ClassSession.template_id.in_(template_ids),
+                func.date(ClassSession.start_at) >= window_start,
+                func.date(ClassSession.start_at) <= window_end,
+                Reservation.seat_id.isnot(None),
+                Reservation.status.in_(["reserved", "checked_in"]),
+                Reservation.person_id != person_id,
+            )
+        )
+        .distinct()
+    )
+    taken_ids = {seat_id for (seat_id,) in (await db.execute(taken_stmt)).all()}
+
+    free_seats = [s for s in seats if s.id not in taken_ids]
+    if not free_seats:
+        return preferred_seat_id, None
+
+    if preferred_seat_id is not None:
+        kept = next((s for s in free_seats if s.id == preferred_seat_id), None)
+        if kept is not None:
+            return kept.id, kept.label
+
+    chosen = free_seats[0]
+    return chosen.id, chosen.label

--- a/app/services/chatbot/tools.py
+++ b/app/services/chatbot/tools.py
@@ -433,6 +433,13 @@ def _materialized_count(stats) -> str:
     return f" Reservé {created} clase(s) de tu horario." if created else ""
 
 
+def _assigned_seat_note(stats) -> str:
+    """Tell the customer which bike was assigned (it may differ from the one first offered if it
+    got taken before the payment acreditó and we auto-reassigned a free one)."""
+    label = stats.get("assigned_seat_label") if isinstance(stats, dict) else None
+    return f" Tu lugar asignado: {label}." if label else ""
+
+
 async def _execute_pending(
     db: AsyncSession,
     pending,
@@ -477,7 +484,7 @@ async def _execute_pending(
                 )
             )
             return (f"¡Listo! Membresía {plan.name} activada. Vence {_fmt_dt(subscription.end_at)}."
-                    f"{_materialized_count(stats)}")
+                    f"{_materialized_count(stats)}{_assigned_seat_note(stats)}")
         # New customer -> enrollment with standing booking (commits internally).
         person, subscription, _payment, plan, _sb, stats = (
             await enrollment_crud.create_member_enrollment_with_standing_booking(
@@ -497,7 +504,8 @@ async def _execute_pending(
             )
         )
         return (f"¡Bienvenido/a {person.full_name}! Inscripción lista con {plan.name}. "
-                f"Vence {_fmt_dt(subscription.end_at)}.{_materialized_count(stats)}")
+                f"Vence {_fmt_dt(subscription.end_at)}.{_materialized_count(stats)}"
+                f"{_assigned_seat_note(stats)}")
 
     if action == ACTION_BUY_DAY_PASS:
         plan_id = int(payload["plan_id"])

--- a/tests/test_resolve_group_seat.py
+++ b/tests/test_resolve_group_seat.py
@@ -1,0 +1,82 @@
+"""Unit tests for the group-wide seat resolver.
+
+``_resolve_group_seat`` is the crux of the "reassign an available bike before refunding" fix:
+a fixed-slot package reserves the SAME seat for every template of a timeslot group across the
+whole membership window, so the seat must be free everywhere. When the preferred bike is taken,
+the resolver must auto-pick another free one instead of letting ``create_standing_booking`` raise
+"Seat already reserved" -> 0 bookings -> refund.
+
+DB-free: a fake AsyncSession returns the two query results the resolver consumes (the active seats
+for the venue, then the seat_ids already taken across the group/window). The local test DB is not
+available in every environment and the seat-selection decision is the part worth pinning down.
+"""
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+from app.crud.standing_bookings.utils import _resolve_group_seat
+
+_START = datetime.date(2026, 6, 1)
+_END = datetime.date(2026, 6, 30)
+_PERSON = 389
+
+
+def _seat(seat_id: int, label: str):
+    s = MagicMock()
+    s.id = seat_id
+    s.label = label
+    return s
+
+
+def _template(template_id: int, venue_id: int = 20):
+    t = MagicMock()
+    t.id = template_id
+    t.venue_id = venue_id
+    return t
+
+
+_GROUP = [_template(t) for t in (10, 15, 20, 25, 30)]
+
+
+def _db(seats, taken_ids):
+    """First execute() -> active venue seats; second -> rows of (seat_id,) already taken."""
+    db = AsyncMock()
+    seats_res = MagicMock()
+    seats_res.scalars.return_value.all.return_value = seats
+    taken_res = MagicMock()
+    taken_res.all.return_value = [(sid,) for sid in taken_ids]
+    db.execute = AsyncMock(side_effect=[seats_res, taken_res])
+    return db
+
+
+async def test_keeps_preferred_seat_when_free():
+    db = _db([_seat(7, "B07"), _seat(13, "B13")], taken_ids=set())
+    seat_id, label = await _resolve_group_seat(db, _GROUP, _START, _END, _PERSON, preferred_seat_id=13)
+    assert (seat_id, label) == (13, "B13")
+
+
+async def test_reassigns_when_preferred_seat_taken():
+    # Seat 13 is taken somewhere in the group/window -> swap to the first free bike (B07).
+    db = _db([_seat(7, "B07"), _seat(13, "B13")], taken_ids={13})
+    seat_id, label = await _resolve_group_seat(db, _GROUP, _START, _END, _PERSON, preferred_seat_id=13)
+    assert (seat_id, label) == (7, "B07")
+
+
+async def test_auto_assigns_when_no_preferred_seat():
+    db = _db([_seat(7, "B07"), _seat(13, "B13")], taken_ids={7})
+    seat_id, label = await _resolve_group_seat(db, _GROUP, _START, _END, _PERSON, preferred_seat_id=None)
+    assert (seat_id, label) == (13, "B13")
+
+
+async def test_keeps_preferred_when_all_taken_so_refund_path_applies():
+    # Genuinely full: every bike taken -> return the preferred id unchanged (no label) so the
+    # caller's existing "Seat already reserved" -> refund path still triggers.
+    db = _db([_seat(7, "B07"), _seat(13, "B13")], taken_ids={7, 13})
+    seat_id, label = await _resolve_group_seat(db, _GROUP, _START, _END, _PERSON, preferred_seat_id=13)
+    assert (seat_id, label) == (13, None)
+
+
+async def test_seatless_venue_returns_none():
+    # Venue defines no seats -> capacity-based booking, no seat to assign.
+    db = _db([], taken_ids=set())
+    seat_id, label = await _resolve_group_seat(db, _GROUP, _START, _END, _PERSON, preferred_seat_id=13)
+    assert (seat_id, label) == (None, None)


### PR DESCRIPTION
## Problema
Cuando un cliente paga por MercadoPago a través del chatbot un **paquete con horario fijo**, la compra reserva el **mismo asiento** para todos los templates del grupo (ej. Lun–Vie) durante **todo el periodo**. Si esa bici estaba ocupada por otra persona en cualquier sesión del grupo, los standing bookings fallaban → 0 creados → `_assert_materialization_success` lanzaba → el webhook **reembolsaba** el pago.

Log de prod que lo disparó:
```
standing_bookings - ERROR - Seat 13 is already reserved by another person for this template  (x5)
standing_bookings - Successfully created 0 standing bookings for templates []
mercadopago_webhook - booking failed after payment ... -> refunding payment 164725532321
```

## Solución
Nuevo `_resolve_group_seat(...)` (`app/crud/standing_bookings/utils.py`) que elige una bici libre en **todas** las sesiones del grupo durante toda la ventana, reutilizando la misma semántica de "asiento ocupado" de `create_standing_booking`:
- conserva la bici preferida si está libre (en renovaciones, mantiene su misma bici);
- si está ocupada, **asigna otra bici libre**;
- si **ninguna** está libre, deja la preferida sin cambios → se mantiene el reembolso actual (clase realmente llena);
- `(None, None)` para clases sin asiento (por cupo).

Se cablea en `_create_standing_bookings_for_group` + `_handle_fixed_timeslot_effects`, por lo que aplica a **todos los flujos** (chatbot/MercadoPago, renovación manual del staff por GraphQL, y POS).

La confirmación de WhatsApp ahora indica la bici asignada (*"Tu lugar asignado: …"*).

## Pruebas
- `tests/test_resolve_group_seat.py` — 5 tests unitarios (DB-free), todos pasan: conserva preferida libre, reasigna si ocupada, auto-asigna sin preferida, conserva preferida si todo lleno (→ reembolso), venue sin asientos.
- `py_compile` + import de los módulos CRUD OK.

## Limitación conocida (fuera de alcance)
Carrera entre dos pagos concurrentes que resuelvan a la misma bici libre (el lock del webhook es por `external_reference`, no por asiento).

🤖 Generated with [Claude Code](https://claude.com/claude-code)