### PR TITLE
refactor(fase-3): visibilidad de errores en resolvers + quitar leads del schema

### DIFF
--- a/app/graphql/class_sessions/queries.py
+++ b/app/graphql/class_sessions/queries.py
@@ -30,6 +30,9 @@ from app.crud.reservationsCrud import (
     get_sessions_with_seats_by_date,
     get_week_sessions_with_seats
 )
+from app.core.logging_config import get_logger
+
+logger = get_logger("graphql.class_sessions.queries")
 
 def _to_session_with_seats_items(data: List[dict]) -> List[SessionWithSeats]:
     gql_items: List[SessionWithSeats] = []
@@ -115,7 +118,8 @@ class ClassSessionQueries:
                 total_count=len(session_list)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("get_class_sessions query failed")
             return ClassSessionsResponse(
                 sessions=[],
                 total_count=0
@@ -149,7 +153,8 @@ class ClassSessionQueries:
                 total_count=len(session_list)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("get_sessions_by_template query failed")
             return ClassSessionsResponse(
                 sessions=[],
                 total_count=0
@@ -180,11 +185,12 @@ class ClassSessionQueries:
                     message="Session not found"
                 )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("get_session_capacity_info query failed")
             return SessionCapacityResponse(
                 success=False,
                 capacity_info=None,
-                message=f"Error retrieving capacity info: {str(e)}"
+                message="Error retrieving capacity info"
             )
 
     @strawberry.field(permission_classes=[IsAuthenticated])
@@ -206,11 +212,12 @@ class ClassSessionQueries:
                 message="Coverage report generated successfully"
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("get_session_coverage_report query failed")
             return SessionCoverageResponse(
                 success=False,
                 report=None,
-                message=f"Error generating coverage report: {str(e)}"
+                message="Error generating coverage report"
             )
 
     @strawberry.field(permission_classes=[IsAuthenticated])

--- a/app/graphql/reservations/queries.py
+++ b/app/graphql/reservations/queries.py
@@ -26,6 +26,9 @@ from app.graphql.reservations.types import (
 )
 from app.graphql.auth.permissions import IsAuthenticated
 from app.graphql.context import Context
+from app.core.logging_config import get_logger
+
+logger = get_logger("graphql.reservations.queries")
 
 
 @strawberry.type
@@ -45,8 +48,9 @@ class ReservationQuery:
             reservation_data = await get_reservation_by_id(db, id)
             return Reservation.from_data(reservation_data) if reservation_data else None
 
-        except Exception as e:
-            # Log error but don't expose to client
+        except Exception:
+            # A DB/query failure here must not look like "reservation not found".
+            logger.exception("reservation query failed")
             return None
 
     @strawberry.field(permission_classes=[IsAuthenticated])
@@ -91,7 +95,8 @@ class ReservationQuery:
                 total_count=len(reservations)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("reservations query failed")
             return ReservationsResponse(
                 reservations=[],
                 total_count=0
@@ -131,7 +136,8 @@ class ReservationQuery:
                 total_count=len(sessions)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("available_sessions query failed")
             return SessionsResponse(
                 sessions=[],
                 total_count=0
@@ -157,7 +163,8 @@ class ReservationQuery:
                 total_count=len(seats)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("available_seats query failed")
             return SeatsResponse(
                 seats=[],
                 available_count=0,
@@ -187,7 +194,8 @@ class ReservationQuery:
 
             return [Reservation.from_data(data) for data in reservations_data]
 
-        except Exception as e:
+        except Exception:
+            logger.exception("person_reservations query failed")
             return []
 
     @strawberry.field(permission_classes=[IsAuthenticated])
@@ -209,7 +217,8 @@ class ReservationQuery:
 
             return [Reservation.from_data(data) for data in reservations_data]
 
-        except Exception as e:
+        except Exception:
+            logger.exception("session_reservations query failed")
             return []
 
     @strawberry.field(permission_classes=[IsAuthenticated])
@@ -237,5 +246,6 @@ class ReservationQuery:
 
             return [Session.from_data(data) for data in sessions_data]
 
-        except Exception as e:
+        except Exception:
+            logger.exception("upcoming_sessions query failed")
             return []

--- a/app/graphql/schema.py
+++ b/app/graphql/schema.py
@@ -19,8 +19,11 @@ from app.graphql.members.queries import MembersQuery
 from app.graphql.members.mutations import MemberMutation
 from app.graphql.memberships.queries import MembershipsQuery
 from app.graphql.memberships.mutations import MembershipMutation
-from app.graphql.leads.queries import LeadsQuery
-from app.graphql.leads.mutations import LeadsMutation
+# NOTE: LeadsQuery/LeadsMutation intentionally NOT exposed. They were 19 unimplemented
+# stub resolvers with NO authorization wired into the public schema (a latent trap:
+# the next dev filling in a TODO would inherit auth-less resolvers). The frontend
+# does not use them. Re-add here — WITH permission_classes/require_capability — only
+# when leads is actually implemented.
 from app.graphql.reservations.queries import ReservationQuery
 from app.graphql.reservations.mutations import ReservationMutation
 from app.graphql.standing_bookings.queries import StandingBookingQuery
@@ -68,13 +71,13 @@ except ImportError as e:
         pass
 
 @strawberry.type
-class Query(UserQuery, MembersQuery, MembershipsQuery, LeadsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery, PermissionsQuery, OwnerAgentQuery, PosQuery):
+class Query(UserQuery, MembersQuery, MembershipsQuery, ReservationQuery, StandingBookingQuery, SessionQuery, ClassSessionQueries, DashboardQuery, WhatsAppChatQuery, WhatsAppTemplateQuery, NotificationSettingsQuery, ChatbotConfigQuery, CampaignsQuery, PermissionsQuery, OwnerAgentQuery, PosQuery):
     @strawberry.field
     def hello(self) -> str:
         return "Hello from GraphQL!"
 
 @strawberry.type
-class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, LeadsMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation, OwnerAgentMutation, PosMutation, StepUpMutation):
+class Mutation(AuthMutation, UserMutation, MemberMutation, MembershipMutation, ReservationMutation, StandingBookingMutation, SessionMutation, ClassSessionMutations, WhatsAppChatMutation, WhatsAppTemplateMutation, NotificationSettingsMutation, ChatbotConfigMutation, CampaignsMutation, PermissionsMutation, OwnerAgentMutation, PosMutation, StepUpMutation):
     pass
 
 

--- a/app/graphql/standing_bookings/queries.py
+++ b/app/graphql/standing_bookings/queries.py
@@ -29,6 +29,9 @@ from app.graphql.standing_bookings.types import (
 )
 from app.graphql.auth.permissions import IsAuthenticated
 from app.graphql.context import Context
+from app.core.logging_config import get_logger
+
+logger = get_logger("graphql.standing_bookings.queries")
 
 
 @strawberry.type
@@ -48,7 +51,8 @@ class StandingBookingQuery:
                 total_count=len(class_types_data)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("class_types query failed")
             return ClassTypesResponse(
                 class_types=[],
                 total_count=0
@@ -76,7 +80,8 @@ class StandingBookingQuery:
                 total_count=len(templates_data)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("class_templates query failed")
             return ClassTemplatesResponse(
                 templates=[],
                 total_count=0
@@ -98,7 +103,8 @@ class StandingBookingQuery:
                 total_count=len(templates_data)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("all_class_templates query failed")
             return ClassTemplatesResponse(
                 templates=[],
                 total_count=0
@@ -128,7 +134,8 @@ class StandingBookingQuery:
                 total_count=len(seats_data)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("template_available_seats query failed")
             return AvailableSeatsResponse(
                 seats=[],
                 available_count=0,
@@ -158,7 +165,8 @@ class StandingBookingQuery:
                 total_count=len(standing_bookings_data)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("standing_bookings query failed")
             return StandingBookingsResponse(
                 standing_bookings=[],
                 total_count=0
@@ -189,11 +197,12 @@ class StandingBookingQuery:
                 message="Standing booking retrieved successfully"
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("standing_booking query failed")
             return StandingBookingResponse(
                 success=False,
                 standing_booking=None,
-                message=f"Error retrieving standing booking: {str(e)}"
+                message="Error retrieving standing booking"
             )
 
     @strawberry.field(permission_classes=[IsAuthenticated])
@@ -218,7 +227,8 @@ class StandingBookingQuery:
                 total_count=len(standing_bookings_data)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("standing_bookings_for_person query failed")
             return StandingBookingsResponse(
                 standing_bookings=[],
                 total_count=0
@@ -246,7 +256,8 @@ class StandingBookingQuery:
                 total_count=len(standing_bookings_data)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("standing_bookings_for_template query failed")
             return StandingBookingsResponse(
                 standing_bookings=[],
                 total_count=0
@@ -278,7 +289,8 @@ class StandingBookingQuery:
                 total_count=len(weekday_templates)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("class_templates_by_weekday query failed")
             return ClassTemplatesResponse(
                 templates=[],
                 total_count=0
@@ -317,7 +329,8 @@ class StandingBookingQuery:
                 total_count=len(seat_templates)
             )
 
-        except Exception as e:
+        except Exception:
+            logger.exception("templates_requiring_seats query failed")
             return ClassTemplatesResponse(
                 templates=[],
                 total_count=0


### PR DESCRIPTION
## Fase 3 backend — visibilidad de errores + superficie de ataque

**Visibilidad de errores** (cero cambio de contrato / forma de respuesta)
Varios resolvers de query tragaban fallos de BD devolviendo respuesta vacía / None / [] **sin loguear**, así que un error de BD se veía igual que "no hay datos" y no dejaba rastro. Se añade `logger.exception` antes de cada retorno de swallow (traceback al log), manteniendo la respuesta byte-idéntica:
- `reservations/queries.py` — 7 resolvers
- `standing_bookings/queries.py` — 10 resolvers
- `class_sessions/queries.py` — 4 resolvers

Además se genericizan 3 mensajes client-facing que filtraban `str(excepción)` interna (info-leak); el detalle va al log. Las ramas `except ValueError` (validación al usuario) se dejan intactas.

**Superficie de ataque (leads)**
`LeadsQuery`/`LeadsMutation` eran 19 resolvers stub **sin autorización** expuestos en el schema público (trampa latente: el próximo dev que implemente un TODO heredaba resolvers sin auth). El frontend no los usa. Se quitan del schema; el módulo `leads/` queda sin referencias. Re-exponer solo cuando se implemente, **con** `permission_classes`/`require_capability`.

**Validación**: py_compile de los 4 archivos; grep confirma 0 swallows sin loguear, 0 `str(e)` en mensajes de query, 0 referencias a `leads` fuera del módulo. Revisión adversarial pre-merge (10 agentes) limpia. Sin migración → deploy solo-código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
