### PR TITLE
security: Fase 1 hardening (JWT, GraphQL, logging, authz coverage)

### DIFF
--- a/alembic/versions/f8b1c2d3e4a5_gate_finance_member_capabilities.py
+++ b/alembic/versions/f8b1c2d3e4a5_gate_finance_member_capabilities.py
@@ -1,0 +1,77 @@
+"""Seed member/finance/messaging capabilities and default staff grants.
+
+Backfills grants so that enforcing require_capability on the previously
+IsAuthenticated-only resolvers (members, payments, subscriptions, dashboard,
+chats, campaigns) does not lock out the roles that already use those screens:
+
+- admin: seeded for display only (admin is an implicit super-user in code).
+- staff (front desk): granted the day-to-day capabilities it already exercises
+  (payments, subscriptions, viewing members and chats).
+
+The two more sensitive capabilities — send_campaigns and view_finances — are
+intentionally NOT granted to staff here; an admin can toggle them per role from
+the in-app permissions matrix.
+
+Revision ID: f8b1c2d3e4a5
+Revises: b2c3d4e5f6a8
+Create Date: 2026-07-01 00:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "f8b1c2d3e4a5"
+down_revision: Union[str, None] = "b2c3d4e5f6a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+NEW_CAPABILITIES = (
+    "manage_payments",
+    "manage_subscriptions",
+    "send_campaigns",
+    "view_members",
+    "view_finances",
+    "view_chats",
+)
+
+# Front-desk defaults so staff keeps working after gating (admin toggles the rest).
+STAFF_DEFAULT_CAPABILITIES = (
+    "manage_payments",
+    "manage_subscriptions",
+    "view_members",
+    "view_chats",
+)
+
+
+def _seed(role_code: str, capabilities: Sequence[str]) -> None:
+    values = ", ".join(f"('{cap}')" for cap in capabilities)
+    op.execute(
+        f"""
+        INSERT INTO {SCHEMA}.role_capabilities (role_id, capability)
+        SELECT r.id, c.capability
+        FROM {SCHEMA}.roles r
+        CROSS JOIN (VALUES {values}) AS c(capability)
+        WHERE r.code = '{role_code}'
+        ON CONFLICT DO NOTHING
+        """
+    )
+
+
+def upgrade() -> None:
+    # Admin grants exist only so every capability shows in the settings matrix;
+    # admin is an implicit super-user in code regardless of these rows.
+    _seed("admin", NEW_CAPABILITIES)
+    # Staff keeps the front-desk capabilities it already used pre-gating.
+    _seed("staff", STAFF_DEFAULT_CAPABILITIES)
+
+
+def downgrade() -> None:
+    caps = ", ".join(f"'{cap}'" for cap in NEW_CAPABILITIES)
+    op.execute(
+        f"DELETE FROM {SCHEMA}.role_capabilities WHERE capability IN ({caps})"
+    )

--- a/app/core/env.py
+++ b/app/core/env.py
@@ -1,8 +1,18 @@
 """Environment loading helpers."""
+import os
 from pathlib import Path
 
 
 _LOADED = False
+
+
+def is_production() -> bool:
+    """True when running in the production environment.
+
+    Mirrors the comparison already used for secure-cookie settings so callers
+    can gate behaviour (GraphiQL IDE, introspection, redaction) consistently.
+    """
+    return os.getenv("ENVIRONMENT", "development").strip().lower() == "production"
 
 
 def load_environment() -> None:

--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from app.core.env import is_production
+
 
 class SecurityFilter(logging.Filter):
     """Filter to remove sensitive information from logs while preserving context"""
@@ -26,8 +28,19 @@ class SecurityFilter(logging.Filter):
     ]
 
     def filter(self, record):
+        import re
+
+        # Merge args into the message first so parameterised records (e.g.
+        # SQLAlchemy's "%r" bound parameters, which arrive in record.args, not
+        # record.msg) are also subject to redaction.
+        if record.args:
+            try:
+                record.msg = record.getMessage()
+                record.args = None
+            except Exception:
+                pass
+
         if hasattr(record, 'msg'):
-            import re
             msg = str(record.msg)
 
             # Only apply pattern-based filtering, not keyword blanket censoring
@@ -42,16 +55,21 @@ def setup_logging():
     """Configure application logging based on environment variables"""
 
     # Environment configuration
-    # Defaults tuned for diagnostics; can be overridden with env vars
-    log_level = os.getenv("LOG_LEVEL", "DEBUG").upper()
-    sql_log_level = os.getenv("SQL_LOG_LEVEL", "INFO").upper()
+    # Defaults are production-safe: quiet level, SQL echo off, redaction on.
+    # Override with env vars for local diagnostics (e.g. LOG_LEVEL=DEBUG).
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    sql_log_level = os.getenv("SQL_LOG_LEVEL", "WARNING").upper()
     log_format = os.getenv("LOG_FORMAT", "text").lower()
 
     # Resolve default log file within backend/logs/app.log regardless of CWD
     default_log_path = Path(__file__).resolve().parents[2] / "logs" / "app.log"
     log_file_path = os.getenv("LOG_FILE_PATH", str(default_log_path))
     auth_log_events = os.getenv("AUTH_LOG_EVENTS", "true").lower() == "true"
-    enable_security_filter = os.getenv("ENABLE_SECURITY_FILTER", "false").lower() == "true"
+    # Redaction is opt-out via env var, but always forced on in production so a
+    # misconfigured deploy cannot log secrets/PII unredacted.
+    enable_security_filter = (
+        os.getenv("ENABLE_SECURITY_FILTER", "false").lower() == "true" or is_production()
+    )
 
     # Create logs directory
     log_dir = Path(log_file_path).parent

--- a/app/crud/permissions.py
+++ b/app/crud/permissions.py
@@ -23,6 +23,13 @@ OPERATE_POS = "operate_pos"  # run the checkout (create sales)
 MANAGE_CASH_SESSION = "manage_cash_session"  # open/close caja, corte, cash movements
 VIEW_POS_REPORTS = "view_pos_reports"  # read sales + cash-session reports
 MANAGE_PRODUCTS = "manage_products"  # CRUD of the product catalog / inventory
+# Members / finance / messaging capabilities (gate previously IsAuthenticated-only resolvers)
+MANAGE_PAYMENTS = "manage_payments"  # create/update/delete payments
+MANAGE_SUBSCRIPTIONS = "manage_subscriptions"  # create/renew/enroll subscriptions
+SEND_CAMPAIGNS = "send_campaigns"  # create/schedule/trigger WhatsApp campaigns
+VIEW_MEMBERS = "view_members"  # read the member directory + detail (PII)
+VIEW_FINANCES = "view_finances"  # read payments, metrics, dashboard KPIs
+VIEW_CHATS = "view_chats"  # read WhatsApp conversations/messages
 ALL_CAPABILITIES: List[str] = [
     MANAGE_MEMBERSHIP_PLANS,
     MANAGE_OWNER_AGENT,
@@ -31,6 +38,12 @@ ALL_CAPABILITIES: List[str] = [
     MANAGE_CASH_SESSION,
     VIEW_POS_REPORTS,
     MANAGE_PRODUCTS,
+    MANAGE_PAYMENTS,
+    MANAGE_SUBSCRIPTIONS,
+    SEND_CAMPAIGNS,
+    VIEW_MEMBERS,
+    VIEW_FINANCES,
+    VIEW_CHATS,
 ]
 
 ADMIN_ROLE_CODE = "admin"

--- a/app/db/postgresql.py
+++ b/app/db/postgresql.py
@@ -7,16 +7,24 @@ from app.core.env import load_environment
 
 load_environment()
 
-# Get database URL from environment
-database_url = os.getenv("DATABASE_URL", "postgresql+asyncpg://appuser:secret123@localhost:5432/defaultdb")
+# Get database URL from environment. No fallback: refuse to start pointing at a
+# hardcoded default DB, which would mask a misconfigured deployment and embeds a
+# credential in source.
+database_url = os.getenv("DATABASE_URL")
+if not database_url:
+    raise RuntimeError(
+        "DATABASE_URL must be set. Refusing to start without an explicit database URL."
+    )
 
-# Configure SQL logging based on environment
-sql_log_level = os.getenv("SQL_LOG_LEVEL", "INFO").upper()
-enable_sql_echo = sql_log_level in ["DEBUG", "INFO"]
+# SQL echo is off unless SQL_LOG_LEVEL is explicitly DEBUG. Echoing statements
+# logs bound parameters (member PII, password hashes) and adds per-request I/O.
+sql_log_level = os.getenv("SQL_LOG_LEVEL", "WARNING").upper()
+enable_sql_echo = sql_log_level == "DEBUG"
 
 engine = create_async_engine(
     database_url,
     echo=enable_sql_echo,
+    hide_parameters=not enable_sql_echo,  # never log bound params outside debug
     pool_pre_ping=True,  # Verify connections before using them
     pool_recycle=3600,    # Recycle connections every hour
 )

--- a/app/graphql/auth/mutations.py
+++ b/app/graphql/auth/mutations.py
@@ -4,7 +4,8 @@ from user_agents import parse
 import uuid
 import datetime
 
-from app.security.hashing import verify_password
+from app.security.hashing import verify_password, dummy_verify
+from app.security.login_rate_limit import check_allowed, record_failure, record_success
 from app.security.jwt import (
     create_access_token,
     create_refresh_token,
@@ -20,6 +21,7 @@ from app.crud.usersCrud import get_person_by_id
 from app.crud.permissions import get_capabilities_for_person
 from app.graphql.auth.claims import build_access_claims, build_session_claims
 from app.crud.sessionCrud import create_session, revoke_session
+from app.graphql.context import _get_active_session
 from app.graphql.auth.types import LoginInput, TokenResponse
 from app.models.sessionModel import Session
 from app.core.logging_config import get_logger
@@ -50,14 +52,34 @@ class AuthMutation:
         db = info.context.db
         logger.info("Login attempt for '%s' from %s", identifier, ip_address or "unknown-ip")
 
+        # Throttle brute-force / credential-stuffing before touching the DB.
+        allowed, retry_after = check_allowed(ip_address, identifier)
+        if not allowed:
+            logger.warning(
+                "Login rate-limited for '%s' from %s (retry in %ss)",
+                identifier, ip_address or "unknown-ip", retry_after,
+            )
+            raise HTTPException(
+                status_code=429,
+                detail="Demasiados intentos fallidos. Intenta de nuevo más tarde.",
+            )
+
         account = await get_account_by_username(db=db, username=identifier)
         logger.info("Account lookup for '%s': %s", identifier, "found" if account else "not-found")
 
+        # Unified error + constant-time behaviour: a missing account still runs a
+        # bcrypt check so it cannot be distinguished from a wrong password by
+        # message or timing (prevents user enumeration).
         if not account:
-            raise HTTPException(status_code=401, detail="Account not found")
+            dummy_verify()
+            record_failure(ip_address, identifier)
+            raise HTTPException(status_code=401, detail="Credenciales inválidas")
 
         if not verify_password(password, account.password_hash):
-            raise HTTPException(status_code=401, detail="Credentials not valid")
+            record_failure(ip_address, identifier)
+            raise HTTPException(status_code=401, detail="Credenciales inválidas")
+
+        record_success(ip_address, identifier)
 
         # Load the person's roles + effective capabilities so the client can
         # gate its UI without an extra round-trip. The backend re-checks
@@ -127,8 +149,9 @@ class AuthMutation:
             max_age=get_access_cookie_max_age_seconds(),
         )
 
-        # Mantener header para compatibilidad temporal
-        response.headers["x-access-token"] = access_token
+        # The token travels in the HttpOnly cookie and in the GraphQL body below.
+        # It is deliberately NOT echoed in a JS-readable response header (that
+        # would defeat the HttpOnly protection).
 
         logger.info("User '%s' logged in; session %s", account.username, session_id[:8])
         return TokenResponse(access_token=access_token)
@@ -148,6 +171,11 @@ class AuthMutation:
         payload = verify_refresh_token(refresh_token)
         if not payload:
             raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+        # Reject refresh tokens whose session has been revoked/deleted (e.g. after
+        # logout), consistent with build_context which re-checks on every request.
+        if await _get_active_session(db, payload.get("session_id")) is None:
+            raise HTTPException(status_code=401, detail="Session no longer active")
 
         # Re-derive roles/capabilities from the DB so newly granted/revoked
         # permissions take effect on the next refresh (not only on re-login).
@@ -180,8 +208,7 @@ class AuthMutation:
             max_age=get_access_cookie_max_age_seconds(),
         )
 
-        # Mantener header para compatibilidad temporal
-        response.headers["x-access-token"] = new_access_token
+        # Not echoed in a JS-readable header (see login).
 
         return TokenResponse(access_token=new_access_token)
 

--- a/app/graphql/campaigns/mutations.py
+++ b/app/graphql/campaigns/mutations.py
@@ -16,7 +16,8 @@ from strawberry.types import Info
 
 from app.crud import campaignsCrud as crud
 from app.crud import whatsappTemplatesCrud as templates_crud
-from app.graphql.auth.permissions import IsAuthenticated
+from app.crud.permissions import SEND_CAMPAIGNS
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
 from app.graphql.campaigns.types import (
     CampaignMutationResult,
     CampaignResult,
@@ -96,6 +97,9 @@ class CampaignsMutation:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     async def create_campaign(self, info: Info, input: CreateCampaignInput) -> CampaignResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignResult(success=False, error=error)
         if input.objective not in CAMPAIGN_OBJECTIVES:
             return CampaignResult(success=False, error="Objetivo de campaña desconocido.")
         if not (input.name or "").strip():
@@ -135,6 +139,9 @@ class CampaignsMutation:
         self, info: Info, id: int, input: UpdateCampaignInput
     ) -> CampaignResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignResult(success=False, error="Campaña no encontrada.")
@@ -180,6 +187,9 @@ class CampaignsMutation:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     async def delete_campaign(self, info: Info, id: int) -> CampaignMutationResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignMutationResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignMutationResult(success=False, error="Campaña no encontrada.")
@@ -194,6 +204,9 @@ class CampaignsMutation:
     async def build_campaign_audience(self, info: Info, id: int) -> CampaignRunResult:
         """Materialize campaign_recipients for preview before sending."""
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignRunResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignRunResult(success=False, error="Campaña no encontrada.")
@@ -215,6 +228,9 @@ class CampaignsMutation:
         self, info: Info, id: int, scheduled_at: datetime, send_local_time: bool = False
     ) -> CampaignResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignResult(success=False, error="Campaña no encontrada.")
@@ -236,6 +252,9 @@ class CampaignsMutation:
         self, info: Info, id: int, dry_run: bool = False
     ) -> CampaignRunResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignRunResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignRunResult(success=False, error="Campaña no encontrada.")
@@ -266,6 +285,9 @@ class CampaignsMutation:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     async def pause_campaign(self, info: Info, id: int) -> CampaignResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignResult(success=False, error="Campaña no encontrada.")
@@ -279,6 +301,9 @@ class CampaignsMutation:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     async def resume_campaign(self, info: Info, id: int) -> CampaignRunResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignRunResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignRunResult(success=False, error="Campaña no encontrada.")
@@ -291,6 +316,9 @@ class CampaignsMutation:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     async def cancel_campaign(self, info: Info, id: int) -> CampaignResult:
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignResult(success=False, error="Campaña no encontrada.")
@@ -303,6 +331,9 @@ class CampaignsMutation:
     async def retry_campaign_failures(self, info: Info, id: int) -> CampaignRunResult:
         """Re-dispatch failed recipients (run_campaign only picks pending/failed)."""
         db: AsyncSession = info.context.db
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignRunResult(success=False, error=error)
         campaign = await crud.get_campaign_model(db, id)
         if campaign is None:
             return CampaignRunResult(success=False, error="Campaña no encontrada.")
@@ -314,6 +345,9 @@ class CampaignsMutation:
     @strawberry.mutation(permission_classes=[IsAuthenticated])
     async def run_campaign_sweep(self, info: Info) -> CampaignRunResult:
         """Run scheduled-campaign + conversion sweeps now (testing / manual trigger)."""
+        error = await require_capability(info, SEND_CAMPAIGNS)
+        if error:
+            return CampaignRunResult(success=False, error=error)
         try:
             send_stats = await campaign_service.run_campaign_sweep()
             await campaign_service.run_conversion_sweep()

--- a/app/graphql/context.py
+++ b/app/graphql/context.py
@@ -112,7 +112,8 @@ async def _mint_access_from_refresh(
             samesite=cookie_samesite,
             max_age=get_access_cookie_max_age_seconds(),
         )
-        response.headers["x-access-token"] = new_access_token
+        # Refreshed token stays in the HttpOnly cookie only; not echoed in a
+        # JS-readable response header.
 
     return user, account_id, session_id
 

--- a/app/graphql/dashboard/queries.py
+++ b/app/graphql/dashboard/queries.py
@@ -9,8 +9,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
 from app.crud.dashboard_metrics import get_dashboard_metrics
-from app.graphql.auth.permissions import IsAuthenticated
+from app.crud.permissions import VIEW_FINANCES
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
 from app.graphql.dashboard.types import DashboardMetrics
+
+
+def _empty_dashboard_metrics() -> DashboardMetrics:
+    """Zeroed KPIs returned when the requester lacks view_finances."""
+    return DashboardMetrics(
+        total_members=0, active_members=0, new_members=0, period_reservations=0,
+        period_revenue=0.0, avg_occupancy=0.0, total_members_prev=0,
+        active_members_prev=0, new_members_prev=0, reservations_prev=0,
+        revenue_prev=0.0, avg_occupancy_prev=0.0,
+        revenue_by_day=[], occupancy_by_class=[], new_members_by_day=[],
+        membership_distribution=[], top_membership_sales_all_time=None,
+        top_membership_sales_period=None,
+    )
 
 
 @strawberry.type
@@ -29,6 +43,8 @@ class DashboardQuery:
         the (start, end) window. Previous-period values use a same-sized
         window shifted back so the UI can render trend deltas.
         """
