### PR TITLE
security(deps): migrar python-jose -> PyJWT

### DIFF
--- a/app/security/jwt.py
+++ b/app/security/jwt.py
@@ -2,7 +2,8 @@ import os
 from datetime import datetime, timedelta
 from datetime import timezone
 from fastapi import HTTPException
-from jose import ExpiredSignatureError, JWTError, jwt
+import jwt
+from jwt import PyJWTError
 from zoneinfo import ZoneInfo
 
 from app.core.env import load_environment
@@ -83,13 +84,13 @@ def create_access_token(data: dict, expires_delta: timedelta = None):
 def verify_token(token: str):
     try:
         return jwt.decode(token, SECRET_KEY_ACCESS_TOKEN, algorithms=[ALGORITHM])
-    except JWTError as e:
+    except PyJWTError as e:
         logger.warning(f"Error verifying access token: {e}")
         return None
-    
+
 def verify_refresh_token(token: str):
     try:
         return jwt.decode(token, SECRET_KEY_REFRESH_TOKEN, algorithms=[ALGORITHM])
-    except JWTError as e:
+    except PyJWTError as e:
         logger.warning(f"Error verifying refresh token: {e}")
         return None

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ asyncpg>=0.29.0
 alembic>=1.13.0
 
 # Authentication
-python-jose[cryptography]>=3.3.0
+PyJWT>=2.8.0
 passlib[bcrypt]>=1.7.4
 
 # File handling and utilities


### PR DESCRIPTION
Migra el firmado/verificación JWT de `python-jose` (poco mantenido) a `PyJWT` (activo). HS256 explícito, sin JWE → API equivalente. Contenido a `app/security/jwt.py` + `requirements.txt`. Los tests de tokens del CI (login/context) validan el round-trip encode/decode antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)