### PR TITLE
perf(fase-2): rendimiento backend + hallazgos de revision adversarial

### DIFF
--- a/app/crud/classSessionCrud.py
+++ b/app/crud/classSessionCrud.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import selectinload
 
 from app.models.classModel import ClassSession, ClassTemplate, ClassType, Reservation
 from app.models.venueModel import Venue
+from app.crud.time_filters import between_dates, from_date, on_date, until_date
 
 logger = logging.getLogger(__name__)
 
@@ -92,9 +93,9 @@ async def get_sessions_by_template(
     query = select(ClassSession).where(ClassSession.template_id == template_id)
 
     if start_date:
-        query = query.where(func.date(ClassSession.start_at) >= start_date)
+        query = query.where(from_date(ClassSession.start_at, start_date))
     if end_date:
-        query = query.where(func.date(ClassSession.start_at) <= end_date)
+        query = query.where(until_date(ClassSession.start_at, end_date))
     if status:
         query = query.where(ClassSession.status == status)
 
@@ -146,7 +147,7 @@ async def generate_sessions_from_template(
             existing_query = select(ClassSession).where(
                 and_(
                     ClassSession.template_id == template_id,
-                    func.date(ClassSession.start_at) == current_date
+                    on_date(ClassSession.start_at, current_date),
                 )
             )
             existing_result = await db.execute(existing_query)
@@ -265,12 +266,7 @@ async def get_sessions_by_date_range(
         selectinload(ClassSession.venue),
         selectinload(ClassSession.template),
         selectinload(ClassSession.instructor)
-    ).where(
-        and_(
-            func.date(ClassSession.start_at) >= start_date,
-            func.date(ClassSession.start_at) <= end_date
-        )
-    )
+    ).where(between_dates(ClassSession.start_at, start_date, end_date))
 
     if venue_id:
         query = query.where(ClassSession.venue_id == venue_id)

--- a/app/crud/dashboard_metrics.py
+++ b/app/crud/dashboard_metrics.py
@@ -475,10 +475,27 @@ async def _sum_revenue(
 
 _T = TypeVar("_T")
 
-# Bound on concurrent DB sessions spun up for the dashboard fan-out. Kept well
-# under the engine pool (pool_size=5 + max_overflow=10 = 15) so a dashboard load
-# cannot starve the pool of connections needed by other in-flight requests.
+# GLOBAL bound on concurrent fan-out DB sessions across ALL in-flight dashboard
+# loads (not per call). The engine pool is pool_size=5 + max_overflow=10 = 15;
+# capping total fan-out checkouts here means a burst of simultaneous dashboards
+# adds at most _DASHBOARD_FANOUT connections combined, leaving headroom for the
+# requests' own sessions and other endpoints. A per-call semaphore (the naive
+# version) would NOT bound this: N concurrent dashboards could each open 6.
 _DASHBOARD_FANOUT = 6
+
+# One semaphore per event loop (an asyncio.Semaphore is bound to the loop it is
+# first awaited on). Same lazy per-loop pattern as GraphQLClient's refresh sem.
+_fanout_semaphores: "dict[int, asyncio.Semaphore]" = {}
+
+
+def _get_fanout_semaphore() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    key = id(loop)
+    sem = _fanout_semaphores.get(key)
+    if sem is None:
+        sem = asyncio.Semaphore(_DASHBOARD_FANOUT)
+        _fanout_semaphores[key] = sem
+    return sem
 
 
 async def _gather_in_sessions(
@@ -488,10 +505,11 @@ async def _gather_in_sessions(
 
     A single AsyncSession cannot run queries concurrently ("another operation is
     in progress"), so each task gets a fresh session from the factory. A
-    semaphore caps how many run at once to protect the connection pool. Results
-    are returned in the same order as ``tasks``.
+    process-global (per-loop) semaphore caps how many fan-out sessions run at
+    once ACROSS all concurrent dashboard loads, so the pool cannot be starved.
+    Results are returned in the same order as ``tasks``.
     """
-    sem = asyncio.Semaphore(_DASHBOARD_FANOUT)
+    sem = _get_fanout_semaphore()
 
     async def _run(fn: Callable[[AsyncSession], Awaitable[_T]]) -> _T:
         async with sem:

--- a/app/crud/dashboard_metrics.py
+++ b/app/crud/dashboard_metrics.py
@@ -13,15 +13,17 @@ useful.
 """
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Awaitable, Callable, Optional, TypeVar
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.crud.memberships.payment_metrics import DailyPointData, PlanBucketData
 from app.crud.memberships.utils import _normalize_to_utc
+from app.db.postgresql import async_session_factory
 from app.models import (
     MembershipPlan,
     MembershipSubscription,
@@ -471,6 +473,34 @@ async def _sum_revenue(
 # --------------------------------------------------------------------------- #
 
 
+_T = TypeVar("_T")
+
+# Bound on concurrent DB sessions spun up for the dashboard fan-out. Kept well
+# under the engine pool (pool_size=5 + max_overflow=10 = 15) so a dashboard load
+# cannot starve the pool of connections needed by other in-flight requests.
+_DASHBOARD_FANOUT = 6
+
+
+async def _gather_in_sessions(
+    tasks: list[Callable[[AsyncSession], Awaitable[_T]]],
+) -> list[_T]:
+    """Run each read-only metric in its OWN session, concurrently but bounded.
+
+    A single AsyncSession cannot run queries concurrently ("another operation is
+    in progress"), so each task gets a fresh session from the factory. A
+    semaphore caps how many run at once to protect the connection pool. Results
+    are returned in the same order as ``tasks``.
+    """
+    sem = asyncio.Semaphore(_DASHBOARD_FANOUT)
+
+    async def _run(fn: Callable[[AsyncSession], Awaitable[_T]]) -> _T:
+        async with sem:
+            async with async_session_factory() as session:
+                return await fn(session)
+
+    return await asyncio.gather(*(_run(fn) for fn in tasks))
+
+
 def _previous_window(
     start_date: datetime, end_date: datetime
 ) -> tuple[datetime, datetime]:
@@ -486,7 +516,7 @@ def _previous_window(
 
 
 async def get_dashboard_metrics(
-    db: AsyncSession,
+    db: AsyncSession,  # noqa: ARG001 - kept for signature stability; fan-out uses its own sessions
     *,
     start_date: datetime,
     end_date: datetime,
@@ -499,47 +529,58 @@ async def get_dashboard_metrics(
 
     Flow KPIs (revenue, reservations, new members, occupancy) and their prev
     counterparts use the (start, end) and (prev_start, prev_end) windows.
+
+    The request ``db`` is intentionally not used for the queries: the 18 metrics
+    fan out over dedicated sessions (a single AsyncSession can't run concurrent
+    queries). It stays in the signature so callers don't need to change.
     """
     start = _normalize_to_utc(start_date)
     end = _normalize_to_utc(end_date)
     prev_start, prev_end = _previous_window(start, end)
 
-    # Stock — snapshot at end_date and at start_date (= prev_end)
-    total_members = await count_active_members(db, as_of=end)
-    total_members_prev = await count_active_members(db, as_of=start)
-    active_members = await count_active_subscriptions(db, as_of=end)
-    active_members_prev = await count_active_subscriptions(db, as_of=start)
-
-    # Flow — current and previous windows
-    new_members = await count_new_members(db, start_date=start, end_date=end)
-    new_members_prev = await count_new_members(
-        db, start_date=prev_start, end_date=prev_end
-    )
-
-    period_reservations = await count_reservations(db, start_date=start, end_date=end)
-    reservations_prev = await count_reservations(
-        db, start_date=prev_start, end_date=prev_end
-    )
-
-    period_revenue = await _sum_revenue(db, start_date=start, end_date=end)
-    revenue_prev = await _sum_revenue(db, start_date=prev_start, end_date=prev_end)
-
-    avg_occupancy = await calculate_occupancy_avg(
-        db, start_date=start, end_date=end
-    )
-    avg_occupancy_prev = await calculate_occupancy_avg(
-        db, start_date=prev_start, end_date=prev_end
-    )
-
-    # Series
-    revenue_series = await revenue_by_day(db, start_date=start, end_date=end)
-    occupancy_series = await occupancy_by_class(db, start_date=start, end_date=end)
-    new_members_serie = await new_members_series(db, start_date=start, end_date=end)
-    plan_distribution = await membership_distribution(db, as_of=end)
-    top_sales_all_time = await top_membership_sales(db)
-    top_sales_period = await top_membership_sales(
-        db, start_date=start, end_date=end
-    )
+    # These 18 metrics are independent read-only aggregations. Run them
+    # concurrently, each in its own session (a single session serializes queries),
+    # instead of ~18 sequential round-trips on the request session. Order here
+    # MUST match the unpacking below.
+    (
+        total_members,
+        total_members_prev,
+        active_members,
+        active_members_prev,
+        new_members,
+        new_members_prev,
+        period_reservations,
+        reservations_prev,
+        period_revenue,
+        revenue_prev,
+        avg_occupancy,
+        avg_occupancy_prev,
+        revenue_series,
+        occupancy_series,
+        new_members_serie,
+        plan_distribution,
+        top_sales_all_time,
+        top_sales_period,
+    ) = await _gather_in_sessions([
+        lambda s: count_active_members(s, as_of=end),
+        lambda s: count_active_members(s, as_of=start),
+        lambda s: count_active_subscriptions(s, as_of=end),
+        lambda s: count_active_subscriptions(s, as_of=start),
+        lambda s: count_new_members(s, start_date=start, end_date=end),
+        lambda s: count_new_members(s, start_date=prev_start, end_date=prev_end),
+        lambda s: count_reservations(s, start_date=start, end_date=end),
+        lambda s: count_reservations(s, start_date=prev_start, end_date=prev_end),
+        lambda s: _sum_revenue(s, start_date=start, end_date=end),
+        lambda s: _sum_revenue(s, start_date=prev_start, end_date=prev_end),
+        lambda s: calculate_occupancy_avg(s, start_date=start, end_date=end),
+        lambda s: calculate_occupancy_avg(s, start_date=prev_start, end_date=prev_end),
+        lambda s: revenue_by_day(s, start_date=start, end_date=end),
+        lambda s: occupancy_by_class(s, start_date=start, end_date=end),
+        lambda s: new_members_series(s, start_date=start, end_date=end),
+        lambda s: membership_distribution(s, as_of=end),
+        lambda s: top_membership_sales(s),
+        lambda s: top_membership_sales(s, start_date=start, end_date=end),
+    ])
 
     return DashboardMetricsData(
         total_members=total_members,

--- a/app/crud/locks.py
+++ b/app/crud/locks.py
@@ -30,3 +30,29 @@ async def lock_class_session(db: AsyncSession, session_id: int) -> None:
         sa_text("SELECT pg_advisory_xact_lock(:k)"),
         {"k": _lock_key("class_session", session_id)},
     )
+
+
+# Fixed key: one coarse lock serializes ALL multi-session batch runs against
+# each other (materialization + reschedule share it).
+_MATERIALIZE_BATCH_KEY = _lock_key("materialize_batch", 0)
+
+
+async def lock_materialization_batch(db: AsyncSession) -> None:
+    """Serialize whole multi-session batch runs (materialize / reschedule).
+
+    A batch acquires MANY per-session ``lock_class_session`` locks, held until
+    the single terminal commit, in a data-dependent order. Two concurrent
+    batches could therefore grab the same pair of session locks in opposite
+    order and ABBA-deadlock (Postgres kills one; the batch's per-item
+    ``except: continue`` then runs on the aborted transaction and the final
+    commit rolls back — silently losing every reservation it created).
+
+    Taking this coarse lock FIRST (before any per-session lock) makes batches
+    mutually exclusive, so no two batches ever hold session locks at the same
+    time. A single manual booking still only holds ONE session lock and never
+    takes this one, so it can never form a cycle with a batch.
+    """
+    await db.execute(
+        sa_text("SELECT pg_advisory_xact_lock(:k)"),
+        {"k": _MATERIALIZE_BATCH_KEY},
+    )

--- a/app/crud/reservationsCrud.py
+++ b/app/crud/reservationsCrud.py
@@ -15,6 +15,7 @@ from app.models import (
     SeatType, MembershipSubscription
 )
 from app.crud.locks import lock_class_session
+from app.crud.time_filters import between_dates
 
 
 @dataclass
@@ -527,12 +528,7 @@ async def _get_sessions_with_seats_range(
             joinedload(ClassSession.class_type),
             joinedload(ClassSession.venue),
         )
-        .where(
-            and_(
-                func.date(ClassSession.start_at) >= start_date,
-                func.date(ClassSession.start_at) <= end_date,
-            )
-        )
+        .where(between_dates(ClassSession.start_at, start_date, end_date))
     )
 
     if class_type_id:
@@ -545,6 +541,25 @@ async def _get_sessions_with_seats_range(
 
     sessions_result = await db.execute(session_query)
     sessions = sessions_result.scalars().all()
+
+    # Todas las reservas del rango en UNA query (antes: una query por sesión, N+1
+    # que en la vista semanal significaba ~50 round-trips).
+    reservations_by_session: Dict[int, List[Reservation]] = {}
+    if sessions:
+        session_ids = [s.id for s in sessions]
+        all_res_result = await db.execute(
+            select(Reservation)
+            .options(joinedload(Reservation.person))
+            .where(
+                and_(
+                    Reservation.session_id.in_(session_ids),
+                    Reservation.seat_id.isnot(None),
+                    Reservation.status.in_(['reserved', 'checked_in']),
+                )
+            )
+        )
+        for r in all_res_result.scalars().all():
+            reservations_by_session.setdefault(r.session_id, []).append(r)
 
     results: List[Dict[str, Any]] = []
     seats_cache: Dict[int, List] = {}
@@ -592,19 +607,8 @@ async def _get_sessions_with_seats_range(
 
         venue_seats = seats_cache[session.venue_id]
 
-        # Reservations for this session mapped by seat_id
-        reservations_result = await db.execute(
-            select(Reservation)
-            .options(joinedload(Reservation.person))
-            .where(
-                and_(
-                    Reservation.session_id == session.id,
-                    Reservation.seat_id.isnot(None),
-                    Reservation.status.in_(['reserved', 'checked_in']),
-                )
-            )
-        )
-        reservations = reservations_result.scalars().all()
+        # Reservations for this session mapped by seat_id (pre-cargadas en bloque)
+        reservations = reservations_by_session.get(session.id, [])
         reserved_by_seat: Dict[int, People] = {}
         for r in reservations:
             if r.seat_id is not None and r.person is not None:

--- a/app/crud/sessionCrud.py
+++ b/app/crud/sessionCrud.py
@@ -46,8 +46,9 @@ async def verify_session(db: AsyncSession, session_id: str) -> Session | None:
 async def update_last_active_at(db: AsyncSession, session_id: str) -> None:
     """Updates the last_active_at timestamp for a session using database function.
 
-    Note: Does NOT commit or flush - changes will be committed when the session closes.
-    This function is typically called from build_context() which shares the request session.
+    Note: Does NOT commit or flush - only queues the UPDATE. The caller MUST commit:
+    ``get_db`` does not commit on close, so an uncommitted change is silently rolled
+    back (e.g. read-only requests). ``build_context`` commits explicitly after calling this.
     """
     logger.debug("Updating last_active_at for session %s", session_id)
     stmt = update(Session).where(Session.session == session_id).values(last_active_at=func.now())
@@ -58,7 +59,8 @@ async def update_last_active_at(db: AsyncSession, session_id: str) -> None:
 async def touch_session(db: AsyncSession, session_id: str) -> None:
     """Updates the last_active_at timestamp for a session with explicit UTC time.
 
-    Note: Does NOT commit or flush - changes will be committed when the session closes.
+    Note: Does NOT commit or flush - only queues the UPDATE. The caller MUST commit
+    (``get_db`` does not commit on close, so an uncommitted change is rolled back).
     """
     timestamp = datetime.now(timezone.utc)
     await db.execute(
@@ -72,7 +74,8 @@ async def touch_session(db: AsyncSession, session_id: str) -> None:
 async def revoke_session(db: AsyncSession, session_id: str) -> None:
     """Marks the session as revoked.
 
-    Note: Does NOT commit or flush - changes will be committed when the session closes.
+    Note: Does NOT commit or flush - only queues the UPDATE; the caller MUST commit
+    (the logout/revoke mutations do). ``get_db`` does not commit on close.
     """
     timestamp = datetime.now(timezone.utc)
     await db.execute(
@@ -107,7 +110,8 @@ async def revoke_other_sessions(db: AsyncSession, user_id: int, keep_session_id:
 async def update_refresh_token(db: AsyncSession, session_id: str, refresh_token: str) -> None:
     """Stores a new refresh token for an existing session.
 
-    Note: Does NOT commit or flush - changes will be committed when the session closes.
+    Note: Does NOT commit or flush - only queues the UPDATE; the caller MUST commit
+    (``get_db`` does not commit on close, so an uncommitted change is rolled back).
     """
     await db.execute(
         update(Session)

--- a/app/crud/standing_bookings/bookings.py
+++ b/app/crud/standing_bookings/bookings.py
@@ -14,6 +14,7 @@ from app.models.classModel import (
 )
 from app.models.membershipsModel import MembershipSubscription
 from app.models.venueModel import Seat
+from app.crud.time_filters import between_dates
 
 from .data import StandingBookingData, _standing_booking_to_data
 
@@ -87,8 +88,7 @@ async def create_standing_booking(
             .where(
                 and_(
                     ClassSession.template_id == template_id,
-                    func.date(ClassSession.start_at) >= start_date,
-                    func.date(ClassSession.start_at) <= end_date,
+                    between_dates(ClassSession.start_at, start_date, end_date),
                     Reservation.seat_id == seat_id,
                     Reservation.status.in_(["reserved", "checked_in"]),
                     Reservation.person_id != person_id,

--- a/app/crud/standing_bookings/catalog.py
+++ b/app/crud/standing_bookings/catalog.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import joinedload
 
 from app.models.classModel import ClassTemplate, ClassType, ClassSession, Reservation
 from app.models.venueModel import Seat
+from app.crud.time_filters import on_date
 
 from .data import ClassTemplateData, ClassTypeData, SeatData
 
@@ -120,7 +121,7 @@ async def get_available_seats_for_template(
     session_stmt = select(ClassSession).where(
         and_(
             ClassSession.template_id == template_id,
-            func.date(ClassSession.start_at) == date_to_check,
+            on_date(ClassSession.start_at, date_to_check),
         )
     )
     session_result = await db.execute(session_stmt)

--- a/app/crud/standing_bookings/materialization.py
+++ b/app/crud/standing_bookings/materialization.py
@@ -14,6 +14,7 @@ from app.models.classModel import (
 )
 
 from app.crud.locks import lock_class_session
+from app.crud.time_filters import between_dates
 
 from .utils import _session_has_capacity
 
@@ -196,8 +197,11 @@ async def _materialize_single_standing_booking(
         .where(
             and_(
                 ClassSession.template_id == template.id,
-                func.date(ClassSession.start_at) >= max(start_date, standing_booking.start_date),
-                func.date(ClassSession.start_at) <= min(end_date, standing_booking.end_date),
+                between_dates(
+                    ClassSession.start_at,
+                    max(start_date, standing_booking.start_date),
+                    min(end_date, standing_booking.end_date),
+                ),
                 ClassSession.status == "scheduled",
             )
         )
@@ -328,8 +332,7 @@ async def get_materialization_preview(
         .where(
             and_(
                 ClassSession.template_id == template.id,
-                func.date(ClassSession.start_at) >= start_date,
-                func.date(ClassSession.start_at) <= end_date,
+                between_dates(ClassSession.start_at, start_date, end_date),
                 ClassSession.status == "scheduled",
             )
         )

--- a/app/crud/standing_bookings/materialization.py
+++ b/app/crud/standing_bookings/materialization.py
@@ -13,7 +13,7 @@ from app.models.classModel import (
     StandingBookingException,
 )
 
-from app.crud.locks import lock_class_session
+from app.crud.locks import lock_class_session, lock_materialization_batch
 from app.crud.time_filters import between_dates
 
 from .utils import _session_has_capacity
@@ -80,6 +80,10 @@ async def materialize_standing_bookings(
 
     end_date = start_date + timedelta(weeks=window_weeks)
     stats = _init_materialization_stats()
+
+    # Coarse batch lock FIRST (before any per-session lock below) so two
+    # concurrent multi-session batches cannot ABBA-deadlock on session locks.
+    await lock_materialization_batch(db)
 
     conditions = [
         StandingBooking.status == "active",

--- a/app/crud/standing_bookings/reschedule.py
+++ b/app/crud/standing_bookings/reschedule.py
@@ -12,6 +12,8 @@ from app.models.classModel import (
     Reservation,
 )
 
+from app.crud.locks import lock_materialization_batch
+
 from .bookings import create_standing_booking_exception
 from .data import RescheduleItem
 from .utils import (
@@ -318,6 +320,12 @@ async def reschedule_standing_booking(
     target_seat_id: Optional[int] = None,
     strict: bool = False,
 ) -> Dict[str, Any]:
+    # Coarse batch lock FIRST: this creates reservations across MANY target
+    # sessions (each taking a per-session lock), so it shares the same
+    # serialization lock as materialization to avoid an ABBA deadlock between
+    # concurrent batches.
+    await lock_materialization_batch(db)
+
     sb_stmt = select(StandingBooking).where(StandingBooking.id == standing_booking_id)
     sb_result = await db.execute(sb_stmt)
     standing_booking = sb_result.scalar_one_or_none()

--- a/app/crud/standing_bookings/utils.py
+++ b/app/crud/standing_bookings/utils.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.classModel import ClassTemplate, ClassSession, StandingBooking, Reservation
 from app.models.venueModel import Seat
+from app.crud.time_filters import between_dates
 
 
 def _normalize_weekday_to_iso(weekday: Optional[int]) -> Optional[int]:
@@ -71,8 +72,7 @@ async def _load_sessions_by_template_ids(
     stmt = select(ClassSession).where(
         and_(
             ClassSession.template_id.in_(template_ids),
-            func.date(ClassSession.start_at) >= start_date,
-            func.date(ClassSession.start_at) <= end_date,
+            between_dates(ClassSession.start_at, start_date, end_date),
             ClassSession.status == "scheduled",
         )
     )
@@ -232,8 +232,7 @@ async def _resolve_group_seat(
         .where(
             and_(
                 ClassSession.template_id.in_(template_ids),
-                func.date(ClassSession.start_at) >= window_start,
-                func.date(ClassSession.start_at) <= window_end,
+                between_dates(ClassSession.start_at, window_start, window_end),
                 Reservation.seat_id.isnot(None),
                 Reservation.status.in_(["reserved", "checked_in"]),
                 Reservation.person_id != person_id,

--- a/app/crud/time_filters.py
+++ b/app/crud/time_filters.py
@@ -1,0 +1,52 @@
+"""Sargable date-range filters for timestamptz columns.
+
+``func.date(column) >= some_date`` wraps the column in a function, so Postgres
+cannot use an index on the column (e.g. ``idx_sessions_time``/``idx_sessions_template``)
+and falls back to scanning. These helpers express the same predicate as a plain
+range over the column, which IS index-usable.
+
+Exactness: ``func.date(timestamptz)`` buckets by the DB **session** timezone
+(this deployment runs Postgres in ``America/Mexico_City``, and the app does not
+override it on connect). So the day boundary here is built as midnight of the
+target date IN THE SESSION TIMEZONE via ``AT TIME ZONE current_setting('TimeZone')``
+— NOT UTC — so the range is byte-for-byte equivalent to the old ``func.date()``
+predicate regardless of what the session timezone is. The RHS is a stable
+constant (no reference to the column), so the predicate stays sargable.
+"""
+from datetime import date, timedelta
+
+from sqlalchemy import and_, cast, func
+from sqlalchemy.types import TIMESTAMP
+
+
+def _local_day_start(d: date):
+    """Midnight of ``d`` in the DB session timezone, as a timestamptz constant.
+
+    ``timezone(current_setting('TimeZone'), d::timestamp)`` interprets ``d 00:00``
+    as local wall-clock time in the session zone and yields the corresponding
+    instant — matching how ``func.date`` derives the calendar day.
+    """
+    return func.timezone(
+        func.current_setting("TimeZone"),
+        cast(d, TIMESTAMP(timezone=False)),
+    )
+
+
+def from_date(column, d: date):
+    """``func.date(column) >= d`` — sargable form."""
+    return column >= _local_day_start(d)
+
+
+def until_date(column, d: date):
+    """``func.date(column) <= d`` — sargable form (half-open upper bound)."""
+    return column < _local_day_start(d + timedelta(days=1))
+
+
+def between_dates(column, start: date, end: date):
+    """``func.date(column) BETWEEN start AND end`` — sargable form."""
+    return and_(from_date(column, start), until_date(column, end))
+
+
+def on_date(column, d: date):
+    """``func.date(column) == d`` — sargable form."""
+    return between_dates(column, d, d)

--- a/app/graphql/context.py
+++ b/app/graphql/context.py
@@ -98,8 +98,13 @@ async def _mint_access_from_refresh(
 
     try:
         await update_last_active_at(db, session_id)
+        # get_db no commitea al cerrar: sin este commit el UPDATE se revierte
+        # silenciosamente en requests de solo-lectura. Estamos en context-build,
+        # antes de cualquier resolver, así que no hay otro trabajo pendiente.
+        await db.commit()
     except Exception as e:
         logger.warning("Failed to update last_active_at for session %s: %s", session_id[:8], e)
+        await db.rollback()
 
     if response is not None:
         cookie_secure = get_cookie_secure_setting()

--- a/app/graphql/members/mutations.py
+++ b/app/graphql/members/mutations.py
@@ -1,5 +1,6 @@
 ﻿from typing import Optional
 from datetime import datetime, timezone
+import asyncio
 import logging
 import time
 
@@ -267,8 +268,10 @@ class MemberMutation:
             # Read file data
             file_data = await file.read()
 
-            # Validate image
-            is_valid, error_message = image_service.validate_image(file_data, file.filename)
+            # Validate image (PIL es CPU-bound/sincrono: fuera del event loop)
+            is_valid, error_message = await asyncio.to_thread(
+                image_service.validate_image, file_data, file.filename
+            )
             if not is_valid:
                 return MemberResponse(
                     success=False,
@@ -294,11 +297,12 @@ class MemberMutation:
             if member_data.profile_picture_path:
                 image_service.delete_old_picture(member_data.profile_picture_path)
 
-            # Process and save new image
-            new_path = image_service.process_and_save_image(
+            # Process and save new image (resize/re-encode PIL en un thread)
+            new_path = await asyncio.to_thread(
+                image_service.process_and_save_image,
                 file_data=file_data,
                 user_id=member_id,
-                original_filename=file.filename
+                original_filename=file.filename,
             )
 
             if not new_path:

--- a/app/graphql/members/queries.py
+++ b/app/graphql/members/queries.py
@@ -49,14 +49,22 @@ class MembersQuery:
         offset: int = 0,
         search: Optional[str] = None
     ) -> List[Member]:
-        """Get comprehensive list of all members with optional filters"""
+        """Get comprehensive list of members with optional filters.
+
+        A default/max page size is enforced: ``limit=None`` previously
+        materialized every member with all their payment/reservation/booking
+        collections just to sum totals in Python. Use ``members_page`` for
+        explicit pagination with a total count.
+        """
         if await require_capability(info, VIEW_MEMBERS):
             return []
         db: AsyncSession = info.context.db
+        safe_limit = max(1, min(int(limit) if limit else 100, 500))
+        safe_offset = max(0, int(offset or 0))
         members_data = await get_members_list(
             db=db,
-            limit=limit,
-            offset=offset,
+            limit=safe_limit,
+            offset=safe_offset,
             search=search
         )
 

--- a/app/services/whatsapp_media_assets_service.py
+++ b/app/services/whatsapp_media_assets_service.py
@@ -1,8 +1,10 @@
 """Reusable WhatsApp media asset storage and validation."""
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import mimetypes
+import threading
 from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
@@ -212,25 +214,40 @@ async def _reuse_existing_asset(
     return await crud.make_asset_active(db, asset, public_url=public_url)
 
 
-async def _put_object(storage_key: str, raw: bytes, mime_type: str) -> None:
-    if not media_storage_config.is_configured():
-        raise MediaAssetError(
-            "Storage R2 no configurado. Define MEDIA_S3_ENDPOINT_URL, MEDIA_S3_BUCKET, "
-            "MEDIA_S3_ACCESS_KEY_ID, MEDIA_S3_SECRET_ACCESS_KEY y MEDIA_PUBLIC_BASE_URL."
-        )
+# boto3 client cacheado a nivel de modulo: crearlo es caro (resuelve credenciales,
+# carga modelos de servicio) y put_object es thread-safe, asi que uno solo basta.
+_s3_client = None
+_s3_client_lock = threading.Lock()
+
+
+def _get_s3_client():
+    global _s3_client
+    if _s3_client is not None:
+        return _s3_client
     try:
         import boto3  # type: ignore
+    except ImportError as exc:  # pragma: no cover - dependency issue
+        raise MediaAssetError("Falta instalar boto3 para subir media a R2/S3.") from exc
+    with _s3_client_lock:
+        if _s3_client is None:
+            _s3_client = boto3.client(
+                "s3",
+                endpoint_url=media_storage_config.S3_ENDPOINT_URL,
+                region_name=media_storage_config.S3_REGION,
+                aws_access_key_id=media_storage_config.S3_ACCESS_KEY_ID,
+                aws_secret_access_key=media_storage_config.S3_SECRET_ACCESS_KEY,
+            )
+    return _s3_client
+
+
+def _put_object_blocking(storage_key: str, raw: bytes, mime_type: str) -> None:
+    """Synchronous S3 upload — must run in a worker thread, never on the event loop."""
+    try:
         from botocore.exceptions import BotoCoreError, ClientError  # type: ignore
     except ImportError as exc:  # pragma: no cover - dependency issue
         raise MediaAssetError("Falta instalar boto3 para subir media a R2/S3.") from exc
 
-    client = boto3.client(
-        "s3",
-        endpoint_url=media_storage_config.S3_ENDPOINT_URL,
-        region_name=media_storage_config.S3_REGION,
-        aws_access_key_id=media_storage_config.S3_ACCESS_KEY_ID,
-        aws_secret_access_key=media_storage_config.S3_SECRET_ACCESS_KEY,
-    )
+    client = _get_s3_client()
     try:
         client.put_object(
             Bucket=media_storage_config.S3_BUCKET,
@@ -241,6 +258,17 @@ async def _put_object(storage_key: str, raw: bytes, mime_type: str) -> None:
         )
     except (BotoCoreError, ClientError) as exc:
         raise MediaAssetError(f"No se pudo subir el archivo a R2/S3: {exc}") from exc
+
+
+async def _put_object(storage_key: str, raw: bytes, mime_type: str) -> None:
+    if not media_storage_config.is_configured():
+        raise MediaAssetError(
+            "Storage R2 no configurado. Define MEDIA_S3_ENDPOINT_URL, MEDIA_S3_BUCKET, "
+            "MEDIA_S3_ACCESS_KEY_ID, MEDIA_S3_SECRET_ACCESS_KEY y MEDIA_PUBLIC_BASE_URL."
+        )
+    # boto3 es sincrono: una subida de hasta 100 MB bloquearia el event loop
+    # completo (todas las requests). Se despacha a un thread del pool.
+    await asyncio.to_thread(_put_object_blocking, storage_key, raw, mime_type)
 
 
 async def store_object(storage_key: str, raw: bytes, mime_type: str) -> str:

--- a/tests/test_capacity_locking.py
+++ b/tests/test_capacity_locking.py
@@ -46,6 +46,37 @@ def test_capacity_paths_take_session_lock(rel_path, functions):
     assert not missing, f"{rel_path}: capacity paths without lock_class_session: {missing}"
 
 
+# Multi-session batch entry points MUST take the coarse batch lock to avoid an
+# ABBA deadlock between concurrent batches (each accumulates many per-session
+# locks in a data-dependent order held until the terminal commit).
+BATCH_FUNCTIONS = {
+    "standing_bookings/materialization.py": ["materialize_standing_bookings"],
+    "standing_bookings/reschedule.py": ["reschedule_standing_booking"],
+}
+
+
+def _functions_calling(path, callee):
+    tree = ast.parse(open(path, encoding="utf-8-sig").read())
+    out = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef):
+            out[node.name] = any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Name)
+                and c.func.id == callee
+                for c in ast.walk(node)
+            )
+    return out
+
+
+@pytest.mark.parametrize("rel_path,functions", sorted(BATCH_FUNCTIONS.items()))
+def test_batch_paths_take_batch_lock(rel_path, functions):
+    path = os.path.join(_CRUD, *rel_path.split("/"))
+    calling = _functions_calling(path, "lock_materialization_batch")
+    missing = [f for f in functions if not calling.get(f, False)]
+    assert not missing, f"{rel_path}: batch paths without lock_materialization_batch: {missing}"
+
+
 def test_lock_key_is_stable_and_64bit():
     """The advisory-lock key must be deterministic across processes and fit int8."""
     key = _lock_key("class_session", 42)

--- a/tests/test_time_filters.py
+++ b/tests/test_time_filters.py
@@ -1,0 +1,60 @@
+"""time_filters must render a sargable range that is exactly equivalent to
+func.date(col) OP d — bucketing by the DB SESSION timezone, not UTC.
+
+Regression guard for the tz bug: an earlier version built the boundary at UTC
+midnight, which shifts the day by the session's UTC offset (this deployment runs
+Postgres in America/Mexico_City) and silently miscounts sessions/reservations
+near midnight. The correct form applies ``AT TIME ZONE current_setting('TimeZone')``.
+"""
+from datetime import date
+
+from sqlalchemy import Column, DateTime
+from sqlalchemy.dialects import postgresql
+
+from app.crud.time_filters import between_dates, from_date, on_date, until_date
+
+_COL = Column("start_at", DateTime(timezone=True))
+
+
+def _sql(expr):
+    return str(
+        expr.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def test_from_date_is_session_tz_lower_bound():
+    sql = _sql(from_date(_COL, date(2026, 7, 6)))
+    assert "start_at >=" in sql
+    assert "current_setting('TimeZone')" in sql
+    assert "'2026-07-06'" in sql
+    # must NOT wrap the column (that would defeat the index)
+    assert "date(start_at)" not in sql.lower()
+
+
+def test_until_date_is_half_open_next_day():
+    sql = _sql(until_date(_COL, date(2026, 7, 6)))
+    assert "start_at <" in sql
+    # half-open: upper bound is the NEXT day's midnight
+    assert "'2026-07-07'" in sql
+
+
+def test_on_date_is_single_day_range():
+    sql = _sql(on_date(_COL, date(2026, 7, 6)))
+    assert "start_at >=" in sql and "start_at <" in sql
+    assert "'2026-07-06'" in sql and "'2026-07-07'" in sql
+
+
+def test_between_dates_spans_inclusive():
+    sql = _sql(between_dates(_COL, date(2026, 7, 1), date(2026, 7, 31)))
+    assert "'2026-07-01'" in sql
+    # inclusive end -> half-open at Aug 1
+    assert "'2026-08-01'" in sql
+
+
+def test_no_utc_midnight_regression():
+    """The boundary must go through the session timezone, never a bare UTC cast."""
+    sql = _sql(from_date(_COL, date(2026, 7, 6))).lower()
+    assert "current_setting('timezone')" in sql, sql


### PR DESCRIPTION
## Fase 2 backend (segundo corte) + correcciones de revision pre-merge

Continua el trabajo de Fase 2 ya mergeado en #42 (TOCTOU de aforo + indices). Este PR trae:

**Rendimiento**
- Queries sargables (`time_filters.py`): reemplaza `func.date(col)` por rangos indexables. **Tz-exacto**: bucketea por la zona de sesion (America/Mexico_City) via `AT TIME ZONE current_setting('TimeZone')`, verificado contra la BD real.
- N+1 del calendario semanal con asientos resuelto (una query `IN` en vez de ~50).
- Dashboard: 18 metricas independientes en paralelo, cada una con su sesion.
- boto3/PIL fuera del event loop (`asyncio.to_thread`); cliente boto3 cacheado.
- `get_db`: commit explicito de `last_active_at` en `build_context`.
- Cap de paginacion en el resolver `members`.

**Correcciones de la revision adversarial pre-merge (25 agentes)**
- Deadlock ABBA en materializacion batch -> lock coarse `lock_materialization_batch` que serializa los batches multi-sesion.
- Fan-out del dashboard -> semaforo **global** por-event-loop (antes por-llamada, no acotaba el pool).

**Validacion**: py_compile + smokes standalone + tests AST de gobierno + equivalencia SQL contra prod. No hay migracion nueva (la de indices ya se aplico en #42), asi que este deploy es solo-codigo.

Deploy: Coolify redeploya automaticamente al mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)