+        if await require_capability(info, VIEW_FINANCES):
+            return _empty_dashboard_metrics()
         db: AsyncSession = info.context.db
 
         if end_date is None:

--- a/app/graphql/members/queries.py
+++ b/app/graphql/members/queries.py
@@ -5,8 +5,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.types import Info
 
 from app.crud.membersCrud import count_members, get_members_list, get_member_by_id
+from app.crud.permissions import VIEW_MEMBERS
 from app.graphql.members.types import Member, PaginatedMembers
-from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
 from app.core.conversions import coerce_int
 
 
@@ -21,6 +22,8 @@ class MembersQuery:
         search: Optional[str] = None
     ) -> PaginatedMembers:
         """Get a paginated list of members with an exact total."""
+        if await require_capability(info, VIEW_MEMBERS):
+            return PaginatedMembers(items=[], total=0)
         db: AsyncSession = info.context.db
         safe_limit = max(1, min(int(limit or 100), 500))
         safe_offset = max(0, int(offset or 0))
@@ -47,6 +50,8 @@ class MembersQuery:
         search: Optional[str] = None
     ) -> List[Member]:
         """Get comprehensive list of all members with optional filters"""
+        if await require_capability(info, VIEW_MEMBERS):
+            return []
         db: AsyncSession = info.context.db
         members_data = await get_members_list(
             db=db,
@@ -60,6 +65,8 @@ class MembersQuery:
     @strawberry.field(permission_classes=[IsAuthenticated])
     async def member(self, info: Info, member_id: int) -> Optional[Member]:
         """Get detailed member information by ID"""
+        if await require_capability(info, VIEW_MEMBERS):
+            return None
         db: AsyncSession = info.context.db
 
         member_id = coerce_int(member_id)

--- a/app/graphql/memberships/mutations.py
+++ b/app/graphql/memberships/mutations.py
@@ -28,7 +28,11 @@ from app.crud.membershipsCrud import (
     delete_payment
 )
 from app.crud.membersCrud import get_member_by_id
-from app.crud.permissions import MANAGE_MEMBERSHIP_PLANS
+from app.crud.permissions import (
+    MANAGE_MEMBERSHIP_PLANS,
+    MANAGE_PAYMENTS,
+    MANAGE_SUBSCRIPTIONS,
+)
 from app.graphql.memberships.types import (
     CreateMembershipPlanInput, UpdateMembershipPlanInput, CreateSubscriptionInput,
     CreateMemberEnrollmentInput, RenewSubscriptionInput,
@@ -197,6 +201,10 @@ class MembershipMutation:
         """Create a new membership subscription"""
         db: AsyncSession = info.context.db
 
+        error = await require_capability(info, MANAGE_SUBSCRIPTIONS)
+        if error:
+            return SubscriptionResponse(subscription=None, message=error)
+
         try:
             created_by = getattr(info.context, 'account_id', None)
 
@@ -253,6 +261,10 @@ class MembershipMutation:
     async def create_member_enrollment(self, info: Info, input: CreateMemberEnrollmentInput) -> MemberEnrollmentResponse:
         """Create member, subscription and payment; optionally create standing bookings + sessions like renewal."""
         db: AsyncSession = info.context.db
+
+        error = await require_capability(info, MANAGE_SUBSCRIPTIONS)
+        if error:
+            return MemberEnrollmentResponse(member=None, subscription=None, payment=None, message=error)
 
         try:
             created_by = getattr(info.context, 'account_id', None)
@@ -373,6 +385,13 @@ class MembershipMutation:
         """Renew a member's subscription."""
         db: AsyncSession = info.context.db
 
+        error = await require_capability(info, MANAGE_SUBSCRIPTIONS)
+        if error:
+            return SubscriptionRenewalResponse(
+                success=False, subscription=None, payment=None, message=error,
+                standingBookingId=None, materializationStats=None,
+            )
+
         try:
             created_by = getattr(info.context, 'account_id', None)
 
@@ -489,7 +508,11 @@ class MembershipMutation:
     async def update_payment(self, info: Info, input: UpdatePaymentInput) -> PaymentMutationResponse:
         """Update an existing payment."""
         db: AsyncSession = info.context.db
-        
+
+        error = await require_capability(info, MANAGE_PAYMENTS)
+        if error:
+            return PaymentMutationResponse(success=False, payment=None, message=error)
+
         try:
             from sqlalchemy.orm import selectinload
             payment = await update_payment(
@@ -533,7 +556,11 @@ class MembershipMutation:
     async def delete_payment(self, info: Info, payment_id: int) -> PaymentMutationResponse:
         """Delete an existing payment."""
         db: AsyncSession = info.context.db
-        
+
+        error = await require_capability(info, MANAGE_PAYMENTS)
+        if error:
+            return PaymentMutationResponse(success=False, payment=None, message=error)
+
         try:
             success = await delete_payment(db=db, payment_id=payment_id, commit=True)
             if success:

--- a/app/graphql/memberships/queries.py
+++ b/app/graphql/memberships/queries.py
@@ -16,8 +16,19 @@ from app.graphql.memberships.types import (
     PaginatedPayments,
     PaymentMetrics,
 )
-from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
+from app.crud.permissions import VIEW_FINANCES
 from app.core.conversions import coerce_int
+
+
+def _empty_payment_metrics() -> PaymentMetrics:
+    """Zeroed metrics returned when the requester lacks view_finances."""
+    return PaymentMetrics(
+        total_amount=0.0, total_count=0, avg_amount=0.0, completed_amount=0.0,
+        pending_count=0, pending_amount=0.0, failed_count=0, refunded_count=0,
+        orphan_count=0, duplicate_suspect_count=0,
+        by_method=[], by_plan=[], by_status=[], daily_series=[],
+    )
 
 
 @strawberry.type
@@ -92,6 +103,8 @@ class MembershipsQuery:
         Returns both the page items and the total row count matching the filters,
         so the UI can render an accurate "X of Y" footer without a second query.
         """
+        if await require_capability(info, VIEW_FINANCES):
+            return PaginatedPayments(items=[], total=0)
         db: AsyncSession = info.context.db
         from app.crud.membershipsCrud import get_payments, count_payments
 
@@ -125,6 +138,8 @@ class MembershipsQuery:
         duplicates within 5 minutes). Filter parameters are the same as the
         `payments` query so the panel stays in sync with the table.
         """
+        if await require_capability(info, VIEW_FINANCES):
+            return _empty_payment_metrics()
         db: AsyncSession = info.context.db
         from app.crud.membershipsCrud import get_payment_metrics
 

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -1,9 +1,14 @@
 import logging
+import os
 # from dataclasses import dataclass
 # from fastapi import Request, Response
 # from sqlalchemy.ext.asyncio import AsyncSession
 # from strawberry.fastapi import BaseContext
 import strawberry
+from strawberry.extensions import AddValidationRules, QueryDepthLimiter
+from graphql import NoSchemaIntrospectionCustomRule
+
+from app.core.env import is_production
 
 # from app.security.jwt import verify_token
 # from app.crud.usersCrud import get_user_by_id
@@ -86,4 +91,18 @@ class RootSubscription(WhatsAppChatSubscription):
 #     response: Response
 #     user: object | None = None
    
-schema = strawberry.Schema(query=Query, mutation=Mutation, subscription=RootSubscription)
+# Query-cost guardrails. Depth limit blunts maliciously nested queries (DoS);
+# introspection is disabled in production so the schema/attack surface is not
+# self-documenting on the public endpoint (the GraphiQL IDE is also turned off
+# in main.py for production).
+_MAX_QUERY_DEPTH = int(os.getenv("GRAPHQL_MAX_DEPTH", "15"))
+_schema_extensions = [QueryDepthLimiter(max_depth=_MAX_QUERY_DEPTH)]
+if is_production():
+    _schema_extensions.append(AddValidationRules([NoSchemaIntrospectionCustomRule]))
+
+schema = strawberry.Schema(
+    query=Query,
+    mutation=Mutation,
+    subscription=RootSubscription,
+    extensions=_schema_extensions,
+)

--- a/app/graphql/whatsapp/queries.py
+++ b/app/graphql/whatsapp/queries.py
@@ -11,7 +11,8 @@ from app.crud.whatsappCrud import (
     get_conversation_messages,
 )
 from app.graphql.whatsapp.types import ChatConversation, ChatMessage
-from app.graphql.auth.permissions import IsAuthenticated
+from app.graphql.auth.permissions import IsAuthenticated, require_capability
+from app.crud.permissions import VIEW_CHATS
 
 
 @strawberry.type
@@ -25,6 +26,8 @@ class WhatsAppChatQuery:
         search: Optional[str] = None,
     ) -> List[ChatConversation]:
         """List WhatsApp conversations ordered by most recent activity."""
+        if await require_capability(info, VIEW_CHATS):
+            return []
         db: AsyncSession = info.context.db
         data = await get_conversations(db=db, limit=limit, offset=offset, search=search)
         return [ChatConversation.from_data(d) for d in data]
@@ -36,6 +39,8 @@ class WhatsAppChatQuery:
         id: int,
     ) -> Optional[ChatConversation]:
         """Fetch a single conversation enriched like the list (for incremental inserts)."""
+        if await require_capability(info, VIEW_CHATS):
+            return None
         db: AsyncSession = info.context.db
         data = await get_conversation_data(db=db, conversation_id=id)
         return ChatConversation.from_data(data) if data else None
@@ -49,6 +54,8 @@ class WhatsAppChatQuery:
         offset: int = 0,
     ) -> List[ChatMessage]:
         """Messages of a conversation in chronological order."""
