### PR TITLE
deps(backend): capear upper bounds de deps directas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,39 +6,41 @@ uvicorn[standard]>=0.27.0
 strawberry-graphql[fastapi]>=0.282.0
 
 # Database
-sqlalchemy>=2.0.25
+# Upper bounds cap the next MAJOR so a breaking release can't land silently on a
+# fresh install / CI / deploy (the current resolution stays well within range).
+sqlalchemy>=2.0.25,<3
 asyncpg>=0.29.0
-alembic>=1.13.0
+alembic>=1.13.0,<2
 
 # Authentication
-PyJWT>=2.8.0
-passlib[bcrypt]>=1.7.4
+PyJWT>=2.8.0,<3
+passlib[bcrypt]>=1.7.4,<2
 
 # File handling and utilities
 python-multipart>=0.0.9
-user-agents>=2.2.0
-Pillow>=10.1.0
+user-agents>=2.2.0,<3
+Pillow>=10.1.0,<13
 
 # HTTP client for WhatsApp Cloud API calls
 httpx>=0.27.0
 
 # S3-compatible storage for WhatsApp media assets (Cloudflare R2)
-boto3>=1.34.0
+boto3>=1.34.0,<2
 
 # Environment file loading (.env)
-python-dotenv>=1.0.0
+python-dotenv>=1.0.0,<2
 
 # Date/time handling
 tzdata>=2024.1
 
-# Background job scheduling
-APScheduler>=3.10.0
+# Background job scheduling (APScheduler 4.x is a rewrite -> cap at <4)
+APScheduler>=3.10.0,<4
 
 # Date utilities (for memberships)
-python-dateutil>=2.9.0
+python-dateutil>=2.9.0,<3
 
 # Optional: Better JSON serialization
-pydantic>=2.5.0
+pydantic>=2.5.0,<3
 
 # LangChain / LangGraph WhatsApp agents (customer chatbot + owner/admin agent)
 langchain-core>=0.3.0
@@ -46,5 +48,5 @@ langchain-anthropic>=0.3.0     # pulls the official `anthropic` SDK; ChatAnthrop
 langgraph>=0.2.50              # langgraph.prebuilt.create_react_agent
 
 # Testing (dev only)
-pytest>=8.0.0
+pytest>=8.0.0,<9
 pytest-asyncio>=0.23.0


### PR DESCRIPTION
Cierra el ítem de pinning de P2 (backend). Caps de siguiente-major en las deps directas con major estable (SQLAlchemy<3, alembic<2, boto3<2, Pillow<13, pydantic<3, PyJWT<3, ...). Caps por encima de las versiones que el CI ya resuelve → no rompe nada; el CI (incl. alembic + 163 tests) lo valida. No es un lockfile con hashes (diferido), pero cierra la preocupación de bumps mayores sin riesgo de deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)