### PR TITLE
perf(bookings): cerrar TOCTOU de aforo + indices de sesiones/reservas

### DIFF
--- a/alembic/versions/a3c5d7e9f1b2_perf_indexes_sessions_reservations.py
+++ b/alembic/versions/a3c5d7e9f1b2_perf_indexes_sessions_reservations.py
@@ -1,0 +1,52 @@
+"""Performance indexes: auth sessions lookup + booking-path drift reconciliation.
+
+- ``sessions.session`` is looked up on EVERY authenticated request
+  (``verify_session``) and ``sessions.user_id`` on session listing/revocation;
+  neither had an index.
+- ``idx_reservations_session``, ``idx_sessions_instructor`` and
+  ``idx_sessions_template`` are declared on the models (classModel.py) but were
+  missing in the real database (schema drift, tables predate the models).
+  ``idx_reservations_session (session_id, status)`` backs the per-session
+  capacity count used by every booking flow.
+
+All statements are idempotent (IF NOT EXISTS) so environments where any of
+these already exist are unaffected.
+
+Revision ID: a3c5d7e9f1b2
+Revises: f8b1c2d3e4a5
+Create Date: 2026-07-06 00:00:00.000000
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "a3c5d7e9f1b2"
+down_revision: Union[str, None] = "f8b1c2d3e4a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+SCHEMA = "app"
+
+INDEXES = (
+    # (name, table, columns)
+    ("ix_sessions_session", "sessions", "(session)"),
+    ("ix_sessions_user_id", "sessions", "(user_id)"),
+    ("idx_reservations_session", "reservations", "(session_id, status)"),
+    ("idx_sessions_instructor", "class_sessions", "(instructor_id, start_at)"),
+    ("idx_sessions_template", "class_sessions", "(template_id, start_at)"),
+)
+
+
+def upgrade() -> None:
+    for name, table, columns in INDEXES:
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS {name} ON {SCHEMA}.{table} {columns}"
+        )
+
+
+def downgrade() -> None:
+    for name, _table, _columns in INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {SCHEMA}.{name}")

--- a/app/crud/locks.py
+++ b/app/crud/locks.py
@@ -1,0 +1,32 @@
+"""Postgres advisory-lock helpers shared by the booking flows.
+
+Mirrors the per-contact lock in ``app/services/whatsapp_outbound.py``: a
+transaction-scoped ``pg_advisory_xact_lock`` (auto-released at commit/rollback,
+so nothing leaks on pooled asyncpg connections) keyed by a namespaced blake2b
+hash, so keys cannot collide with other advisory-lock users.
+"""
+import hashlib
+
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _lock_key(namespace: str, object_id: int) -> int:
+    """Stable signed 64-bit advisory-lock key (process-independent)."""
+    h = hashlib.blake2b(f"{namespace}:{object_id}".encode("utf-8"), digest_size=8).digest()
+    return int.from_bytes(h, "big", signed=True)
+
+
+async def lock_class_session(db: AsyncSession, session_id: int) -> None:
+    """Serialize capacity/seat checks + reservation inserts for one class session.
+
+    The capacity check (count reservations, compare to ``capacity``) has no
+    backing constraint in the DB, so two concurrent bookings that both count
+    before either inserts can oversell the class (TOCTOU). Callers MUST take
+    this lock BEFORE counting; it is held until the surrounding transaction
+    commits or rolls back.
+    """
+    await db.execute(
+        sa_text("SELECT pg_advisory_xact_lock(:k)"),
+        {"k": _lock_key("class_session", session_id)},
+    )

--- a/app/crud/reservationsCrud.py
+++ b/app/crud/reservationsCrud.py
@@ -14,6 +14,7 @@ from app.models import (
     Reservation, People, Seat, ClassSession, ClassType, Venue,
     SeatType, MembershipSubscription
 )
+from app.crud.locks import lock_class_session
 
 
 @dataclass
@@ -73,6 +74,10 @@ async def create_reservation(
     commit: bool = True
 ) -> Reservation:
     """Create a new reservation"""
+
+    # Serialize the availability checks + insert for this session (TOCTOU): without
+    # the lock, two concurrent bookings can both count "1 spot left" and oversell.
+    await lock_class_session(db, session_id)
 
     # Validate session exists and is not full
     session_result = await db.execute(

--- a/app/crud/standing_bookings/materialization.py
+++ b/app/crud/standing_bookings/materialization.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 from typing import Any, Dict, List, Optional
 
 from sqlalchemy import and_, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
 
@@ -11,6 +12,8 @@ from app.models.classModel import (
     StandingBooking,
     StandingBookingException,
 )
+
+from app.crud.locks import lock_class_session
 
 from .utils import _session_has_capacity
 
@@ -234,6 +237,11 @@ async def _create_reservation_if_possible(
     seat_id_override: Optional[int] = None,
 ) -> None:
     """Create a reservation if possible, respecting capacity and seat constraints."""
+    # Serialize check+insert per session: the capacity count has no backing DB
+    # constraint, so two concurrent materializations (or a manual booking racing a
+    # materialization) could both see the last free spot and oversell (TOCTOU).
+    await lock_class_session(db, session_id)
+
     existing = await _get_existing_reservation(db, session_id, standing_booking.person_id)
     if existing:
         stats["skipped_existing"] += 1
@@ -266,7 +274,20 @@ async def _create_reservation_if_possible(
         source=source,
     )
 
-    db.add(reservation)
+    # SAVEPOINT so a lone constraint violation (uq_session_person /
+    # uq_reservations_seat_once) skips this reservation without poisoning the
+    # whole batch's transaction.
+    try:
+        async with db.begin_nested():
+            db.add(reservation)
+            await db.flush()
+    except IntegrityError as exc:
+        if "uq_reservations_seat_once" in str(exc):
+            stats["skipped_seat_taken"] += 1
+        else:
+            stats["skipped_existing"] += 1
+        return
+
     stats["created_reservations"] += 1
 
 

--- a/app/crud/standing_bookings/reschedule.py
+++ b/app/crud/standing_bookings/reschedule.py
@@ -350,35 +350,39 @@ async def reschedule_standing_booking(
         try:
             from app.crud.reservationsCrud import create_reservation
 
-            await create_reservation(
-                db=db,
-                session_id=item.target_session_id,
-                person_id=standing_booking.person_id,
-                seat_id=item.seat_id,
-                source="override",
-                commit=False,
-            )
-
-            await create_standing_booking_exception(
-                db=db,
-                standing_booking_id=item.standing_booking_id,
-                session_date=item.session_date,
-                action="reschedule",
-                new_session_id=item.target_session_id,
-                new_seat_id=item.seat_id,
-            )
-
-            if item.source_session_id:
-                reservation_stmt = select(Reservation).where(
-                    and_(
-                        Reservation.session_id == item.source_session_id,
-                        Reservation.person_id == standing_booking.person_id,
-                    )
+            # SAVEPOINT per item: a failed insert (e.g. constraint violation from a
+            # concurrent booking) must skip only this item, not poison the whole
+            # transaction so every later item fails with InFailedSQLTransaction.
+            async with db.begin_nested():
+                await create_reservation(
+                    db=db,
+                    session_id=item.target_session_id,
+                    person_id=standing_booking.person_id,
+                    seat_id=item.seat_id,
+                    source="override",
+                    commit=False,
                 )
-                reservation_result = await db.execute(reservation_stmt)
-                reservation = reservation_result.scalar_one_or_none()
-                if reservation and reservation.status in ["reserved", "waitlisted"]:
-                    reservation.status = "canceled"
+
+                await create_standing_booking_exception(
+                    db=db,
+                    standing_booking_id=item.standing_booking_id,
+                    session_date=item.session_date,
+                    action="reschedule",
+                    new_session_id=item.target_session_id,
+                    new_seat_id=item.seat_id,
+                )
+
+                if item.source_session_id:
+                    reservation_stmt = select(Reservation).where(
+                        and_(
+                            Reservation.session_id == item.source_session_id,
+                            Reservation.person_id == standing_booking.person_id,
+                        )
+                    )
+                    reservation_result = await db.execute(reservation_stmt)
+                    reservation = reservation_result.scalar_one_or_none()
+                    if reservation and reservation.status in ["reserved", "waitlisted"]:
+                        reservation.status = "canceled"
 
             item.status = "rescheduled"
             item.reason = "Rescheduled"

--- a/app/models/sessionModel.py
+++ b/app/models/sessionModel.py
@@ -11,13 +11,14 @@ class Session(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     refresh_token: Mapped[str] = mapped_column(Text, nullable=False)
-    session: Mapped[str] = mapped_column(String(80), nullable=False)
+    # Consultada en cada request autenticado (verify_session) — indexada.
+    session: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
     device_name: Mapped[Optional[str]] = mapped_column(nullable=True)
     ip_address: Mapped[Optional[str]] = mapped_column(INET, nullable=True)
     last_active_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
     revoked_at: Mapped[Optional[datetime]] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
     user_agent: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    user_id: Mapped[Optional[int]] = mapped_column(nullable=True)
+    user_id: Mapped[Optional[int]] = mapped_column(nullable=True, index=True)
     created_at: Mapped[Optional[datetime]] = mapped_column(
         TIMESTAMP(timezone=True),
         nullable=True,

--- a/tests/test_capacity_locking.py
+++ b/tests/test_capacity_locking.py
@@ -1,0 +1,56 @@
+"""Governance test: booking flows that count capacity must hold the advisory lock.
+
+The capacity check (count reservations vs session.capacity) has no backing DB
+constraint, so any code path that counts-then-inserts MUST serialize on
+``lock_class_session`` or two concurrent bookings can oversell a class (TOCTOU).
+Parses the source with AST (no imports/DB needed) and fails loudly if the lock
+call is removed.
+"""
+import ast
+import os
+
+import pytest
+
+from app.crud.locks import _lock_key
+
+_BACKEND_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_CRUD = os.path.join(_BACKEND_ROOT, "app", "crud")
+
+# file (relative to app/crud) -> functions that MUST call lock_class_session
+LOCKED_FUNCTIONS = {
+    "reservationsCrud.py": ["create_reservation"],
+    "standing_bookings/materialization.py": ["_create_reservation_if_possible"],
+}
+
+
+def _functions_with_lock(path):
+    tree = ast.parse(open(path, encoding="utf-8-sig").read())
+    out = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            has_lock = any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Name)
+                and c.func.id == "lock_class_session"
+                for c in ast.walk(node)
+            )
+            out[node.name] = has_lock
+    return out
+
+
+@pytest.mark.parametrize("rel_path,functions", sorted(LOCKED_FUNCTIONS.items()))
+def test_capacity_paths_take_session_lock(rel_path, functions):
+    path = os.path.join(_CRUD, *rel_path.split("/"))
+    locked = _functions_with_lock(path)
+    missing = [f for f in functions if not locked.get(f, False)]
+    assert not missing, f"{rel_path}: capacity paths without lock_class_session: {missing}"
+
+
+def test_lock_key_is_stable_and_64bit():
+    """The advisory-lock key must be deterministic across processes and fit int8."""
+    key = _lock_key("class_session", 42)
+    assert key == _lock_key("class_session", 42)
+    assert -(2**63) <= key < 2**63
+    # namespacing: same id under another namespace must not collide
+    assert key != _lock_key("other_ns", 42)
+    assert _lock_key("class_session", 1) != _lock_key("class_session", 2)


### PR DESCRIPTION
TOCTOU de aforo: el chequeo de capacidad (contar reservas vs capacity) no tiene constraint en BD, asi que dos reservas concurrentes podian ver ambas "queda 1 lugar" y sobrevender la clase. Ahora todo camino que cuenta-e-inserta serializa con pg_advisory_xact_lock por sesion de clase (app/crud/locks.py, mismo patron que whatsapp_outbound):

- reservationsCrud.create_reservation (manual + reschedule)
- materialization._create_reservation_if_possible (standing bookings)

Ademas, cada insercion de reserva en lote va en SAVEPOINT (begin_nested) para que una violacion de constraint aislada (uq_session_person / uq_reservations_seat_once) se contabilice como skip sin envenenar la transaccion del lote (materializacion y reschedule_standing_booking).

Indices (migracion a3c5d7e9f1b2, idempotente con IF NOT EXISTS):
- sessions.session (consultada en CADA request autenticado por verify_session) y sessions.user_id: no tenian indice.
- idx_reservations_session (session_id, status): respalda el conteo de aforo; declarado en el modelo pero ausente en la BD real (drift).
- idx_sessions_instructor / idx_sessions_template: idem drift.

Test de gobierno: tests/test_capacity_locking.py (AST) falla si algun camino de aforo pierde el lock.


Claude-Session: https://claude.ai/code/session_0115UqoYpmaw6q4VyYqbBTzj