+        if await require_capability(info, VIEW_CHATS):
+            return []
         db: AsyncSession = info.context.db
         data = await get_conversation_messages(
             db=db, conversation_id=conversation_id, limit=limit, offset=offset

--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from strawberry.subscriptions import (
     GRAPHQL_WS_PROTOCOL,
 )
 
+from app.core.env import is_production
 from app.graphql.schema import schema
 from app.graphql.context import build_context
 from app.webhooks.whatsapp_webhook import router as whatsapp_webhook_router
@@ -76,7 +77,9 @@ app.add_middleware(
 graphql_app = GraphQLRouter(
     schema=schema,
     context_getter=build_context,
-    graphql_ide="graphiql",
+    # Serve the interactive IDE only outside production so the public endpoint
+    # does not expose an explorable UI (introspection is disabled in schema.py).
+    graphql_ide=None if is_production() else "graphiql",
     subscription_protocols=[
         GRAPHQL_TRANSPORT_WS_PROTOCOL,
         GRAPHQL_WS_PROTOCOL,

--- a/app/security/hashing.py
+++ b/app/security/hashing.py
@@ -6,3 +6,17 @@ def hash_password(password: str) -> str:
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return bcrypt.checkpw(plain_password.encode('utf-8'), hashed_password.encode('utf-8'))
+
+
+# Fixed valid bcrypt hash (default cost) used to equalise login timing when an
+# account does not exist, so a "no such user" response takes as long as a real
+# "wrong password" one and cannot be distinguished by timing.
+_DUMMY_HASH = bcrypt.hashpw(b"timing-equalisation-placeholder", bcrypt.gensalt()).decode('utf-8')
+
+
+def dummy_verify() -> None:
+    """Run a bcrypt check against a throwaway hash to burn ~one verify's worth of time."""
+    try:
+        bcrypt.checkpw(b"invalid", _DUMMY_HASH.encode('utf-8'))
+    except Exception:
+        pass

--- a/app/security/jwt.py
+++ b/app/security/jwt.py
@@ -5,12 +5,37 @@ from fastapi import HTTPException
 from jose import ExpiredSignatureError, JWTError, jwt
 from zoneinfo import ZoneInfo
 
+from app.core.env import load_environment
 from app.core.logging_config import get_logger
+
+# Make sure backend/.env is loaded before we read the secrets (systemd/container
+# runtimes may also supply them directly, which takes precedence).
+load_environment()
 
 logger = get_logger("auth.jwt")
 
-SECRET_KEY_ACCESS_TOKEN = os.getenv("SECRET_KEY_ACCESS_TOKEN", "super-secret")
-SECRET_KEY_REFRESH_TOKEN = os.getenv("SECRET_KEY_REFRESH_TOKEN", "super-secret1")
+# Minimum secret strength. HS256 is symmetric, so a weak/known key lets anyone
+# forge tokens for any person_id/capabilities.
+_MIN_SECRET_BYTES = 32
+
+
+def _require_secret(env_name: str) -> str:
+    """Read a mandatory JWT secret from the environment, failing fast if weak.
+
+    There is deliberately NO fallback default: a missing or trivial secret must
+    abort startup instead of silently running in an insecure mode.
+    """
+    value = os.getenv(env_name)
+    if not value or len(value.encode("utf-8")) < _MIN_SECRET_BYTES:
+        raise RuntimeError(
+            f"{env_name} must be set to a strong secret of at least "
+            f"{_MIN_SECRET_BYTES} bytes. Refusing to start with a missing or weak JWT secret."
+        )
+    return value
+
+
+SECRET_KEY_ACCESS_TOKEN = _require_secret("SECRET_KEY_ACCESS_TOKEN")
+SECRET_KEY_REFRESH_TOKEN = _require_secret("SECRET_KEY_REFRESH_TOKEN")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 5))  # default 5 minutes
 ACCESS_TOKEN_EXPIRE_DAYS = int(os.getenv("ACCESS_TOKEN_EXPIRE_DAYS", 30))

--- a/app/security/login_rate_limit.py
+++ b/app/security/login_rate_limit.py
@@ -1,0 +1,62 @@
+"""In-process rate limiting for the login mutation.
+
+Tracks recent failed attempts keyed by ``(ip, identifier)`` and enforces a
+lockout window once a threshold is exceeded. This is per-process (per worker);
+a shared store (e.g. Redis) is the production-grade upgrade for multi-worker
+deployments — see the optimization plan, Fase 4.
+"""
+import os
+import time
+import threading
+from collections import defaultdict, deque
+
+_MAX_ATTEMPTS = int(os.getenv("LOGIN_MAX_ATTEMPTS", "10"))
+_WINDOW_SECONDS = int(os.getenv("LOGIN_ATTEMPT_WINDOW_SECONDS", "300"))
+_LOCKOUT_SECONDS = int(os.getenv("LOGIN_LOCKOUT_SECONDS", "300"))
+
+_lock = threading.Lock()
+_failures: "defaultdict[tuple, deque]" = defaultdict(deque)  # key -> timestamps
+_locked_until: "dict[tuple, float]" = {}                     # key -> monotonic ts
+
+
+def _key(ip, identifier) -> tuple:
+    return (ip or "?", (identifier or "?").strip().lower())
+
+
+def check_allowed(ip, identifier):
+    """Return ``(allowed, retry_after_seconds)`` without recording anything."""
+    key = _key(ip, identifier)
+    now = time.monotonic()
+    with _lock:
+        until = _locked_until.get(key)
+        if until is not None:
+            remaining = until - now
+            if remaining > 0:
+                return False, int(remaining) + 1
+            # Lockout expired: clear state.
+            _locked_until.pop(key, None)
+            _failures.pop(key, None)
+    return True, 0
+
+
+def record_failure(ip, identifier) -> None:
+    """Record a failed attempt; may trigger a lockout for the key."""
+    key = _key(ip, identifier)
+    now = time.monotonic()
+    with _lock:
+        dq = _failures[key]
+        dq.append(now)
+        cutoff = now - _WINDOW_SECONDS
+        while dq and dq[0] < cutoff:
+            dq.popleft()
+        if len(dq) >= _MAX_ATTEMPTS:
+            _locked_until[key] = now + _LOCKOUT_SECONDS
+            dq.clear()
+
+
+def record_success(ip, identifier) -> None:
+    """Clear failure/lockout state for the key after a successful login."""
+    key = _key(ip, identifier)
+    with _lock:
+        _failures.pop(key, None)
+        _locked_until.pop(key, None)

--- a/db_schema_introspect.py
+++ b/db_schema_introspect.py
@@ -1,5 +1,7 @@
 ﻿import asyncio
 import json
+import os
+import sys
 from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -7,7 +9,11 @@ from pathlib import Path
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy import inspect, text
 
-DATABASE_URL = "postgresql+asyncpg://appuser:secret123@localhost:5432/defaultdb"
+# Read the connection string from the environment (same var as the app). No
+# hardcoded credential in source.
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    sys.exit("DATABASE_URL is not set. Export it before running the introspection script.")
 TARGET_SCHEMA = "app"
 BASE_PATH = Path(__file__).parent
 OUTPUT_JSON = BASE_PATH / "db_schema_report.json"

--- a/tests/test_authz_coverage.py
+++ b/tests/test_authz_coverage.py
@@ -1,0 +1,57 @@
+"""Governance test: sensitive GraphQL resolvers must enforce a capability.
+
+Parses the resolver source (AST, no imports needed) and asserts each listed
+function calls one of the authoritative capability checks. This fails loudly if
+a gate is removed or a new sensitive resolver is added without one.
+"""
+import ast
+import os
+
+import pytest
+
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_GRAPHQL = os.path.join(_BACKEND_ROOT, "app", "graphql")
+
+_GUARD_CALLS = {"require_capability", "require_any_capability", "require_admin"}
+
+# file (relative to app/graphql) -> resolver functions that MUST be gated
+SENSITIVE = {
+    "members/queries.py": ["members_page", "members", "member"],
+    "memberships/queries.py": ["payments", "payment_metrics"],
+    "dashboard/queries.py": ["dashboard_metrics"],
+    "whatsapp/queries.py": ["conversations", "conversation", "conversation_messages"],
+    "memberships/mutations.py": [
+        "create_subscription", "create_member_enrollment", "renew_subscription",
+        "update_payment", "delete_payment",
+    ],
+    "campaigns/mutations.py": [
+        "create_campaign", "update_campaign", "delete_campaign",
+        "build_campaign_audience", "schedule_campaign", "trigger_campaign",
+        "pause_campaign", "resume_campaign", "cancel_campaign",
+        "retry_campaign_failures", "run_campaign_sweep",
+    ],
+}
+
+
+def _functions_with_guard(path):
+    """Return {func_name: bool_has_guard_call} for every async def in the file."""
+    tree = ast.parse(open(path, encoding="utf-8-sig").read())
+    out = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            has_guard = any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Name)
+                and c.func.id in _GUARD_CALLS
+                for c in ast.walk(node)
+            )
+            out[node.name] = has_guard
+    return out
+
+
+@pytest.mark.parametrize("rel_path,functions", sorted(SENSITIVE.items()))
+def test_sensitive_resolvers_declare_capability(rel_path, functions):
+    path = os.path.join(_GRAPHQL, *rel_path.split("/"))
+    guards = _functions_with_guard(path)
+    missing = [f for f in functions if not guards.get(f, False)]
+    assert not missing, f"{rel_path}: resolvers without a capability check: {missing}"

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,125 @@
+"""Regression tests for the Fase 1 security-hardening changes.
+
+These tests deliberately avoid the database so they run without a provisioned
+Postgres (they do not use the ``db`` fixture).
+"""
+import importlib
+import logging
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+# --------------------------------------------------------------------------- #
+# env.is_production
+# --------------------------------------------------------------------------- #
+def test_is_production_toggles(monkeypatch):
+    from app.core.env import is_production
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    assert is_production() is True
+    monkeypatch.setenv("ENVIRONMENT", "PRODUCTION")  # case-insensitive
+    assert is_production() is True
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    assert is_production() is False
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    assert is_production() is False  # defaults to non-production
+
+
+# --------------------------------------------------------------------------- #
+# Login rate limiter
+# --------------------------------------------------------------------------- #
+def test_login_rate_limit_locks_out_and_resets(monkeypatch):
+    monkeypatch.setenv("LOGIN_MAX_ATTEMPTS", "3")
+    import app.security.login_rate_limit as rl
+    importlib.reload(rl)
+
+    ip, ident = "203.0.113.7", "Admin@Gym.com"
+    for _ in range(2):
+        allowed, _ = rl.check_allowed(ip, ident)
+        assert allowed
+        rl.record_failure(ip, ident)
+
+    rl.record_failure(ip, ident)  # third failure crosses the threshold
+    allowed, retry_after = rl.check_allowed(ip, ident)
+    assert not allowed and retry_after > 0
+
+    # identifier match is case-insensitive
+    allowed_ci, _ = rl.check_allowed(ip, "admin@gym.com")
+    assert not allowed_ci
+
+    # a successful login clears the lockout
+    rl.record_success(ip, ident)
+    allowed_after, _ = rl.check_allowed(ip, ident)
+    assert allowed_after
+
+
+# --------------------------------------------------------------------------- #
+# Password hashing / timing-equalisation helper
+# --------------------------------------------------------------------------- #
+def test_password_roundtrip_and_dummy_verify():
+    from app.security.hashing import hash_password, verify_password, dummy_verify
+
+    h = hash_password("s3cret-pass")
+    assert verify_password("s3cret-pass", h) is True
+    assert verify_password("wrong", h) is False
+    dummy_verify()  # must never raise, even though there is no real account
+
+
+# --------------------------------------------------------------------------- #
+# Log redaction now also covers record.args (SQLAlchemy-style bound params)
+# --------------------------------------------------------------------------- #
+def test_security_filter_redacts_args():
+    from app.core.logging_config import SecurityFilter
+
+    f = SecurityFilter()
+    rec = logging.LogRecord(
+        "x", logging.INFO, __file__, 1, "token=%s",
+        ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc",), None,
+    )
+    f.filter(rec)
+    assert "[JWT_TOKEN]" in rec.getMessage()
+    assert rec.args in (None, ())  # args merged into msg
+
+
+# --------------------------------------------------------------------------- #
+# JWT fail-fast (needs python-jose; runs in a subprocess for a clean import)
+# --------------------------------------------------------------------------- #
+_HAS_JOSE = importlib.util.find_spec("jose") is not None
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _run_import_jwt(env_extra):
+    env = dict(os.environ)
+    for k in ("SECRET_KEY_ACCESS_TOKEN", "SECRET_KEY_REFRESH_TOKEN"):
+        env.pop(k, None)
+    env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, "-c", "import app.security.jwt"],
+        cwd=_BACKEND_ROOT, env=env, capture_output=True, text=True,
+    )
+
+
+@pytest.mark.skipif(not _HAS_JOSE, reason="python-jose not installed")
+def test_jwt_fails_fast_without_secrets():
+    result = _run_import_jwt({})
+    assert result.returncode != 0
+    assert "SECRET_KEY_ACCESS_TOKEN" in result.stderr
+
+
+@pytest.mark.skipif(not _HAS_JOSE, reason="python-jose not installed")
+def test_jwt_fails_fast_on_weak_secret():
+    result = _run_import_jwt(
+        {"SECRET_KEY_ACCESS_TOKEN": "short", "SECRET_KEY_REFRESH_TOKEN": "x" * 32}
+    )
+    assert result.returncode != 0
+
+
+@pytest.mark.skipif(not _HAS_JOSE, reason="python-jose not installed")
+def test_jwt_imports_with_strong_secrets():
+    result = _run_import_jwt(
+        {"SECRET_KEY_ACCESS_TOKEN": "a" * 40, "SECRET_KEY_REFRESH_TOKEN": "b" * 40}
+    )
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
Cierra vectores explotables en el endpoint GraphQL público y añade autorización por capacidad a resolvers antes protegidos solo por IsAuthenticated. Cambios verificados con py_compile + smoke tests + chequeo AST de gobierno.

- JWT fail-fast: elimina los fallbacks "super-secret"; exige secretos
  >=32 bytes en el arranque (app/security/jwt.py, app/core/env.py).
- GraphiQL/introspección off en producción + QueryDepthLimiter (app/main.py, app/graphql/schema.py).
- Defaults de logging seguros: LOG_LEVEL=INFO, SQL echo solo en DEBUG, hide_parameters, SecurityFilter redacta record.args, filtro forzado en prod (app/core/logging_config.py, app/db/postgresql.py).
- DATABASE_URL fail-fast sin fallback; quita credenciales hardcodeadas (app/db/postgresql.py, db_schema_introspect.py).
- Flujo de tokens: elimina la cabecera legible x-access-token y valida revocación de sesión en refreshToken (auth/mutations.py, graphql/context.py).
- Login: mensaje unificado + bcrypt dummy anti-enumeración + rate limiting por IP+identificador (auth/mutations.py, security/hashing.py, security/login_rate_limit.py).
- Autorización por capacidad en 25 resolvers sensibles (pagos, suscripciones, campañas, socios/finanzas/dashboard/chats). Nuevas capacidades y migración f8b1c2d3e4a5 que siembra grants de staff (admin las restantes vía la matriz).
- Tests: tests/test_security_hardening.py, tests/test_authz_coverage.py.

IMPORTANTE (orden de despliegue): ejecutar `alembic upgrade head` (migración f8b1c2d3e4a5) antes o junto con el deploy del código. Los gates deniegan por defecto; sin el seeding, el rol staff perdería acceso a pagos/suscripciones/socios/chats. admin no se ve afectado.


Claude-Session: https://claude.ai/code/session_017dPr8iqiXm2p4zuTLN3fMb